### PR TITLE
Implement add product/therapy endpoints

### DIFF
--- a/client/src/pages/backend/product_bundle/AddProductModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddProductModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
+import { addProduct } from '../../../services/ProductService';
 
 interface AddProductModalProps {
     show: boolean;
@@ -11,9 +12,14 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide }) => {
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
 
-    const handleSubmit = (e: React.FormEvent) => {
+    const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        onHide();
+        try {
+            await addProduct({ code, name, price: Number(price) });
+            onHide();
+        } catch (err) {
+            alert('新增產品失敗');
+        }
     };
 
     return (

--- a/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
+import { addTherapy } from '../../../services/TherapyService';
 
 interface AddTherapyModalProps {
     show: boolean;
@@ -11,9 +12,14 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide }) => {
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
 
-    const handleSubmit = (e: React.FormEvent) => {
+    const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        onHide();
+        try {
+            await addTherapy({ code, name, price: Number(price) });
+            onHide();
+        } catch (err) {
+            alert('新增療程失敗');
+        }
     };
 
     return (

--- a/client/src/services/ProductService.ts
+++ b/client/src/services/ProductService.ts
@@ -47,4 +47,21 @@ export const getProductById = async (productId: number): Promise<Product> => {
     console.error("獲取產品詳情失敗：", error);
     throw error;
   }
-}; 
+};
+
+export const addProduct = async (data: { code: string; name: string; price: number }) => {
+  try {
+    const token = localStorage.getItem("token");
+    const response = await axios.post(`${API_URL}/`, data, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Store-ID": "1",
+        "X-Store-Level": "admin",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("新增產品失敗：", error);
+    throw error;
+  }
+};

--- a/client/src/services/TherapyService.ts
+++ b/client/src/services/TherapyService.ts
@@ -136,3 +136,20 @@ export const getAllTherapiesForDropdown = async () => {
     const response = await axios.get(`${API_URL}/for-dropdown`);
     return response.data;
 };
+
+export const addTherapy = async (data: { code: string; name: string; price: number }) => {
+    try {
+        const token = localStorage.getItem("token");
+        const response = await axios.post(`${API_URL}/package`, data, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "X-Store-ID": "1",
+                "X-Store-Level": "admin",
+            },
+        });
+        return response.data;
+    } catch (error) {
+        console.error("新增療程失敗：", error);
+        throw error;
+    }
+};

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -11,6 +11,7 @@ from app.routes.health_check import health_check_bp
 from app.routes.staff import staff_bp
 from app.routes.pure_medical_record import pure_medical_bp
 from app.routes.product_bundle import product_bundle_bp
+from app.routes.product import product_bp
 from .routes.sales_order_routes import sales_order_bp
 from app.routes.store import store_bp
 
@@ -67,6 +68,7 @@ def create_app():
     app.register_blueprint(stress_test, url_prefix='/api/stress-test')
     app.register_blueprint(staff_bp, url_prefix='/api/staff')
     app.register_blueprint(product_bundle_bp, url_prefix='/api/product-bundles')
+    app.register_blueprint(product_bp, url_prefix='/api/product')
     app.register_blueprint(store_bp, url_prefix='/api/stores')
 
     # 註冊產品銷售路由

--- a/server/app/models/product_model.py
+++ b/server/app/models/product_model.py
@@ -1,0 +1,32 @@
+import pymysql
+from app.config import DB_CONFIG
+from pymysql.cursors import DictCursor
+
+
+def connect_to_db():
+    """建立資料庫連線"""
+    return pymysql.connect(**DB_CONFIG, cursorclass=DictCursor)
+
+
+def create_product(data: dict):
+    """新增一筆產品資料"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            query = (
+                "INSERT INTO product (code, name, price) "
+                "VALUES (%s, %s, %s)"
+            )
+            cursor.execute(query, (
+                data.get("code"),
+                data.get("name"),
+                data.get("price"),
+            ))
+            product_id = conn.insert_id()
+        conn.commit()
+        return product_id
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -460,3 +460,27 @@ def get_all_therapies_for_dropdown():
     finally:
         conn.close()
 
+
+def create_therapy(data: dict):
+    """新增一筆療程套餐資料"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            query = (
+                "INSERT INTO therapy (code, name, price, content) "
+                "VALUES (%s, %s, %s, %s)"
+            )
+            cursor.execute(query, (
+                data.get("code"),
+                data.get("name"),
+                data.get("price"),
+                data.get("content", None),
+            ))
+            therapy_id = conn.insert_id()
+        conn.commit()
+        return therapy_id
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()

--- a/server/app/routes/product.py
+++ b/server/app/routes/product.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, request, jsonify
+from app.models.product_model import create_product
+from app.middleware import admin_required
+
+product_bp = Blueprint("product", __name__)
+
+@product_bp.route("/", methods=["POST"])
+@admin_required
+def add_product():
+    data = request.json
+    if not all(k in data for k in ("code", "name", "price")):
+        return jsonify({"error": "缺少必要欄位"}), 400
+    try:
+        product_id = create_product(data)
+        return jsonify({"message": "產品新增成功", "product_id": product_id}), 201
+    except Exception as e:
+        if "Duplicate entry" in str(e):
+            return jsonify({"error": "產品編號重複"}), 409
+        return jsonify({"error": str(e)}), 500

--- a/server/app/routes/therapy.py
+++ b/server/app/routes/therapy.py
@@ -16,7 +16,8 @@ from app.models.therapy_model import (
     search_therapy_sells,
     update_therapy_sell,
     delete_therapy_sell,
-    get_all_therapies_for_dropdown 
+    get_all_therapies_for_dropdown,
+    create_therapy
 )
 from app.middleware import auth_required, admin_required, get_user_from_token
 
@@ -321,4 +322,19 @@ def get_therapy_list():
         therapy_list = get_all_therapies_for_dropdown()
         return jsonify(therapy_list)
     except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@therapy_bp.route("/package", methods=["POST"])
+@admin_required
+def add_therapy_package():
+    """新增療程套餐"""
+    data = request.json
+    if not all(k in data for k in ("code", "name", "price")):
+        return jsonify({"error": "缺少必要欄位"}), 400
+    try:
+        therapy_id = create_therapy(data)
+        return jsonify({"message": "療程新增成功", "therapy_id": therapy_id}), 201
+    except Exception as e:
+        if "Duplicate entry" in str(e):
+            return jsonify({"error": "療程編號重複"}), 409
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- implement endpoints to create products and therapies
- wire up the modals in Product Bundle page to POST to backend
- add services for creating products and therapies

## Testing
- `pip install -r requirements.txt`
- `pip install requests pandas flask-login bcrypt xlsxwriter`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687be3cad0a083299eaee8c439789c3a