### PR TITLE
Add sample stress test data and UI tweaks

### DIFF
--- a/client/src/pages/backend/AddStaff.tsx
+++ b/client/src/pages/backend/AddStaff.tsx
@@ -229,7 +229,7 @@ const AddStaff: React.FC = () => {
                                     上一頁
                                 </Button>
                                 {currentStep < 3 && <Button variant="info" className="text-white" onClick={nextStep}>下一頁</Button>}
-                                {currentStep === 3 && <Button variant="success" onClick={handleSave}>儲存</Button>}
+                                {currentStep === 3 && <Button variant="info" className="text-white" onClick={handleSave}>儲存</Button>}
                             </Card.Footer>
                         </Form>
                     </Card>

--- a/client/src/pages/inventory/InventoryManagement.tsx
+++ b/client/src/pages/inventory/InventoryManagement.tsx
@@ -19,9 +19,6 @@ const InventoryManagement: React.FC = () => {
                         <Button onClick={() => navigate("/inventory/inventory-analysis")} variant="info" size="lg" className="text-white px-4 py-2">庫存分析</Button>
                     </Col>
                     <Col xs={12} sm={6} md={4} className="d-grid">
-                        <Button onClick={() => navigate("/inventory/inventory-insert")} variant="info" size="lg" className="text-white px-4 py-2">新增庫存數據</Button>
-                    </Col>
-                    <Col xs={12} sm={6} md={4} className="d-grid">
                         <Button onClick={() => navigate("/inventory/inventory-update")} variant="info" size="lg" className="text-white px-4 py-2">更新庫存數據</Button>
                     </Col>
                     <Col xs={12} sm={6} md={4} className="d-grid">

--- a/client/src/pages/inventory/InventorySearch.tsx
+++ b/client/src/pages/inventory/InventorySearch.tsx
@@ -170,7 +170,7 @@ const InventorySearch: React.FC = () => {
             return;
         }
         
-        navigate(`/inventory/update/${selectedItems[0]}`);
+        navigate(`/inventory/inventory-update?id=${selectedItems[0]}`);
     };
     
     // 處理匯出功能

--- a/mysql-init-scripts/02_data.sql
+++ b/mysql-init-scripts/02_data.sql
@@ -259,3 +259,21 @@ VALUES
 (LAST_INSERT_ID(), 6, NULL, '膠原蛋白粉', 'Product', '盒', 1500.00, 2, 3000.00, '保健食品', '客戶要求分兩次取貨');
 
 
+-- 壓力源測試樣本資料
+INSERT INTO `ipn_stress` (`member_id`, `a_score`, `b_score`, `c_score`, `d_score`, `test_date`, `store_id`) VALUES
+(1, 3, 4, 5, 2, '2024-06-30', 1);
+SET @stress_id1 := LAST_INSERT_ID();
+INSERT INTO `ipn_stress_answer` (`ipn_stress_id`, `question_no`, `answer`) VALUES
+(@stress_id1, 'a1', 'A'), (@stress_id1, 'a2', 'B'), (@stress_id1, 'a3', 'A'), (@stress_id1, 'a4', 'B'), (@stress_id1, 'a5', 'A'),
+(@stress_id1, 'b1', 'A'), (@stress_id1, 'b2', 'B'), (@stress_id1, 'b3', 'A'), (@stress_id1, 'b4', 'B'), (@stress_id1, 'b5', 'A'),
+(@stress_id1, 'c1', 'B'), (@stress_id1, 'c2', 'A'), (@stress_id1, 'c3', 'B'), (@stress_id1, 'c4', 'A'), (@stress_id1, 'c5', 'B'),
+(@stress_id1, 'd1', 'A'), (@stress_id1, 'd2', 'B'), (@stress_id1, 'd3', 'A'), (@stress_id1, 'd4', 'B'), (@stress_id1, 'd5', 'A');
+
+INSERT INTO `ipn_stress` (`member_id`, `a_score`, `b_score`, `c_score`, `d_score`, `test_date`, `store_id`) VALUES
+(2, 4, 5, 3, 4, '2024-07-01', 2);
+SET @stress_id2 := LAST_INSERT_ID();
+INSERT INTO `ipn_stress_answer` (`ipn_stress_id`, `question_no`, `answer`) VALUES
+(@stress_id2, 'a1', 'B'), (@stress_id2, 'a2', 'A'), (@stress_id2, 'a3', 'B'), (@stress_id2, 'a4', 'A'), (@stress_id2, 'a5', 'B'),
+(@stress_id2, 'b1', 'B'), (@stress_id2, 'b2', 'A'), (@stress_id2, 'b3', 'B'), (@stress_id2, 'b4', 'A'), (@stress_id2, 'b5', 'B'),
+(@stress_id2, 'c1', 'A'), (@stress_id2, 'c2', 'B'), (@stress_id2, 'c3', 'A'), (@stress_id2, 'c4', 'B'), (@stress_id2, 'c5', 'A'),
+(@stress_id2, 'd1', 'B'), (@stress_id2, 'd2', 'A'), (@stress_id2, 'd3', 'B'), (@stress_id2, 'd4', 'A'), (@stress_id2, 'd5', 'B');


### PR DESCRIPTION
## Summary
- seed sample stress test data for store 1 and 2
- remove inventory add button from inventory management page
- fix navigate path for editing inventory records
- tweak save button style in Add Staff form

## Testing
- `npm run build` *(fails: cannot find module 'jwt-decode' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e441bd8f88329a5edac0540400fd5