### PR TITLE
Add inventory records endpoint

### DIFF
--- a/client/src/config/pageTitles.ts
+++ b/client/src/config/pageTitles.ts
@@ -48,7 +48,7 @@ export const pageTitles: PageTitleMap = {
   '/inventory': { basic: '庫存管理 1.1.4', admin: '庫存管理 1.2.4' },
   '/inventory/inventory-search': { basic: '庫存查詢(銷售) 1.1.4.1', admin: '庫存查詢(銷售) 1.2.4.1' },
   '/inventory/inventory-analysis': { basic: '庫存分析 1.1.4.2', admin: '庫存分析 1.2.4.2' },
-  '/inventory/inventory-update': { basic: '更新庫存數據(進貨) 1.1.4.3', admin: '更新庫存數據(進貨) 1.2.4.3' },
+  '/inventory/inventory-update': { basic: '更新庫存資料 (進貨) 1.1.4.3', admin: '更新庫存資料 (進貨) 1.2.4.3' },
   '/inventory/inventory-add': { basic: '新增庫存數據 1.1.4.3.1', admin: '新增庫存數據 1.2.4.3.1' },
   '/inventory/inventory-detail': { basic: '進出明細查詢 1.1.4.4', admin: '進出明細查詢 1.2.4.4' },
   

--- a/client/src/pages/inventory/InventoryInsert.tsx
+++ b/client/src/pages/inventory/InventoryInsert.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Container, Row, Col, Form, Button } from "react-bootstrap";
-import { getAllProducts, getSaleCategories } from "../../services/ProductSellService";
+import { getAllProducts } from "../../services/ProductSellService";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 
@@ -16,7 +16,6 @@ interface Product {
 const InventoryInsert = () => {
   const navigate = useNavigate();
   const [products, setProducts] = useState<Product[]>([]);
-  const [categories, setCategories] = useState<string[]>([]);
   const [formData, setFormData] = useState({
     product_id: "",
     category: "",
@@ -28,11 +27,6 @@ const InventoryInsert = () => {
     getAllProducts().then((res) => {
       console.log("產品資料:", res);
       setProducts(res);
-    });
-
-    getSaleCategories().then((res) => {
-      console.log("類別資料:", res);
-      setCategories(res);
     });
   }, []);
 
@@ -86,18 +80,13 @@ const InventoryInsert = () => {
                     <Col xs={12} md={6}>
                       <Form.Group controlId="category">
                         <Form.Label>類別</Form.Label>
-                        <Form.Select
+                        <Form.Control
+                          type="text"
+                          placeholder="可輸入或留空"
                           name="category"
                           value={formData.category}
                           onChange={handleChange}
-                        >
-                          <option value="">-- 選擇類別 --</option>
-                          {categories.map((cat, idx) => (
-                            <option key={`cat-${idx}`} value={cat}>
-                              {cat}
-                            </option>
-                          ))}
-                        </Form.Select>
+                        />
                       </Form.Group>
                     </Col>
                   </Row>

--- a/client/src/pages/inventory/InventoryUpdate.tsx
+++ b/client/src/pages/inventory/InventoryUpdate.tsx
@@ -34,10 +34,16 @@ const InventoryEntryForm = () => {
 
   const handleSubmit = async () => {
     try {
+      if (!formData.staff_id) {
+        alert("請選擇進貨人");
+        return;
+      }
+
       const payload = {
         productId: Number(formData.product_id),
+        quantity: Number(formData.quantity),
         stockIn: Number(formData.quantity),
-        stockInTime: formData.date,
+        date: formData.date,
         staffId: Number(formData.staff_id),
         note: formData.note
       };
@@ -51,7 +57,7 @@ const InventoryEntryForm = () => {
 
   return (
     <>
-      <Header title="更新庫存資料 (進貨) 1.1.4.3" />
+      <Header />
       <Container
         className="mt-4"
         style={{ marginLeft: "200px", paddingRight: "30px", maxWidth: "calc(100% - 220px)" }}
@@ -115,9 +121,9 @@ const InventoryEntryForm = () => {
                 >
                   <option value="">-- 選擇進貨人 --</option>
                   {Array.isArray(staffs) && staffs.map((s, index) => {
-                    const key = s?.Staff_ID ? `staff-${s.Staff_ID}` : `staff-fallback-${index}`;
-                    const value = s?.Staff_ID ?? "";
-                    const label = s?.Staff_Name ?? `員工 ${index + 1}`;
+                    const key = (s as any)?.staff_id ? `staff-${(s as any).staff_id}` : `staff-fallback-${index}`;
+                    const value = (s as any)?.staff_id ?? "";
+                    const label = (s as any)?.name ?? `員工 ${index + 1}`;
                     return (
                       <option key={key} value={value}>
                         {label}

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -1,0 +1,7 @@
+# Sample Inventory Data
+
+The `inventory_sample.sql` file contains example stock transactions for testing the inventory features. Import it into your database after the main schema and data are loaded:
+
+```bash
+mysql -u <user> -p <database> < sample_data/inventory_sample.sql
+```

--- a/sample_data/inventory_sample.sql
+++ b/sample_data/inventory_sample.sql
@@ -1,0 +1,7 @@
+-- Sample inventory transactions for testing
+INSERT INTO inventory (product_id, staff_id, date, quantity, stock_in, stock_out, stock_loan, store_id, stock_threshold) VALUES
+  (1, 1, '2024-06-01', 20, 20, 0, 0, 1, 10),
+  (1, 1, '2024-06-05', -5, 0, 5, 0, 1, 10),
+  (2, 2, '2024-06-02', 15, 15, 0, 0, 2, 15),
+  (2, 2, '2024-06-07', -3, 0, 3, 0, 2, 15),
+  (3, 3, '2024-06-03', 10, 10, 0, 0, 3, 20);

--- a/server/app/models/inventory_model.py
+++ b/server/app/models/inventory_model.py
@@ -184,6 +184,57 @@ def get_low_stock_inventory(store_id=None):
     finally:
         conn.close()
 
+def get_inventory_history(store_id=None, start_date=None, end_date=None):
+    """獲取庫存進出明細，可依店鋪及日期區間篩選"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            query = """
+                SELECT
+                    i.inventory_id AS Inventory_ID,
+                    p.product_id AS Product_ID,
+                    p.name AS ProductName,
+                    p.code AS ProductCode,
+                    i.quantity,
+                    i.stock_in,
+                    i.stock_out,
+                    i.stock_loan,
+                    i.stock_threshold AS StockThreshold,
+                    i.date AS Date,
+                    st.store_id AS Store_ID,
+                    st.store_name AS StoreName,
+                    s.staff_id AS Staff_ID,
+                    s.name AS StaffName
+                FROM inventory i
+                LEFT JOIN product p ON i.product_id = p.product_id
+                LEFT JOIN staff s ON i.staff_id = s.staff_id
+                LEFT JOIN store st ON i.store_id = st.store_id
+            """
+            params = []
+            conditions = []
+            if store_id:
+                conditions.append("i.store_id = %s")
+                params.append(store_id)
+            if start_date:
+                conditions.append("i.date >= %s")
+                params.append(start_date)
+            if end_date:
+                conditions.append("i.date <= %s")
+                params.append(end_date)
+
+            if conditions:
+                query += " WHERE " + " AND ".join(conditions)
+
+            query += " ORDER BY i.date DESC, i.inventory_id DESC"
+
+            cursor.execute(query, params)
+            return cursor.fetchall()
+    except Exception as e:
+        print(f"獲取庫存進出明細錯誤: {e}")
+        return []
+    finally:
+        conn.close()
+
 def update_inventory_item(inventory_id, data):
     """更新庫存記錄"""
     conn = connect_to_db()


### PR DESCRIPTION
## Summary
- support store-restricted inventory CRUD and detail lookup
- provide sample inventory insert script
- allow fetching inventory transaction history
- fix forms and titles for inventory pages

## Testing
- `pip install -r requirements.txt`
- `pip install requests pyjwt pandas flask_login xlsxwriter bcrypt`
- `PYTHONPATH=server pytest -q` *(fails: ModuleNotFoundError: app)*

------
https://chatgpt.com/codex/tasks/task_e_687cb0b54204832998c72cb638c4a3a4