### PR TITLE
Fix therapy sell listing for admin accounts

### DIFF
--- a/client/src/pages/inventory/InventorySearch.tsx
+++ b/client/src/pages/inventory/InventorySearch.tsx
@@ -48,6 +48,11 @@ const InventorySearch: React.FC = () => {
     };
     
     const userStoreId = getUserStoreId();
+    const isAdmin = (() => {
+        const level = localStorage.getItem('store_level');
+        const perm = localStorage.getItem('permission');
+        return level === '總店' || perm === 'admin';
+    })();
 
     // 載入庫存資料
     useEffect(() => {
@@ -58,15 +63,8 @@ const InventorySearch: React.FC = () => {
     const fetchInventoryData = async () => {
         setLoading(true);
         try {
-            // 獲取全部庫存數據
-            const data = await getAllInventory();
-            
-            // 過濾用戶所屬店鋪的數據
-            const filteredData = userStoreId 
-                ? data.filter((item: InventoryItem) => item.Store_ID === userStoreId)
-                : data;
-                
-            setInventoryItems(filteredData);
+            const data = await getAllInventory(isAdmin ? undefined : userStoreId);
+            setInventoryItems(Array.isArray(data) ? data : []);
             setError(null);
         } catch (err) {
             console.error("獲取庫存資料失敗:", err);
@@ -81,15 +79,8 @@ const InventorySearch: React.FC = () => {
     const handleSearch = async () => {
         setLoading(true);
         try {
-            // 搜尋全部數據
-            const data = await searchInventory(keyword);
-            
-            // 過濾用戶所屬店鋪的數據
-            const filteredData = userStoreId 
-                ? data.filter((item: InventoryItem) => item.Store_ID === userStoreId)
-                : data;
-                
-            setInventoryItems(filteredData);
+            const data = await searchInventory(keyword, isAdmin ? undefined : userStoreId);
+            setInventoryItems(Array.isArray(data) ? data : []);
             setError(null);
         } catch (err) {
             console.error("搜尋庫存資料失敗:", err);
@@ -185,7 +176,7 @@ const InventorySearch: React.FC = () => {
     const handleExport = async () => {
         setLoading(true);
         try {
-            await exportInventory();
+            await exportInventory(isAdmin ? undefined : userStoreId);
             setSuccessMessage("庫存數據匯出成功");
         } catch (err) {
             console.error("匯出庫存數據失敗:", err);

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -99,10 +99,12 @@ const AddTherapySell: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
+      const storeId = localStorage.getItem('store_id');
       const payload = {
         ...formData,
         therapy_id: formData.therapyId,
-        therapyId: undefined  // 避免多傳
+        therapyId: undefined,  // 避免多傳
+        storeId: storeId ? Number(storeId) : undefined
       };
       await addTherapySell([payload]);
       alert("銷售紀錄新增成功！");

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -47,13 +47,12 @@ const therapySaleCategoryValueToDisplayMap: { [key: string]: string } = {
   // "PreOrder": "預購", // 根據您資料庫的 ENUM('Sale', 'Gift', 'Discount', 'Ticket')
   // "Loan": "暫借",
 };
-const user = (() => {
-    try {
-      return JSON.parse(localStorage.getItem('user') || '{}');
-    } catch (e) {
-      return {};
-    }
-  })();
+// 從 localStorage 判斷是否具有總店或管理員權限
+const isAdmin = (() => {
+    const level = localStorage.getItem('store_level');
+    const perm = localStorage.getItem('permission');
+    return level === '總店' || perm === 'admin';
+})();
 // --- 結束新增/修改映射表 ---
 
 const TherapySell: React.FC = () => {
@@ -114,7 +113,7 @@ const TherapySell: React.FC = () => {
             setError(null);
     
             let response;
-            if (user.is_admin) {
+            if (isAdmin) {
                 response = await searchTherapySells(searchKeyword); // 不帶 storeId
             } else {
                 response = await searchTherapySells(searchKeyword, storeId);

--- a/client/src/services/InventoryService.ts
+++ b/client/src/services/InventoryService.ts
@@ -4,16 +4,36 @@ import { base_url } from "./BASE_URL";
 const API_URL = `${base_url}/inventory`;
 
 // 獲取所有庫存記錄
-export const getAllInventory = async () => {
-    const response = await axios.get(`${API_URL}/list`);
+export const getAllInventory = async (storeId?: number) => {
+    const level = localStorage.getItem('store_level');
+    const perm = localStorage.getItem('permission');
+    const isAdmin = level === '總店' || perm === 'admin';
+
+    const params: any = {};
+    if (!isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    } else if (isAdmin && storeId !== undefined) {
+        params.store_id = storeId; // allow admin specify store
+    }
+
+    const response = await axios.get(`${API_URL}/list`, { params });
     return response.data;
 };
 
 // 搜尋庫存記錄
-export const searchInventory = async (keyword: string) => {
-    const response = await axios.get(`${API_URL}/search`, {
-        params: { keyword }
-    });
+export const searchInventory = async (keyword: string, storeId?: number) => {
+    const level = localStorage.getItem('store_level');
+    const perm = localStorage.getItem('permission');
+    const isAdmin = level === '總店' || perm === 'admin';
+
+    const params: any = { keyword };
+    if (!isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    } else if (isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    }
+
+    const response = await axios.get(`${API_URL}/search`, { params });
     return response.data;
 };
 
@@ -59,8 +79,19 @@ export const deleteInventoryItem = async (id: number) => {
 };
 
 // 獲取低庫存產品
-export const getLowStockItems = async () => {
-    const response = await axios.get(`${API_URL}/low-stock`);
+export const getLowStockItems = async (storeId?: number) => {
+    const level = localStorage.getItem('store_level');
+    const perm = localStorage.getItem('permission');
+    const isAdmin = level === '總店' || perm === 'admin';
+
+    const params: any = {};
+    if (!isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    } else if (isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    }
+
+    const response = await axios.get(`${API_URL}/low-stock`, { params });
     return response.data;
 };
 
@@ -71,8 +102,20 @@ export const getAllProducts = async () => {
 };
 
 // 匯出庫存數據
-export const exportInventory = async () => {
+export const exportInventory = async (storeId?: number) => {
+    const level = localStorage.getItem('store_level');
+    const perm = localStorage.getItem('permission');
+    const isAdmin = level === '總店' || perm === 'admin';
+
+    const params: any = {};
+    if (!isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    } else if (isAdmin && storeId !== undefined) {
+        params.store_id = storeId;
+    }
+
     const response = await axios.get(`${API_URL}/export`, {
+        params,
         responseType: "blob"
     });
     

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -180,9 +180,12 @@ export const getAllStores = async (): Promise<ApiResponse<Store[]>> => {
 // --- 療程銷售記錄 API ---
 export const getAllTherapySells = async (storeId?: number, forceAll?: boolean): Promise<ApiResponse<TherapySellRow[]>> => {
     try {
-        const user = JSON.parse(localStorage.getItem('user') || '{}');
+        const level = localStorage.getItem('store_level');
+        const perm = localStorage.getItem('permission');
+        const isAdmin = level === '總店' || perm === 'admin';
+
         let url = `${API_URL}/sales`;
-        if (!forceAll && !user.is_admin && storeId !== undefined) {
+        if (!forceAll && !isAdmin && storeId !== undefined) {
             url += `?store_id=${storeId}`;
         }
         const response = await axios.get(url);


### PR DESCRIPTION
## Summary
- correctly detect admin role when fetching therapy sales
- include store id when creating therapy sale entries
- respect admin access when querying inventory endpoints
- propagate store-based inventory filters to the client

## Testing
- `pip install -r server/requirements.txt`
- `pip install requests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687a9ea21bf88329944d393aa37acb5f