### PR TITLE
Update therapy sale page and improve UI

### DIFF
--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Button, Container, Row, Col, Form, InputGroup, Alert } from "react-bootstrap";
+import { Button, Container, Row, Col, Form, InputGroup, Alert, Card } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
@@ -223,7 +223,16 @@ const AddProductSell: React.FC = () => {
   
   const content = (
     <Container className="my-4">
-      {error && <Alert variant="danger" dismissible onClose={() => setError(null)}>{error}</Alert>}
+      {error && (
+        <Alert variant="danger" dismissible onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      <Row className="justify-content-center">
+        <Col md={10}>
+          <Card className="shadow-sm">
+            <Card.Header className="bg-info text-white">新增產品銷售</Card.Header>
+            <Card.Body>
       <Form onSubmit={handleSubmit} noValidate>
         <Row className="g-3">
           {/* --- Left Column --- */}
@@ -340,7 +349,7 @@ const AddProductSell: React.FC = () => {
             <Button variant="info" className="text-white" type="submit" disabled={loading}>
               {loading ? "處理中..." : "確認"}
             </Button>
-            <Button variant="info" className="text-white" onClick={() => {handleCancel}} disabled={loading}>
+            <Button variant="info" className="text-white" onClick={handleCancel} disabled={loading}>
               取消
             </Button>
             <Button variant="info" className="text-white" onClick={handlePrint} disabled={loading}>
@@ -349,6 +358,10 @@ const AddProductSell: React.FC = () => {
           </Col>
         </Row>
       </Form>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
     </Container>
   );
 

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -9,18 +9,18 @@ import {
   Alert,
   Card,
   Spinner,
+  InputGroup,
 } from "react-bootstrap";
+import MemberColumn from "../../components/MemberColumn";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
-import { getAllMembers, Member } from "../../services/MemberService";
-import { getAllStaffForDropdown } from "../../services/StaffService";
-import { getAllTherapiesForDropdown } from "../../services/TherapyService";
-import { addTherapySell, fetchRemainingSessions } from "../../services/TherapySellService";
+import { getStaffMembers, getAllTherapyPackages, addTherapySell, fetchRemainingSessions } from "../../services/TherapySellService";
 
 interface DropdownItem {
   id: number;
   name: string;
+  price?: number;
 }
 
 const AddTherapySell: React.FC = () => {
@@ -32,10 +32,24 @@ const AddTherapySell: React.FC = () => {
     date: new Date().toISOString().split("T")[0],
     amount: 1,
     paymentMethod: "Cash",
+    saleCategory: "銷售",
+    transferCode: "",
+    cardNumber: "",
+    discountAmount: 0,
     note: "",
   });
+  const paymentMethodDisplayMap: { [key: string]: string } = {
+    "現金": "Cash",
+    "信用卡": "CreditCard",
+    "轉帳": "Transfer",
+    "行動支付": "MobilePayment",
+    "待付款": "Pending",
+    "其他": "Others",
+  };
+  const paymentMethodOptions = Object.keys(paymentMethodDisplayMap);
+  const saleCategoryOptions = ["銷售", "贈品", "折扣", "預購", "暫借"];
 
-  const [members, setMembers] = useState<Member[]>([]);
+  const [memberName, setMemberName] = useState<string>("");
   const [staffList, setStaffList] = useState<DropdownItem[]>([]);
   const [therapyList, setTherapyList] = useState<DropdownItem[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -43,18 +57,26 @@ const AddTherapySell: React.FC = () => {
   const [remainingSessions, setRemainingSessions] = useState<number | null>(null);
   const [isFetchingSessions, setIsFetchingSessions] = useState(false);
 
+  const selectedTherapy = therapyList.find(t => String(t.id) === formData.therapyId);
+  const totalPrice = (selectedTherapy?.price || 0) * Number(formData.amount);
+  const finalPayableAmount = totalPrice - Number(formData.discountAmount);
+
   useEffect(() => {
     const fetchInitialData = async () => {
       try {
         setLoading(true);
-        const [membersData, staffData, therapyData] = await Promise.all([
-          getAllMembers(),
-          getAllStaffForDropdown(),
-          getAllTherapiesForDropdown(),
+        const [staffRes, therapyRes] = await Promise.all([
+          getStaffMembers(),
+          getAllTherapyPackages(),
         ]);
-        setMembers(Array.isArray(membersData) ? membersData : []);
-        setStaffList(staffData.map(s => ({ id: s.staff_id, name: s.name })));
-        setTherapyList(therapyData.map(t => ({ id: t.therapy_id, name: t.name })));
+        if (staffRes.success && staffRes.data) {
+          setStaffList(staffRes.data.map(s => ({ id: s.staff_id, name: s.name })));
+        }
+        if (therapyRes.success && therapyRes.data) {
+          setTherapyList(
+            therapyRes.data.map(t => ({ id: t.therapy_id, name: t.TherapyName || t.name, price: t.TherapyPrice }))
+          );
+        }
       } catch (err) {
         setError("無法載入初始資料");
         console.error(err);
@@ -101,10 +123,18 @@ const AddTherapySell: React.FC = () => {
     try {
       const storeId = localStorage.getItem('store_id');
       const payload = {
-        ...formData,
-        therapy_id: formData.therapyId,
-        therapyId: undefined,  // 避免多傳
-        storeId: storeId ? Number(storeId) : undefined
+        memberId: Number(formData.memberId),
+        therapy_id: Number(formData.therapyId),
+        staffId: Number(formData.staffId),
+        purchaseDate: formData.date,
+        amount: Number(formData.amount),
+        storeId: storeId ? Number(storeId) : undefined,
+        paymentMethod: paymentMethodDisplayMap[formData.paymentMethod] || formData.paymentMethod,
+        saleCategory: formData.saleCategory,
+        transferCode: formData.paymentMethod === '轉帳' ? formData.transferCode : undefined,
+        cardNumber: formData.paymentMethod === '信用卡' ? formData.cardNumber : undefined,
+        discount: Number(formData.discountAmount) || 0,
+        note: formData.note,
       };
       await addTherapySell([payload]);
       alert("銷售紀錄新增成功！");
@@ -128,18 +158,22 @@ const AddTherapySell: React.FC = () => {
             <Card.Body>
               {error && <Alert variant="danger">{error}</Alert>}
               <Form onSubmit={handleSubmit}>
+
                 <Row className="mb-3">
-                  <Form.Group as={Col} controlId="memberId">
-                    <Form.Label>會員</Form.Label>
-                    <Form.Select name="memberId" value={formData.memberId} onChange={handleChange} required>
-                      <option value="">請選擇會員</option>
-                      {members.map((member) => (
-                        <option key={member.Member_ID} value={member.Member_ID}>
-                          {member.Name}
-                        </option>
-                      ))}
-                    </Form.Select>
-                  </Form.Group>
+                  <Col>
+                    <MemberColumn
+                      memberId={formData.memberId}
+                      name={memberName}
+                      isEditMode={false}
+                      onMemberChange={(id, name) => {
+                        setFormData(prev => ({ ...prev, memberId: id }));
+                        setMemberName(name);
+                      }}
+                      onError={(msg) => setError(msg)}
+                    />
+                  </Col>
+                </Row>
+                <Row className="mb-3">
                   <Form.Group as={Col} controlId="therapyId">
                     <Form.Label>療程方案</Form.Label>
                     <Form.Select name="therapyId" value={formData.therapyId} onChange={handleChange} required>
@@ -171,27 +205,68 @@ const AddTherapySell: React.FC = () => {
                 </Row>
 
                 <Row className="mb-3">
-                   <Form.Group as={Col} controlId="staffId">
+                  <Form.Group as={Col} controlId="staffId">
                     <Form.Label>服務人員</Form.Label>
                     <Form.Select name="staffId" value={formData.staffId} onChange={handleChange} required>
-                        <option value="">請選擇服務人員</option>
-                        {staffList.map((staff) => (
+                      <option value="">請選擇服務人員</option>
+                      {staffList.map((staff) => (
                         <option key={staff.id} value={staff.id}>
-                            {staff.name}
+                          {staff.name}
                         </option>
-                        ))}
+                      ))}
                     </Form.Select>
                   </Form.Group>
                   <Form.Group as={Col} controlId="paymentMethod">
                     <Form.Label>付款方式</Form.Label>
-                    <Form.Select name="paymentMethod" value={formData.paymentMethod} onChange={handleChange}>
-                      <option value="Cash">現金</option>
-                      <option value="CreditCard">信用卡</option>
-                      <option value="Transfer">銀行轉帳</option>
-                      <option value="MobilePayment">行動支付</option>
-                      <option value="Pending">待付款</option>
-                      <option value="Others">其他</option>
+                    <Form.Select name="paymentMethod" value={formData.paymentMethod} onChange={handleChange} required>
+                      {paymentMethodOptions.map(opt => (
+                        <option key={opt} value={opt}>{opt}</option>
+                      ))}
                     </Form.Select>
+                  </Form.Group>
+                </Row>
+
+                {formData.paymentMethod === '信用卡' && (
+                  <Form.Group className="mb-3" controlId="cardNumber">
+                    <Form.Label>卡號後五碼</Form.Label>
+                    <Form.Control type="text" name="cardNumber" maxLength={5} pattern="\d*" value={formData.cardNumber}
+                      onChange={handleChange} placeholder="請輸入信用卡號後五碼" />
+                  </Form.Group>
+                )}
+                {formData.paymentMethod === '轉帳' && (
+                  <Form.Group className="mb-3" controlId="transferCode">
+                    <Form.Label>轉帳帳號末五碼</Form.Label>
+                    <Form.Control type="text" name="transferCode" maxLength={5} pattern="\d*" value={formData.transferCode}
+                      onChange={handleChange} placeholder="請輸入轉帳帳號末五碼" />
+                  </Form.Group>
+                )}
+
+                <Row className="mb-3">
+                  <Form.Group as={Col} controlId="saleCategory">
+                    <Form.Label>銷售類別</Form.Label>
+                    <Form.Select name="saleCategory" value={formData.saleCategory} onChange={handleChange} required>
+                      {saleCategoryOptions.map(opt => (
+                        <option key={opt} value={opt}>{opt}</option>
+                      ))}
+                    </Form.Select>
+                  </Form.Group>
+                  <Form.Group as={Col} controlId="discountAmount">
+                    <Form.Label>折價</Form.Label>
+                    <InputGroup>
+                      <InputGroup.Text>NT$</InputGroup.Text>
+                      <Form.Control type="number" name="discountAmount" min="0" step="any" value={formData.discountAmount} onChange={handleChange} placeholder="輸入折價金額" />
+                    </InputGroup>
+                  </Form.Group>
+                </Row>
+
+                <Row className="mb-3">
+                  <Form.Group as={Col}>
+                    <Form.Label>總價</Form.Label>
+                    <Form.Control type="text" value={`NT$ ${totalPrice.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
+                  </Form.Group>
+                  <Form.Group as={Col}>
+                    <Form.Label>應收</Form.Label>
+                    <Form.Control type="text" value={`NT$ ${finalPayableAmount.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
                   </Form.Group>
                 </Row>
 
@@ -209,10 +284,10 @@ const AddTherapySell: React.FC = () => {
                   <Button variant="info" type="submit" className="text-white" disabled={loading}>
                     {loading ? "儲存中..." : "確認"}
                   </Button>
-                  <Button variant="info" className="text-white" onClick={() => {}}>
+                  <Button variant="info" className="text-white" onClick={() => navigate(-1)}>
                     取消
                   </Button>
-                  <Button variant="info" className="text-white" onClick={() => {}}>
+                  <Button variant="info" className="text-white" onClick={() => window.print()}>
                     列印
                   </Button>
                 </div>


### PR DESCRIPTION
## Summary
- unify add product sale page styling using Card layout
- enhance therapy sale form with options similar to product sale
- fetch therapy packages and staff lists via `TherapySellService`
- add payment method specific fields, sale category, discounts, and totals
- remove store selection from therapy sales

## Testing
- `npm run lint` *(fails: many lint errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c13a01c83299f4958cecb80d283