### PR TITLE
Fix inventory pages excel export buttons

### DIFF
--- a/client/src/pages/inventory/InventoryAnalysis.tsx
+++ b/client/src/pages/inventory/InventoryAnalysis.tsx
@@ -1,8 +1,17 @@
 import React from "react";
 import { Button, Container, Row, Col, Form, Table } from "react-bootstrap";
+import { exportInventory } from "../../services/InventoryService";
 import Header from "../../components/Header";
 
 const InventoryAnalysis: React.FC = () => {
+    const handleExport = async () => {
+        try {
+            await exportInventory();
+        } catch (err) {
+            console.error("匯出庫存資料失敗", err);
+            alert("匯出失敗");
+        }
+    };
 
     return (
         <div className="d-flex flex-column min-vh-100 bg-white">
@@ -59,7 +68,7 @@ const InventoryAnalysis: React.FC = () => {
                 {/* 下方按鈕 */}
                 <Row className="justify-content-center my-4 g-3">
                     <Col xs="auto" className="ms-auto">
-                        <Button variant="info" className="text-white px-4">報表匯出</Button>
+                        <Button variant="info" className="text-white px-4" onClick={handleExport}>報表匯出</Button>
                     </Col>
                     <Col xs="auto">
                         <Button variant="info" className="text-white px-4">刪除</Button>

--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Container, Row, Col, Form, Button, Table } from "react-bootstrap";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
-import { getInventoryRecords } from "../../services/InventoryService";
+import { getInventoryRecords, exportInventory } from "../../services/InventoryService";
 import { useNavigate } from "react-router-dom";
 
 const formatDate = (d: string) => {
@@ -30,6 +30,15 @@ const InventoryDetail: React.FC = () => {
   const navigate = useNavigate();
   const [records, setRecords] = useState<RecordRow[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const handleExport = async () => {
+    try {
+      await exportInventory();
+    } catch (err) {
+      console.error("匯出庫存資料失敗", err);
+      alert("匯出失敗");
+    }
+  };
 
   useEffect(() => {
     getInventoryRecords().then((res) => setRecords(res));
@@ -115,7 +124,7 @@ const InventoryDetail: React.FC = () => {
       {/* 下方按鈕列 */}
       <Row className="mt-4 justify-content-center g-2">
         <Col xs="auto">
-          <Button variant="info" className="text-white px-4">報表匯出</Button>
+          <Button variant="info" className="text-white px-4" onClick={handleExport}>報表匯出</Button>
         </Col>
         <Col xs="auto">
           <Button variant="info" className="text-white px-4">刪除</Button>

--- a/client/src/pages/inventory/InventoryNotification.tsx
+++ b/client/src/pages/inventory/InventoryNotification.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Button, Col, Container, Form, Row, Table } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
+import { exportInventory } from "../../services/InventoryService";
 import IconButton from "../../components/IconButton";
 
 interface StockRecord {
@@ -36,6 +37,15 @@ const StockUpdate: React.FC = () => {
     setSelectedIds((prev) =>
       prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     );
+  };
+
+  const handleExport = async () => {
+    try {
+      await exportInventory();
+    } catch (err) {
+      console.error("匯出庫存資料失敗", err);
+      alert("匯出失敗");
+    }
   };
 
   return (
@@ -103,7 +113,7 @@ const StockUpdate: React.FC = () => {
         </Table>
 
         <div className="d-flex justify-content-end gap-3 mt-4">
-          <Button variant="info">報表匯出</Button>
+          <Button variant="info" onClick={handleExport}>報表匯出</Button>
           <Button variant="info">刪除</Button>
           <Button variant="info">修改</Button>
           <Button variant="info">確認</Button>

--- a/client/src/pages/inventory/InventoryUpdate.tsx
+++ b/client/src/pages/inventory/InventoryUpdate.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Container, Row, Col, Form, Button } from "react-bootstrap";
 import { getAllProducts, Product } from "../../services/ProductSellService"; // ✅ 改用正確來源
 import { getAllStaffs, Staff } from "../../services/StaffService";
-import { addInventoryItem, getInventoryById, updateInventoryItem } from "../../services/InventoryService";
+import { addInventoryItem, getInventoryById, updateInventoryItem, exportInventory } from "../../services/InventoryService";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Header from "../../components/Header";
 
@@ -82,6 +82,15 @@ const InventoryEntryForm = () => {
     } catch (error) {
       alert("送出失敗，請稍後再試。");
       console.error(error);
+    }
+  };
+
+  const handleExport = async () => {
+    try {
+      await exportInventory();
+    } catch (err) {
+      console.error("匯出庫存資料失敗", err);
+      alert("匯出失敗");
     }
   };
 
@@ -186,7 +195,7 @@ const InventoryEntryForm = () => {
               <Form.Label htmlFor="custom-check" className="mb-0">勾選</Form.Label>
             </Col>
             <Col xs={6} md={2}>
-              <Button variant="info" className="w-100 text-white">報表匯出</Button>
+              <Button variant="info" className="w-100 text-white" onClick={handleExport}>報表匯出</Button>
             </Col>
             <Col xs={6} md={2}>
               <Button variant="info" className="w-100 text-white">刪除</Button>


### PR DESCRIPTION
## Summary
- add missing `exportInventory` calls across inventory pages
- hook buttons to export handlers so spreadsheets download

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails: pyenv: version `3.11.3` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ce22db7a0832982328bcbb6ee0075