### PR TITLE
Add inventory analysis and transaction APIs

### DIFF
--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -63,6 +63,8 @@ CREATE TABLE product (
   `product_id` INT NOT NULL AUTO_INCREMENT,
   `code` VARCHAR(50) NOT NULL UNIQUE,
   `name` VARCHAR(100) NOT NULL,
+  `unit` VARCHAR(20),
+  `category` VARCHAR(50),
   `price` DECIMAL(10, 2) NOT NULL,
   PRIMARY KEY (`product_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/mysql-init-scripts/02_data.sql
+++ b/mysql-init-scripts/02_data.sql
@@ -43,17 +43,17 @@ INSERT INTO `micro_surgery` (`micro_surgery_selection`, `micro_surgery_descripti
 ('複合式療程', '全臉美容'),
 ('醫學美容', '改善暗沉');
 
-INSERT INTO `product` (`code`, `name`, `price`) VALUES
-('SKN001', '保濕面膜', 580.00),
-('SKN002', '精華液', 1200.00),
-('SKN003', '潔面乳', 450.00),
-('SKN004', '保濕乳液', 780.00),
-('SKN005', '防曬霜', 650.00),
-('SUP001', '膠原蛋白粉', 1500.00),
-('SUP002', '維他命C', 850.00),
-('SUP003', '魚油', 720.00),
-('HRB001', '舒壓茶包', 380.00),
-('HRB002', '薰衣草精油', 550.00);
+INSERT INTO `product` (`code`, `name`, `unit`, `category`, `price`) VALUES
+('SKN001', '保濕面膜', '件', 'Skincare', 580.00),
+('SKN002', '精華液', '件', 'Skincare', 1200.00),
+('SKN003', '潔面乳', '件', 'Skincare', 450.00),
+('SKN004', '保濕乳液', '件', 'Skincare', 780.00),
+('SKN005', '防曬霜', '件', 'Skincare', 650.00),
+('SUP001', '膠原蛋白粉', '瓶', 'Supplement', 1500.00),
+('SUP002', '維他命C', '瓶', 'Supplement', 850.00),
+('SUP003', '魚油', '瓶', 'Supplement', 720.00),
+('HRB001', '舒壓茶包', '盒', 'Herb', 380.00),
+('HRB002', '薰衣草精油', '瓶', 'EssentialOil', 550.00);
 
 INSERT INTO `therapy` (`code`, `name`, `price`, `content`) VALUES
 ('TH001', '全身放鬆按摩', 2800.00, '60分鐘全身按摩，幫助放鬆肌肉，改善血液循環'),

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -379,9 +379,11 @@ def get_all_products_with_inventory(store_id=None):
     conn = connect_to_db()
     with conn.cursor() as cursor:
         query = """
-            SELECT 
-                p.product_id, 
-                p.name as product_name, 
+            SELECT
+                p.product_id,
+                p.name as product_name,
+                p.unit as unit,
+                p.category as category,
                 p.price as product_price,
                 COALESCE(SUM(i.quantity), 0) as inventory_quantity,
                 0 as inventory_id
@@ -393,7 +395,7 @@ def get_all_products_with_inventory(store_id=None):
             query += " WHERE i.store_id = %s"
             params.append(store_id)
         
-        query += " GROUP BY p.product_id, p.name, p.price ORDER BY p.name"
+        query += " GROUP BY p.product_id, p.name, p.unit, p.category, p.price ORDER BY p.name"
         
         cursor.execute(query, tuple(params))
         result = cursor.fetchall()
@@ -410,9 +412,11 @@ def search_products_with_inventory(keyword, store_id=None):
         like_keyword = f"%{keyword}%"
         
         query = """
-            SELECT 
-                p.product_id, 
-                p.name as product_name, 
+            SELECT
+                p.product_id,
+                p.name as product_name,
+                p.unit as unit,
+                p.category as category,
                 p.price as product_price,
                 COALESCE(SUM(i.quantity), 0) as inventory_quantity,
                 0 as inventory_id
@@ -434,7 +438,7 @@ def search_products_with_inventory(keyword, store_id=None):
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
-        query += " GROUP BY p.product_id, p.name, p.price ORDER BY p.name"
+        query += " GROUP BY p.product_id, p.name, p.unit, p.category, p.price ORDER BY p.name"
         
         try:
             cursor.execute(query, tuple(params))

--- a/server/app/routes/inventory.py
+++ b/server/app/routes/inventory.py
@@ -12,7 +12,9 @@ from app.models.inventory_model import (
     delete_inventory_item,
     get_low_stock_inventory,
     get_product_list,
-    export_inventory_data
+    export_inventory_data,
+    get_inventory_transactions,
+    analyze_inventory
 )
 from app.middleware import auth_required, get_user_from_token
 
@@ -196,4 +198,44 @@ def export_inventory():
         )
     except Exception as e:
         print(e)
-        return jsonify({"error": str(e)}), 500 
+        return jsonify({"error": str(e)}), 500
+
+
+@inventory_bp.route("/transactions", methods=["GET"])
+@auth_required
+def inventory_transactions():
+    """取得庫存進出明細"""
+    start_date = request.args.get("start_date")
+    end_date = request.args.get("end_date")
+    try:
+        user_store_level = request.store_level
+        user_store_id = request.store_id
+        is_admin = user_store_level == '總店' or request.permission == 'admin'
+        store_id_param = request.args.get('store_id')
+        target_store = store_id_param if is_admin else user_store_id
+
+        transactions = get_inventory_transactions(target_store, start_date, end_date)
+        return jsonify(transactions)
+    except Exception as e:
+        print(e)
+        return jsonify({"error": str(e)}), 500
+
+
+@inventory_bp.route("/analysis", methods=["GET"])
+@auth_required
+def inventory_analysis():
+    """庫存分析"""
+    start_date = request.args.get("start_date")
+    end_date = request.args.get("end_date")
+    try:
+        user_store_level = request.store_level
+        user_store_id = request.store_id
+        is_admin = user_store_level == '總店' or request.permission == 'admin'
+        store_id_param = request.args.get('store_id')
+        target_store = store_id_param if is_admin else user_store_id
+
+        analysis = analyze_inventory(target_store, start_date, end_date)
+        return jsonify(analysis)
+    except Exception as e:
+        print(e)
+        return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- extend `product` table with `unit` and `category`
- seed new fields for example products
- expose product unit and category in product lists
- add inventory transaction and analysis utilities
- expose new `/transactions` and `/analysis` endpoints
- include product details when listing products for sales

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687bc3516cac8329ab3b8cf333155f37