### PR TITLE
Update headquarters wording and streamline forms

### DIFF
--- a/client/src/config/pageTitles.ts
+++ b/client/src/config/pageTitles.ts
@@ -63,11 +63,13 @@ export const pageTitles: PageTitleMap = {
   '/finance/item-selection': { basic: '選擇銷售品項 1.1.5.1.1.1', admin: '選擇銷售品項 1.2.5.1.1.1' },
 
   // Backend
-  '/backend': { basic: '分店後台管理 1.1.6', admin: '總店後台管理 1.2.6' },
-  '/backend/staff': { basic: '分店後台管理-員工資料 1.1.6.1', admin: '總店後台管理-員工資料 1.2.6.1' },
-  '/backend/add-staff': { basic: '分店後台管理-新增入職簡歷 1.1.6.1.1', admin: '總店後台管理-新增入職簡歷 1.2.6.1.1' },
+  '/backend': { basic: '分店後台管理 1.1.6', admin: '總部後台管理 1.2.6' },
+  '/backend/staff': { basic: '分店後台管理-員工資料 1.1.6.1', admin: '總部後台管理-員工資料 1.2.6.1' },
+  '/backend/add-staff': { basic: '分店後台管理-新增入職簡歷 1.1.6.1.1', admin: '總部後台管理-新增入職簡歷 1.2.6.1.1' },
   '/backend/user-accounts': { basic: '無權限', admin: '使用者帳號管理 1.2.6.2' },
   '/backend/user-accounts/add': { basic: '無權限', admin: '新增/修改使用者帳號 1.2.6.2.1' },
   '/backend/product-bundles': { basic: '無權限', admin: '產品組合管理 1.2.6.3' },
+  '/backend/stores': { basic: '無權限', admin: '分店管理 1.2.6.4' },
+  '/backend/add-store': { basic: '無權限', admin: '建立新的分店帳號 1.2.6.4.1' },
 
 };

--- a/client/src/pages/backend/product_bundle/BundleCreateModal.tsx
+++ b/client/src/pages/backend/product_bundle/BundleCreateModal.tsx
@@ -148,7 +148,7 @@ const BundleCreateModal: React.FC<BundleCreateModalProps> = ({ show, onHide, onS
     return (
         <Modal show={show} onHide={onHide} size="lg" onExited={resetStates}>
             <Modal.Header closeButton>
-                <Modal.Title>產品療程管理 1.2.6.3</Modal.Title>
+                <Modal.Title>產品流程管理 1.2.6.3.1</Modal.Title>
             </Modal.Header>
             <Form onSubmit={handleSubmit}>
                 <Modal.Body>

--- a/client/src/pages/finance/AddSalesOrder.tsx
+++ b/client/src/pages/finance/AddSalesOrder.tsx
@@ -116,7 +116,7 @@ const AddSalesOrder: React.FC = () => {
             <Card>
                 <Card.Header className="text-center">
                     <h4>全崴國際無限充能館</h4>
-                    <h3>銷售單(需求待確認)</h3>
+                    <h3>銷售單</h3>
                 </Card.Header>
                 <Card.Body>
                     <Row className="mb-3">

--- a/client/src/pages/member/AddMember.tsx
+++ b/client/src/pages/member/AddMember.tsx
@@ -344,7 +344,6 @@ const AddMember: React.FC = () => {
                 
                 <div className="d-flex justify-content-end gap-2 mt-4">
                     <Button variant="info" className="text-white" onClick={() => navigate(-1)} disabled={loading}>取消</Button>
-                    <Button variant="info" className="text-white" onClick={() => navigate(-1)} disabled={loading}>確認</Button>
                     <Button variant="info" className="text-white" type="submit" disabled={loading}>
                         {loading ? <Spinner as="span" size="sm" /> : "儲存"}
                     </Button>

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -247,7 +247,7 @@ const AddProductSell: React.FC = () => {
             <Form.Group className="mb-3">
               <Form.Label>購買人姓名</Form.Label>
               <MemberColumn memberId={memberId} name={memberName} onMemberChange={handleMemberChange} onError={handleError} triggerSearchOnMount={false} />
-              {formSubmitted && !memberName && <div className="text-danger d-block small mt-1">請選擇購買會員</div>}
+              {formSubmitted && (!memberId || !memberName) && <div className="text-danger d-block small mt-1">請選擇購買會員</div>}
             </Form.Group>
             <Form.Group className="mb-3">
               <Form.Label>購買品項</Form.Label>
@@ -297,12 +297,6 @@ const AddProductSell: React.FC = () => {
 
           {/* --- Right Column --- */}
           <Col md={6}>
-            <Form.Group className="mb-3">
-              <Form.Label>會員編號</Form.Label>
-              <Form.Control type="text" value={memberId} readOnly disabled className="bg-light"/>
-              {formSubmitted && !memberId && <div className="text-danger d-block small mt-1">請選擇會員</div>}
-            </Form.Group>
-            
             <Form.Group className="mb-3">
               <Form.Label>購買日期</Form.Label>
               <Form.Control type="date" value={purchaseDate} max={new Date().toISOString().split("T")[0]} onChange={(e) => setPurchaseDate(e.target.value)} required />

--- a/client/src/utils/authUtils.ts
+++ b/client/src/utils/authUtils.ts
@@ -55,14 +55,14 @@ export const getStoreName = (): string | null => {
 
 /**
  * 依據商店等級格式化商店名稱
- * 若為總店則移除名稱中的「台北」字樣
+ * 若為總店則顯示為「總部」
  * @param name 原始商店名稱
  * @param level 商店等級
  * @returns 格式化後的商店名稱
  */
 export const formatStoreName = (name: string, level?: string | null): string => {
     if (level === '總店') {
-        return name.replace(/台北/g, '') || '總店';
+        return '總部';
     }
     return name;
 };


### PR DESCRIPTION
## Summary
- Show "總部" on home page for admin users
- Rename backend titles to "總部後台管理" and add titles for branch management pages
- Remove unused fields and confirm buttons in membership and sales forms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app' and 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689a306dcc88832983d84f3c5f7e0b78