### PR TITLE
Fix header issue with store level in AuthUtils

### DIFF
--- a/client/src/services/AuthUtils.ts
+++ b/client/src/services/AuthUtils.ts
@@ -65,7 +65,18 @@ export const getAuthHeaders = (): Record<string, string> => {
 
   if (token) headers['Authorization'] = `Bearer ${token}`;
   if (storeId) headers['X-Store-ID'] = storeId;
-  if (storeLevel) headers['X-Store-Level'] = storeLevel;
+
+  if (storeLevel) {
+    // Avoid non-ASCII characters in request headers
+    const asciiLevel =
+      storeLevel === '總店'
+        ? 'admin'
+        : storeLevel === '分店'
+          ? 'branch'
+          : storeLevel;
+    headers['X-Store-Level'] = asciiLevel;
+  }
+
   if (permission) headers['X-Permission'] = permission;
 
   return headers;


### PR DESCRIPTION
## Summary
- map Chinese `store_level` values to ASCII strings before sending headers

## Testing
- `npm run lint` *(fails: 588 problems)*
- `npm run build` *(fails to compile TS files)*
- `pytest` *(fails: connection errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687e07c705488329a76414ffbe930031