### PR TITLE
Fix therapy sell form to support multiple packages

### DIFF
--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Button, Container, Row, Col, Form, InputGroup, Alert } from "react-bootstrap";
+import { Button, Container, Row, Col, Form, InputGroup, Alert, Card } from "react-bootstrap";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
@@ -223,7 +223,16 @@ const AddProductSell: React.FC = () => {
   
   const content = (
     <Container className="my-4">
-      {error && <Alert variant="danger" dismissible onClose={() => setError(null)}>{error}</Alert>}
+      {error && (
+        <Alert variant="danger" dismissible onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
+      <Row className="justify-content-center">
+        <Col md={10}>
+          <Card className="shadow-sm">
+            <Card.Header className="bg-info text-white">新增產品銷售</Card.Header>
+            <Card.Body>
       <Form onSubmit={handleSubmit} noValidate>
         <Row className="g-3">
           {/* --- Left Column --- */}
@@ -247,7 +256,7 @@ const AddProductSell: React.FC = () => {
                   {selectedProducts.length > 0 ? ( selectedProducts.map((p, i) => ( <div key={i}>{p.name} (單價: NT${p.price.toLocaleString()}) x {p.quantity}</div>))
                   ) : ( <span className="text-muted">點擊「選取」按鈕選擇產品</span> )}
                 </div>
-                <Button variant="info" className="text-white align-self-start px-3" onClick={openProductSelection}>選取</Button>
+                <Button variant="info" type="button" className="text-white align-self-start px-3" onClick={openProductSelection}>選取</Button>
               </div>
               <Form.Text muted>可複選，跳出新視窗選取。</Form.Text>
               {formSubmitted && selectedProducts.length === 0 && <div className="text-danger d-block small mt-1">請選擇購買品項</div>}
@@ -340,15 +349,19 @@ const AddProductSell: React.FC = () => {
             <Button variant="info" className="text-white" type="submit" disabled={loading}>
               {loading ? "處理中..." : "確認"}
             </Button>
-            <Button variant="info" className="text-white" onClick={() => {handleCancel}} disabled={loading}>
+            <Button variant="info" type="button" className="text-white" onClick={handleCancel} disabled={loading}>
               取消
             </Button>
-            <Button variant="info" className="text-white" onClick={handlePrint} disabled={loading}>
+            <Button variant="info" type="button" className="text-white" onClick={handlePrint} disabled={loading}>
               列印
             </Button>
           </Col>
         </Row>
       </Form>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
     </Container>
   );
 

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -8,53 +8,61 @@ import {
   Col,
   Alert,
   Card,
-  Spinner,
+  InputGroup,
 } from "react-bootstrap";
+import MemberColumn from "../../components/MemberColumn";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
-import { getAllMembers, Member } from "../../services/MemberService";
-import { getAllStaffForDropdown } from "../../services/StaffService";
-import { getAllTherapiesForDropdown } from "../../services/TherapyService";
-import { addTherapySell, fetchRemainingSessions } from "../../services/TherapySellService";
+import { getStaffMembers, addTherapySell, SelectedTherapyPackageUIData } from "../../services/TherapySellService";
 
 interface DropdownItem {
   id: number;
   name: string;
+  price?: number;
 }
 
 const AddTherapySell: React.FC = () => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     memberId: "",
-    therapyId: "",
     staffId: "",
     date: new Date().toISOString().split("T")[0],
-    amount: 1,
     paymentMethod: "Cash",
+    saleCategory: "銷售",
+    transferCode: "",
+    cardNumber: "",
+    discountAmount: 0,
     note: "",
   });
+  const paymentMethodDisplayMap: { [key: string]: string } = {
+    "現金": "Cash",
+    "信用卡": "CreditCard",
+    "轉帳": "Transfer",
+    "行動支付": "MobilePayment",
+    "待付款": "Pending",
+    "其他": "Others",
+  };
+  const paymentMethodOptions = Object.keys(paymentMethodDisplayMap);
+  const saleCategoryOptions = ["銷售", "贈品", "折扣", "預購", "暫借"];
 
-  const [members, setMembers] = useState<Member[]>([]);
+  const [memberName, setMemberName] = useState<string>("");
   const [staffList, setStaffList] = useState<DropdownItem[]>([]);
-  const [therapyList, setTherapyList] = useState<DropdownItem[]>([]);
+  const [therapyPackages, setTherapyPackages] = useState<SelectedTherapyPackageUIData[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [remainingSessions, setRemainingSessions] = useState<number | null>(null);
-  const [isFetchingSessions, setIsFetchingSessions] = useState(false);
+
+  const [packagesOriginalTotal, setPackagesOriginalTotal] = useState<number>(0);
+  const [finalPayableAmount, setFinalPayableAmount] = useState<number>(0);
 
   useEffect(() => {
     const fetchInitialData = async () => {
       try {
         setLoading(true);
-        const [membersData, staffData, therapyData] = await Promise.all([
-          getAllMembers(),
-          getAllStaffForDropdown(),
-          getAllTherapiesForDropdown(),
-        ]);
-        setMembers(Array.isArray(membersData) ? membersData : []);
-        setStaffList(staffData.map(s => ({ id: s.staff_id, name: s.name })));
-        setTherapyList(therapyData.map(t => ({ id: t.therapy_id, name: t.name })));
+        const staffRes = await getStaffMembers();
+        if (staffRes.success && staffRes.data) {
+          setStaffList(staffRes.data.map(s => ({ id: s.staff_id, name: s.name })));
+        }
       } catch (err) {
         setError("無法載入初始資料");
         console.error(err);
@@ -62,29 +70,60 @@ const AddTherapySell: React.FC = () => {
         setLoading(false);
       }
     };
-    fetchInitialData();
-  }, []);
 
-  useEffect(() => {
-    const getSessions = async () => {
-      if (formData.memberId && formData.therapyId) {
-        setIsFetchingSessions(true);
-        setRemainingSessions(null);
+    const restoreState = () => {
+      const formStateData = localStorage.getItem('addTherapySellFormState');
+      if (formStateData) {
         try {
-          const result = await fetchRemainingSessions(formData.memberId, formData.therapyId);
-          setRemainingSessions(result.remaining_sessions);
-        } catch (err) {
-          setError("查詢剩餘堂數失敗，可能無購買紀錄");
-          setRemainingSessions(0);
-        } finally {
-          setIsFetchingSessions(false);
+          const formState = JSON.parse(formStateData);
+          if (formState.memberId) setFormData(prev => ({ ...prev, memberId: formState.memberId }));
+          if (formState.memberName) setMemberName(formState.memberName);
+          if (formState.staffId) setFormData(prev => ({ ...prev, staffId: formState.staffId }));
+          if (formState.date) setFormData(prev => ({ ...prev, date: formState.date }));
+          if (formState.paymentMethod) setFormData(prev => ({ ...prev, paymentMethod: formState.paymentMethod }));
+          if (formState.saleCategory) setFormData(prev => ({ ...prev, saleCategory: formState.saleCategory }));
+          if (formState.transferCode) setFormData(prev => ({ ...prev, transferCode: formState.transferCode }));
+          if (formState.cardNumber) setFormData(prev => ({ ...prev, cardNumber: formState.cardNumber }));
+          if (typeof formState.discountAmount === 'number') setFormData(prev => ({ ...prev, discountAmount: formState.discountAmount }));
+          if (formState.note) setFormData(prev => ({ ...prev, note: formState.note }));
+          if (Array.isArray(formState.selectedTherapyPackages)) {
+            setTherapyPackages(formState.selectedTherapyPackages);
+          }
+        } catch (e) {
+          console.error('解析 addTherapySellFormState 失敗', e);
         }
-      } else {
-        setRemainingSessions(null);
+      }
+
+      const newSelected = localStorage.getItem('newlySelectedTherapyPackagesWithSessions');
+      if (newSelected) {
+        try {
+          const pkgs = JSON.parse(newSelected);
+          if (Array.isArray(pkgs)) {
+            setTherapyPackages(pkgs);
+          }
+        } catch (e) {
+          console.error('解析 newlySelectedTherapyPackagesWithSessions 失敗', e);
+        }
+        localStorage.removeItem('newlySelectedTherapyPackagesWithSessions');
       }
     };
-    getSessions();
-  }, [formData.memberId, formData.therapyId]);
+
+    fetchInitialData();
+    restoreState();
+  }, []);
+
+  // 重新計算金額
+  useEffect(() => {
+    let total = 0;
+    therapyPackages.forEach(pkg => {
+      total += (pkg.TherapyPrice || 0) * (Number(pkg.userSessions) || 0);
+    });
+    setPackagesOriginalTotal(total);
+  }, [therapyPackages]);
+
+  useEffect(() => {
+    setFinalPayableAmount(packagesOriginalTotal - Number(formData.discountAmount || 0));
+  }, [packagesOriginalTotal, formData.discountAmount]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -94,23 +133,83 @@ const AddTherapySell: React.FC = () => {
     }));
   };
 
+  const openPackageSelection = () => {
+    const formState = {
+      memberId: formData.memberId,
+      memberName,
+      staffId: formData.staffId,
+      date: formData.date,
+      paymentMethod: formData.paymentMethod,
+      saleCategory: formData.saleCategory,
+      transferCode: formData.transferCode,
+      cardNumber: formData.cardNumber,
+      discountAmount: formData.discountAmount,
+      note: formData.note,
+      selectedTherapyPackages: therapyPackages,
+    };
+    localStorage.setItem('addTherapySellFormState', JSON.stringify(formState));
+    navigate('/therapy-package-selection', { state: { fromSellPage: true } });
+  };
+
+  const handleCancel = () => {
+    localStorage.removeItem('addTherapySellFormState');
+    localStorage.removeItem('selectedTherapyPackages');
+    navigate(-1);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setError(null);
     try {
+      if (therapyPackages.length === 0) {
+        setError('請選擇至少一項療程');
+        setLoading(false);
+        return;
+      }
       const storeId = localStorage.getItem('store_id');
-      const payload = {
-        ...formData,
-        therapy_id: formData.therapyId,
-        therapyId: undefined,  // 避免多傳
-        storeId: storeId ? Number(storeId) : undefined
+      const paymentMethod = paymentMethodDisplayMap[formData.paymentMethod] || formData.paymentMethod;
+
+      const saleCategoryMap: { [key: string]: string } = {
+        '銷售': 'Sell',
+        '贈品': 'Gift',
+        '贈送': 'Gift',
+        '折扣': 'Discount',
+        '預購': 'Ticket',
+        '暫借': 'Ticket',
+        '票卷': 'Ticket',
       };
-      await addTherapySell([payload]);
-      alert("銷售紀錄新增成功！");
-      navigate("/therapy-sell");
+
+      const payloads = therapyPackages.map(pkg => {
+        const itemTotal = (pkg.TherapyPrice || 0) * (Number(pkg.userSessions) || 0);
+        let itemDiscount = 0;
+        if (packagesOriginalTotal > 0 && formData.discountAmount > 0) {
+          const proportion = itemTotal / packagesOriginalTotal;
+          itemDiscount = parseFloat((formData.discountAmount * proportion).toFixed(2));
+        }
+        return {
+          memberId: Number(formData.memberId),
+          therapy_id: pkg.therapy_id,
+          staffId: Number(formData.staffId),
+          purchaseDate: formData.date,
+          amount: Number(pkg.userSessions),
+          storeId: storeId ? Number(storeId) : undefined,
+          paymentMethod,
+          saleCategory: saleCategoryMap[formData.saleCategory] || formData.saleCategory,
+          transferCode: formData.paymentMethod === '轉帳' ? formData.transferCode : undefined,
+          cardNumber: formData.paymentMethod === '信用卡' ? formData.cardNumber : undefined,
+          discount: itemDiscount,
+          note: formData.note,
+        };
+      });
+
+      await addTherapySell(payloads);
+      localStorage.removeItem('addTherapySellFormState');
+      localStorage.removeItem('selectedTherapyPackages');
+      alert('銷售紀錄新增成功！');
+      navigate('/therapy-sell');
     } catch (err) {
-      setError("新增失敗，請檢查所有欄位。");
+      setError('新增失敗，請檢查所有欄位。');
       console.error(err);
     } finally {
       setLoading(false);
@@ -128,70 +227,103 @@ const AddTherapySell: React.FC = () => {
             <Card.Body>
               {error && <Alert variant="danger">{error}</Alert>}
               <Form onSubmit={handleSubmit}>
+
                 <Row className="mb-3">
-                  <Form.Group as={Col} controlId="memberId">
-                    <Form.Label>會員</Form.Label>
-                    <Form.Select name="memberId" value={formData.memberId} onChange={handleChange} required>
-                      <option value="">請選擇會員</option>
-                      {members.map((member) => (
-                        <option key={member.Member_ID} value={member.Member_ID}>
-                          {member.Name}
-                        </option>
-                      ))}
-                    </Form.Select>
-                  </Form.Group>
-                  <Form.Group as={Col} controlId="therapyId">
-                    <Form.Label>療程方案</Form.Label>
-                    <Form.Select name="therapyId" value={formData.therapyId} onChange={handleChange} required>
-                      <option value="">請選擇療程</option>
-                      {therapyList.map((therapy) => (
-                        <option key={therapy.id} value={therapy.id}>
-                          {therapy.name}
-                        </option>
-                      ))}
-                    </Form.Select>
-                  </Form.Group>
+                  <Col>
+                    <MemberColumn
+                      memberId={formData.memberId}
+                      name={memberName}
+                      isEditMode={false}
+                      onMemberChange={(id, name) => {
+                        setFormData(prev => ({ ...prev, memberId: id }));
+                        setMemberName(name);
+                      }}
+                      onError={(msg) => setError(msg)}
+                    />
+                  </Col>
                 </Row>
-                
                 <Row className="mb-3">
-                    <Form.Group as={Col} controlId="formRemaining">
-                        <Form.Label>目前剩餘堂數</Form.Label>
-                        <div className="form-control bg-light" style={{ minHeight: '38px', paddingTop: '0.5rem' }}>
-                            {isFetchingSessions ? (
-                                <Spinner as="span" animation="border" size="sm" role="status" aria-hidden="true" />
-                            ) : (
-                                remainingSessions !== null ? `${remainingSessions} 堂` : '請先選擇會員和方案'
-                            )}
-                        </div>
-                    </Form.Group>
-                  <Form.Group as={Col} controlId="amount">
-                    <Form.Label>購買堂數</Form.Label>
-                    <Form.Control type="number" name="amount" value={formData.amount} onChange={handleChange} required min="1" />
+                  <Form.Group as={Col} controlId="therapyPackages">
+                    <Form.Label>療程品項</Form.Label>
+                    <div className="d-flex gap-2">
+                      <div className="flex-grow-1 border rounded p-2" style={{ minHeight: '40px', maxHeight: '120px', overflowY: 'auto' }}>
+                        {therapyPackages.length > 0 ? (
+                          therapyPackages.map((pkg, i) => (
+                            <div key={i}>{pkg.TherapyContent || pkg.TherapyName} x {pkg.userSessions} (單價: NT${pkg.TherapyPrice?.toLocaleString()})</div>
+                          ))
+                        ) : (
+                          <span className="text-muted">點擊「選取」按鈕選擇療程</span>
+                        )}
+                      </div>
+                      <Button variant="info" type="button" className="text-white align-self-start px-3" onClick={openPackageSelection}>選取</Button>
+                    </div>
+                    <Form.Text muted>可複選，跳出新視窗選取。</Form.Text>
                   </Form.Group>
                 </Row>
 
                 <Row className="mb-3">
-                   <Form.Group as={Col} controlId="staffId">
+                  <Form.Group as={Col} controlId="staffId">
                     <Form.Label>服務人員</Form.Label>
                     <Form.Select name="staffId" value={formData.staffId} onChange={handleChange} required>
-                        <option value="">請選擇服務人員</option>
-                        {staffList.map((staff) => (
+                      <option value="">請選擇服務人員</option>
+                      {staffList.map((staff) => (
                         <option key={staff.id} value={staff.id}>
-                            {staff.name}
+                          {staff.name}
                         </option>
-                        ))}
+                      ))}
                     </Form.Select>
                   </Form.Group>
                   <Form.Group as={Col} controlId="paymentMethod">
                     <Form.Label>付款方式</Form.Label>
-                    <Form.Select name="paymentMethod" value={formData.paymentMethod} onChange={handleChange}>
-                      <option value="Cash">現金</option>
-                      <option value="CreditCard">信用卡</option>
-                      <option value="Transfer">銀行轉帳</option>
-                      <option value="MobilePayment">行動支付</option>
-                      <option value="Pending">待付款</option>
-                      <option value="Others">其他</option>
+                    <Form.Select name="paymentMethod" value={formData.paymentMethod} onChange={handleChange} required>
+                      {paymentMethodOptions.map(opt => (
+                        <option key={opt} value={opt}>{opt}</option>
+                      ))}
                     </Form.Select>
+                  </Form.Group>
+                </Row>
+
+                {formData.paymentMethod === '信用卡' && (
+                  <Form.Group className="mb-3" controlId="cardNumber">
+                    <Form.Label>卡號後五碼</Form.Label>
+                    <Form.Control type="text" name="cardNumber" maxLength={5} pattern="\d*" value={formData.cardNumber}
+                      onChange={handleChange} placeholder="請輸入信用卡號後五碼" />
+                  </Form.Group>
+                )}
+                {formData.paymentMethod === '轉帳' && (
+                  <Form.Group className="mb-3" controlId="transferCode">
+                    <Form.Label>轉帳帳號末五碼</Form.Label>
+                    <Form.Control type="text" name="transferCode" maxLength={5} pattern="\d*" value={formData.transferCode}
+                      onChange={handleChange} placeholder="請輸入轉帳帳號末五碼" />
+                  </Form.Group>
+                )}
+
+                <Row className="mb-3">
+                  <Form.Group as={Col} controlId="saleCategory">
+                    <Form.Label>銷售類別</Form.Label>
+                    <Form.Select name="saleCategory" value={formData.saleCategory} onChange={handleChange} required>
+                      {saleCategoryOptions.map(opt => (
+                        <option key={opt} value={opt}>{opt}</option>
+                      ))}
+                    </Form.Select>
+                  </Form.Group>
+                  <Form.Group as={Col} controlId="discountAmount">
+                    <Form.Label>折價</Form.Label>
+                    <InputGroup>
+                      <InputGroup.Text>NT$</InputGroup.Text>
+                      <Form.Control type="number" name="discountAmount" min="0" step="any" value={formData.discountAmount} onChange={handleChange} placeholder="輸入折價金額" />
+                    </InputGroup>
+                  </Form.Group>
+                </Row>
+
+                <Row className="mb-3">
+                  <Form.Group as={Col}>
+                    <Form.Label>總價</Form.Label>
+                    <Form.Control type="text" value={`NT$ ${packagesOriginalTotal.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
+                  </Form.Group>
+                  <Form.Group as={Col}>
+                    <Form.Label>應收</Form.Label>
+                    <Form.Control type="text" value={`NT$ ${finalPayableAmount.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
                   </Form.Group>
                 </Row>
 
@@ -209,10 +341,10 @@ const AddTherapySell: React.FC = () => {
                   <Button variant="info" type="submit" className="text-white" disabled={loading}>
                     {loading ? "儲存中..." : "確認"}
                   </Button>
-                  <Button variant="info" className="text-white" onClick={() => {}}>
+                  <Button variant="info" type="button" className="text-white" onClick={handleCancel}>
                     取消
                   </Button>
-                  <Button variant="info" className="text-white" onClick={() => {}}>
+                  <Button variant="info" type="button" className="text-white" onClick={() => window.print()}>
                     列印
                   </Button>
                 </div>

--- a/client/src/pages/therapy/TherapyPackageSelection.tsx
+++ b/client/src/pages/therapy/TherapyPackageSelection.tsx
@@ -129,7 +129,7 @@ const TherapyPackageSelection: React.FC = () => {
         }
         // 儲存的是 PackageInSelection[]，它已經包含了 userSessions
         localStorage.setItem('newlySelectedTherapyPackagesWithSessions', JSON.stringify(selectedArray));
-        navigate('/therapy-sell/add', { state: { therapyPackagesUpdated: true } }); // <--- 加上 state 標記
+        navigate(-1); // 返回新增頁面
     };
 
     const calculatePageTotal = () => {
@@ -217,10 +217,10 @@ const TherapyPackageSelection: React.FC = () => {
                          <div className="d-flex justify-content-between align-items-center">
                             <div>總計金額: <strong className="h5 mb-0" style={{color: '#00b1c8'}}>NT$ {calculatePageTotal().toLocaleString()}</strong></div>
                             <div>
-                                <Button variant="outline-secondary" onClick={() => navigate('/therapy-sell/add')} className="me-2">
+                                <Button variant="outline-secondary" type="button" onClick={() => navigate(-1)} className="me-2">
                                     取消
                                 </Button>
-                                <Button variant="primary" onClick={handleConfirmSelection} disabled={selectedPackagesMap.size === 0}>
+                                <Button variant="primary" type="button" onClick={handleConfirmSelection} disabled={selectedPackagesMap.size === 0}>
                                     確認選取 ({selectedPackagesMap.size} 項)
                                 </Button>
                             </div>

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -25,7 +25,7 @@ export interface TherapySellRow { // 更改 interface 名稱以避免與組件�
     Price?: number;         // 價錢 (總金額) - API 需返回此欄位
     PaymentMethod: string;  // 付款方式
     StaffName: string;      // 銷售人員
-    SaleCategory: string;   // 銷售類別
+    SaleCategory?: string;  // 銷售類別 (有些 API 可能返回 sale_category)
     Note?: string;          // 備註 - API 需返回此欄位
 }
 
@@ -217,7 +217,10 @@ const TherapySell: React.FC = () => {
                 </td>
                 <td className="align-middle">{sale.StaffName || "-"}</td>
                 <td className="align-middle">
-                    {therapySaleCategoryValueToDisplayMap[sale.SaleCategory] || sale.SaleCategory}
+                    {(() => {
+                        const cat = (sale as any).SaleCategory ?? (sale as any).sale_category;
+                        return therapySaleCategoryValueToDisplayMap[cat] || cat || "-";
+                    })()}
                 </td>
                 <td className="align-middle" style={{ maxWidth: '150px', whiteSpace: 'normal' }}>{sale.Note || "-"}</td>
             </tr>


### PR DESCRIPTION
## Summary
- allow selecting multiple therapy packages and compute totals
- map Chinese sale categories to DB enum values to avoid SQL errors
- restore form state from localStorage when returning from package selection
- add explicit button types and return to previous page after selecting packages

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `PYTHONPATH=server pytest -q` *(fails: requests.exceptions.ConnectionError: Failed to establish a new connection)*

------
https://chatgpt.com/codex/tasks/task_e_687e4c13a01c83299f4958cecb80d283