### PR TITLE
Enable consistent Excel export across pages

### DIFF
--- a/client/src/hooks/useEmployeeRecord.ts
+++ b/client/src/hooks/useEmployeeRecord.ts
@@ -1,5 +1,6 @@
 // client/src/hooks/useEmployeeRecord.ts
 import { useState, useEffect } from "react";
+import { downloadBlob } from '../utils/downloadBlob';
 import {
   getAllEmployeeRecords,
   searchEmployeeRecords,
@@ -96,13 +97,7 @@ export const useEmployeeRecord = () => {
       setLoading(true);
       setError(null);
       const blob = await exportEmployeeRecords();
-      const url = window.URL.createObjectURL(new Blob([blob]));
-      const link = document.createElement("a");
-      link.href = url;
-      link.setAttribute("download", "員工紀錄.xlsx");
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
+      downloadBlob(blob, "員工紀錄.xlsx");
     } catch (err) {
       console.error("匯出失敗：", err);
       setError("匯出報表失敗");

--- a/client/src/hooks/useMedicalRecord.ts
+++ b/client/src/hooks/useMedicalRecord.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { downloadBlob } from '../utils/downloadBlob';
 import { 
     getAllMedicalRecords, 
     searchMedicalRecords, 
@@ -101,7 +102,8 @@ export const useMedicalRecordManagement = () => {
     // 處理匯出報表
     const handleExport = async () => {
         try {
-            await exportMedicalRecords();
+            const blob = await exportMedicalRecords();
+            downloadBlob(blob, "健康檢查紀錄.xlsx");
         } catch (err) {
             console.error("匯出失敗", err);
             alert("匯出報表失敗！");

--- a/client/src/hooks/useMemberManagement.ts
+++ b/client/src/hooks/useMemberManagement.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { downloadBlob } from '../utils/downloadBlob';
 import { 
     Member, 
     getAllMembers, 
@@ -75,13 +76,7 @@ export const useMemberManagement = () => {
     const handleExport = async () => {
         try {
             const blob = await exportMembers();
-            const url = window.URL.createObjectURL(new Blob([blob]));
-            const link = document.createElement("a");
-            link.href = url;
-            link.setAttribute("download", "會員資料.xlsx");
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
+            downloadBlob(blob, "會員資料.xlsx");
         } catch (err) {
             console.error("匯出失敗：", err);
             alert("匯出報表失敗！");

--- a/client/src/hooks/useProductSell.ts
+++ b/client/src/hooks/useProductSell.ts
@@ -7,7 +7,7 @@ import {
   exportProductSells, 
   ProductSell 
 } from '../services/ProductSellService';
-import { downloadBlob } from '../utils/productSellUtils';
+import { downloadBlob } from '../utils/downloadBlob';
 
 interface UseProductSellReturn {
   sales: ProductSell[];

--- a/client/src/hooks/usePureMedicalRecord.ts
+++ b/client/src/hooks/usePureMedicalRecord.ts
@@ -1,5 +1,6 @@
 // .\src\hooks\usePureMedicalRecord.ts
 import { useState, useEffect, useCallback } from 'react';
+import { downloadBlob } from '../utils/downloadBlob';
 import { 
   fetchPureRecords, // <-- 改為 import fetchPureRecords
   deletePureRecord, 
@@ -109,15 +110,7 @@ export const usePureMedicalRecord = (): UsePureMedicalRecordReturn => {
     try {
       setLoading(true);
       const blob = await exportPureRecords();
-      
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = '淨化健康紀錄.xlsx';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      window.URL.revokeObjectURL(url);
+      downloadBlob(blob, '淨化健康紀錄.xlsx');
     } catch (err) {
       console.error("Error exporting pure medical records:", err);
       setError("匯出淨化健康紀錄時發生錯誤");

--- a/client/src/hooks/useTherapyRecord.ts
+++ b/client/src/hooks/useTherapyRecord.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { downloadBlob } from '../utils/downloadBlob';
 import {
   getAllTherapyRecords,
   searchTherapyRecords,
@@ -114,21 +115,7 @@ export const useTherapyRecord = () => {
     try {
       setLoading(true);
       const blob = await exportTherapyRecords();
-      
-      // 建立下載連結
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.style.display = "none";
-      a.href = url;
-      a.download = "療程紀錄.xlsx";
-      
-      // 觸發下載
-      document.body.appendChild(a);
-      a.click();
-      
-      // 清理
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
+      downloadBlob(blob, "療程紀錄.xlsx");
     } catch (err) {
       console.error("匯出失敗：", err);
       setError("匯出報表失敗");

--- a/client/src/pages/health/pure_medical_record/AddPureMedicalRecord.tsx
+++ b/client/src/pages/health/pure_medical_record/AddPureMedicalRecord.tsx
@@ -5,8 +5,9 @@ import { useNavigate } from "react-router-dom";
 import Header from "../../../components/Header";
 import DynamicContainer from "../../../components/DynamicContainer";
 import MemberColumn from "../../../components/MemberColumn";
-import { addPureRecord } from "../../../services/PureMedicalRecordService";
+import { addPureRecord, exportPureRecords } from "../../../services/PureMedicalRecordService";
 import { getAllStaff } from "../../../services/TherapySellService"; // searchMemberById 已被 MemberColumn 內部處理
+import { downloadBlob } from "../../../utils/downloadBlob";
 import { calculateBMI, getTodayDateString } from "../../../utils/pureMedicalUtils";
 
 // 更新 interface 以匹配新的欄位名稱
@@ -214,11 +215,14 @@ const AddPureMedicalRecord: React.FC = () => {
     }
   };
 
-  // "報表匯出" 按鈕的功能 - 暫時未定義，可根據需求實現
-  const handleExportCurrentData = () => {
-    // 實際功能：可能將當前 formData 轉換為特定格式 (如CSV, PDF) 並下載
-    // 或將其發送到後端進行報表生成
-    alert("報表匯出功能尚待實現。\n當前資料：\n" + JSON.stringify(formData, null, 2));
+  const handleExportCurrentData = async () => {
+    try {
+      const blob = await exportPureRecords();
+      downloadBlob(blob, '淨化健康紀錄.xlsx');
+    } catch (err) {
+      alert('匯出失敗');
+      console.error(err);
+    }
   };
   
   const handleTodayDate = () => {

--- a/client/src/pages/inventory/InventoryAnalysis.tsx
+++ b/client/src/pages/inventory/InventoryAnalysis.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Button, Container, Row, Col, Form, Table } from "react-bootstrap";
 import { exportInventory } from "../../services/InventoryService";
+import { downloadBlob } from "../../utils/downloadBlob";
 import Header from "../../components/Header";
 
 const InventoryAnalysis: React.FC = () => {
     const handleExport = async () => {
         try {
-            await exportInventory();
+            const blob = await exportInventory();
+            downloadBlob(blob, `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
         } catch (err) {
             console.error("匯出庫存資料失敗", err);
             alert("匯出失敗");

--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -3,6 +3,7 @@ import { Container, Row, Col, Form, Button, Table } from "react-bootstrap";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import { getInventoryRecords, exportInventory } from "../../services/InventoryService";
+import { downloadBlob } from "../../utils/downloadBlob";
 import { useNavigate } from "react-router-dom";
 
 const formatDate = (d: string) => {
@@ -33,7 +34,8 @@ const InventoryDetail: React.FC = () => {
 
   const handleExport = async () => {
     try {
-      await exportInventory();
+      const blob = await exportInventory();
+      downloadBlob(blob, `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
     } catch (err) {
       console.error("匯出庫存資料失敗", err);
       alert("匯出失敗");

--- a/client/src/pages/inventory/InventoryNotification.tsx
+++ b/client/src/pages/inventory/InventoryNotification.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Button, Col, Container, Form, Row, Table } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import { exportInventory } from "../../services/InventoryService";
+import { downloadBlob } from "../../utils/downloadBlob";
 import IconButton from "../../components/IconButton";
 
 interface StockRecord {
@@ -41,7 +42,8 @@ const StockUpdate: React.FC = () => {
 
   const handleExport = async () => {
     try {
-      await exportInventory();
+      const blob = await exportInventory();
+      downloadBlob(blob, `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
     } catch (err) {
       console.error("匯出庫存資料失敗", err);
       alert("匯出失敗");

--- a/client/src/pages/inventory/InventorySearch.tsx
+++ b/client/src/pages/inventory/InventorySearch.tsx
@@ -5,6 +5,7 @@ import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import ScrollableTable from "../../components/ScrollableTable";
 import { getAllInventory, searchInventory, deleteInventoryItem, exportInventory } from "../../services/InventoryService";
+import { downloadBlob } from "../../utils/downloadBlob";
 
 // 庫存項目接口
 interface InventoryItem {
@@ -176,7 +177,8 @@ const InventorySearch: React.FC = () => {
     const handleExport = async () => {
         setLoading(true);
         try {
-            await exportInventory(isAdmin ? undefined : userStoreId);
+            const blob = await exportInventory(isAdmin ? undefined : userStoreId);
+            downloadBlob(blob, `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
             setSuccessMessage("庫存數據匯出成功");
         } catch (err) {
             console.error("匯出庫存數據失敗:", err);

--- a/client/src/pages/inventory/InventoryUpdate.tsx
+++ b/client/src/pages/inventory/InventoryUpdate.tsx
@@ -3,6 +3,7 @@ import { Container, Row, Col, Form, Button } from "react-bootstrap";
 import { getAllProducts, Product } from "../../services/ProductSellService"; // ✅ 改用正確來源
 import { getAllStaffs, Staff } from "../../services/StaffService";
 import { addInventoryItem, getInventoryById, updateInventoryItem, exportInventory } from "../../services/InventoryService";
+import { downloadBlob } from "../../utils/downloadBlob";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Header from "../../components/Header";
 
@@ -87,7 +88,8 @@ const InventoryEntryForm = () => {
 
   const handleExport = async () => {
     try {
-      await exportInventory();
+      const blob = await exportInventory();
+      downloadBlob(blob, `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
     } catch (err) {
       console.error("匯出庫存資料失敗", err);
       alert("匯出失敗");

--- a/client/src/services/InventoryService.ts
+++ b/client/src/services/InventoryService.ts
@@ -115,7 +115,7 @@ export const getAllProducts = async () => {
 };
 
 // 匯出庫存數據
-export const exportInventory = async (storeId?: number) => {
+export const exportInventory = async (storeId?: number): Promise<Blob> => {
     const level = localStorage.getItem('store_level');
     const perm = localStorage.getItem('permission');
     const isAdmin = level === '總店' || perm === 'admin';
@@ -131,16 +131,6 @@ export const exportInventory = async (storeId?: number) => {
         params,
         responseType: "blob"
     });
-    
-    // 處理下載
-    const blob = new Blob([response.data], {
-        type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    
-    const link = document.createElement("a");
-    link.href = window.URL.createObjectURL(blob);
-    link.setAttribute("download", `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-}; 
+
+    return response.data;
+};

--- a/client/src/services/MedicalService.ts
+++ b/client/src/services/MedicalService.ts
@@ -26,21 +26,12 @@ export const deleteMedicalRecord = async (recordId: number) => {
 };
 
 // 匯出 Excel
-export const exportMedicalRecords = async () => {
+export const exportMedicalRecords = async (): Promise<Blob> => {
     const res = await axios.get(`${API_URL}/export`, {
         responseType: "blob",
     });
 
-    const blob = new Blob([res.data], {
-        type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    });
-
-    const link = document.createElement("a");
-    link.href = window.URL.createObjectURL(blob);
-    link.setAttribute("download", "健康檢查紀錄.xlsx");
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+    return res.data as Blob;
 };
 
 // 檢查會員是否存在

--- a/client/src/utils/downloadBlob.ts
+++ b/client/src/utils/downloadBlob.ts
@@ -1,0 +1,9 @@
+export const downloadBlob = (blob: Blob, filename: string): void => {
+  const url = window.URL.createObjectURL(new Blob([blob]));
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+};

--- a/client/src/utils/productSellUtils.ts
+++ b/client/src/utils/productSellUtils.ts
@@ -56,12 +56,5 @@ export const calculateTotalPrice = (price: number, quantity: number, discount: n
  * @param blob Blob 資料
  * @param filename 檔案名稱
  */
-export const downloadBlob = (blob: Blob, filename: string): void => {
-  const url = window.URL.createObjectURL(new Blob([blob]));
-  const link = document.createElement("a");
-  link.href = url;
-  link.setAttribute("download", filename);
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-}; 
+import { downloadBlob } from './downloadBlob';
+export { downloadBlob };


### PR DESCRIPTION
## Summary
- add shared `downloadBlob` helper
- switch all export actions to use it
- adjust export services to return blobs
- hook and page updates for inventory and health modules

## Testing
- `npm run build` *(fails: Could not resolve entry module and many TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ce732a86883299149f8c8f766376a