### PR TITLE
Fix therapy sell listing for admin accounts

### DIFF
--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -99,10 +99,12 @@ const AddTherapySell: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
+      const storeId = localStorage.getItem('store_id');
       const payload = {
         ...formData,
         therapy_id: formData.therapyId,
-        therapyId: undefined  // 避免多傳
+        therapyId: undefined,  // 避免多傳
+        storeId: storeId ? Number(storeId) : undefined
       };
       await addTherapySell([payload]);
       alert("銷售紀錄新增成功！");

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -47,13 +47,12 @@ const therapySaleCategoryValueToDisplayMap: { [key: string]: string } = {
   // "PreOrder": "預購", // 根據您資料庫的 ENUM('Sale', 'Gift', 'Discount', 'Ticket')
   // "Loan": "暫借",
 };
-const user = (() => {
-    try {
-      return JSON.parse(localStorage.getItem('user') || '{}');
-    } catch (e) {
-      return {};
-    }
-  })();
+// 從 localStorage 判斷是否具有總店或管理員權限
+const isAdmin = (() => {
+    const level = localStorage.getItem('store_level');
+    const perm = localStorage.getItem('permission');
+    return level === '總店' || perm === 'admin';
+})();
 // --- 結束新增/修改映射表 ---
 
 const TherapySell: React.FC = () => {
@@ -114,7 +113,7 @@ const TherapySell: React.FC = () => {
             setError(null);
     
             let response;
-            if (user.is_admin) {
+            if (isAdmin) {
                 response = await searchTherapySells(searchKeyword); // 不帶 storeId
             } else {
                 response = await searchTherapySells(searchKeyword, storeId);

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -180,9 +180,12 @@ export const getAllStores = async (): Promise<ApiResponse<Store[]>> => {
 // --- 療程銷售記錄 API ---
 export const getAllTherapySells = async (storeId?: number, forceAll?: boolean): Promise<ApiResponse<TherapySellRow[]>> => {
     try {
-        const user = JSON.parse(localStorage.getItem('user') || '{}');
+        const level = localStorage.getItem('store_level');
+        const perm = localStorage.getItem('permission');
+        const isAdmin = level === '總店' || perm === 'admin';
+
         let url = `${API_URL}/sales`;
-        if (!forceAll && !user.is_admin && storeId !== undefined) {
+        if (!forceAll && !isAdmin && storeId !== undefined) {
             url += `?store_id=${storeId}`;
         }
         const response = await axios.get(url);


### PR DESCRIPTION
## Summary
- correctly detect admin role when fetching therapy sales
- include store id when creating therapy sale entries

## Testing
- `pip install -r server/requirements.txt`
- `pip install requests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687a9ea21bf88329944d393aa37acb5f