### PR TITLE
feat: add member info to therapy record and enable therapy sell editing

### DIFF
--- a/client/src/pages/therapy/AddTherapyRecord.tsx
+++ b/client/src/pages/therapy/AddTherapyRecord.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Form, Button, Container, Row, Col, Alert, Spinner } from 'react-bootstrap';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Header from '../../components/Header';
 import DynamicContainer from '../../components/DynamicContainer';
 import { getAllStaffForDropdown } from '../../services/StaffService';
@@ -19,13 +19,16 @@ interface DropdownItem {
 
 const AddTherapyRecord: React.FC = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const presetMemberId = (location.state as { memberId?: string } | undefined)?.memberId || '';
     const [formData, setFormData] = useState({
-        member_id: '',
+        member_id: presetMemberId,
         staff_id: '',
         therapy_id: '',
         date: new Date().toISOString().split('T')[0],
         note: '',
     });
+    const [memberLocked] = useState(Boolean(presetMemberId));
 
     const [members, setMembers] = useState<Member[]>([]);
     const [staffList, setStaffList] = useState<DropdownItem[]>([]);
@@ -111,12 +114,18 @@ const AddTherapyRecord: React.FC = () => {
                 <Row className="mb-3">
                     <Form.Group as={Col} controlId="formMember">
                         <Form.Label>會員姓名</Form.Label>
-                        <Form.Select name="member_id" value={formData.member_id} onChange={handleChange} required disabled={loading}>
+                        <Form.Select name="member_id" value={formData.member_id} onChange={handleChange} required disabled={loading || memberLocked}>
                             <option value="" disabled>{loading ? '載入中...' : '請選擇會員'}</option>
                             {members.map((member) => (
                                 <option key={member.Member_ID} value={member.Member_ID}>{member.Name}</option>
                             ))}
                         </Form.Select>
+                    </Form.Group>
+                </Row>
+                <Row className="mb-3">
+                    <Form.Group as={Col} controlId="formMemberId">
+                        <Form.Label>會員編號</Form.Label>
+                        <Form.Control type="text" value={formData.member_id} disabled readOnly />
                     </Form.Group>
                 </Row>
                 <Row className="mb-3">

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -11,10 +11,10 @@ import {
   InputGroup,
 } from "react-bootstrap";
 import MemberColumn from "../../components/MemberColumn";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
-import { getStaffMembers, addTherapySell, SelectedTherapyPackageUIData } from "../../services/TherapySellService";
+import { getStaffMembers, addTherapySell, SelectedTherapyPackageUIData, TherapySellRow, updateTherapySell } from "../../services/TherapySellService";
 
 interface DropdownItem {
   id: number;
@@ -24,6 +24,9 @@ interface DropdownItem {
 
 const AddTherapySell: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const editSale = (location.state as { editSale?: TherapySellRow } | undefined)?.editSale;
+  const isEditMode = Boolean(editSale);
   const [formData, setFormData] = useState({
     memberId: "",
     staffId: "",
@@ -72,6 +75,27 @@ const AddTherapySell: React.FC = () => {
     };
 
     const restoreState = () => {
+      if (isEditMode && editSale) {
+        setFormData(prev => ({
+          ...prev,
+          memberId: editSale.Member_ID?.toString() || "",
+          staffId: editSale.Staff_ID?.toString() || "",
+          date: editSale.PurchaseDate?.split("T")[0] || prev.date,
+          paymentMethod: editSale.PaymentMethod || prev.paymentMethod,
+          saleCategory: editSale.SaleCategory || prev.saleCategory,
+          note: editSale.Note || "",
+        }));
+        setMemberName(editSale.MemberName || "");
+        setTherapyPackages(editSale.therapy_id ? [{
+          therapy_id: editSale.therapy_id,
+          TherapyName: editSale.PackageName,
+          TherapyContent: editSale.PackageName,
+          TherapyPrice: editSale.Price || 0,
+          userSessions: editSale.Sessions?.toString() || "1",
+        }] : []);
+        return;
+      }
+
       const formStateData = localStorage.getItem('addTherapySellFormState');
       if (formStateData) {
         try {
@@ -180,15 +204,14 @@ const AddTherapySell: React.FC = () => {
         '暫借': 'Ticket',
         '票卷': 'Ticket',
       };
-
-      const payloads = therapyPackages.map(pkg => {
+      if (isEditMode && editSale) {
+        const pkg = therapyPackages[0];
         const itemTotal = (pkg.TherapyPrice || 0) * (Number(pkg.userSessions) || 0);
         let itemDiscount = 0;
         if (packagesOriginalTotal > 0 && formData.discountAmount > 0) {
-          const proportion = itemTotal / packagesOriginalTotal;
-          itemDiscount = parseFloat((formData.discountAmount * proportion).toFixed(2));
+          itemDiscount = parseFloat((formData.discountAmount).toFixed(2));
         }
-        return {
+        const payload = {
           memberId: Number(formData.memberId),
           therapy_id: pkg.therapy_id,
           staffId: Number(formData.staffId),
@@ -202,16 +225,40 @@ const AddTherapySell: React.FC = () => {
           discount: itemDiscount,
           note: formData.note,
         };
-      });
-
-      await addTherapySell(payloads);
+        await updateTherapySell(editSale.Order_ID, payload);
+        alert('銷售紀錄修改成功！');
+      } else {
+        const payloads = therapyPackages.map(pkg => {
+          const itemTotal = (pkg.TherapyPrice || 0) * (Number(pkg.userSessions) || 0);
+          let itemDiscount = 0;
+          if (packagesOriginalTotal > 0 && formData.discountAmount > 0) {
+            const proportion = itemTotal / packagesOriginalTotal;
+            itemDiscount = parseFloat((formData.discountAmount * proportion).toFixed(2));
+          }
+          return {
+            memberId: Number(formData.memberId),
+            therapy_id: pkg.therapy_id,
+            staffId: Number(formData.staffId),
+            purchaseDate: formData.date,
+            amount: Number(pkg.userSessions),
+            storeId: storeId ? Number(storeId) : undefined,
+            paymentMethod,
+            saleCategory: saleCategoryMap[formData.saleCategory] || formData.saleCategory,
+            transferCode: formData.paymentMethod === '轉帳' ? formData.transferCode : undefined,
+            cardNumber: formData.paymentMethod === '信用卡' ? formData.cardNumber : undefined,
+            discount: itemDiscount,
+            note: formData.note,
+          };
+        });
+        await addTherapySell(payloads);
+        alert('銷售紀錄新增成功！');
+      }
       localStorage.removeItem('addTherapySellFormState');
       localStorage.removeItem('selectedTherapyPackages');
       localStorage.removeItem('selectedTherapyPackagesWithSessions');
-      alert('銷售紀錄新增成功！');
       navigate('/therapy-sell');
     } catch (err) {
-      setError('新增失敗，請檢查所有欄位。');
+      setError(isEditMode ? '修改失敗，請檢查所有欄位。' : '新增失敗，請檢查所有欄位。');
       console.error(err);
     } finally {
       setLoading(false);
@@ -224,7 +271,7 @@ const AddTherapySell: React.FC = () => {
         <Col md={{ span: 8, offset: 2 }}>
           <Card className="shadow-sm">
             <Card.Header as="h5" className="bg-info text-white">
-              新增療程銷售
+              {isEditMode ? '修改療程銷售' : '新增療程銷售'}
             </Card.Header>
             <Card.Body>
               {error && <Alert variant="danger">{error}</Alert>}

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -279,16 +279,21 @@ const TherapySell: React.FC = () => {
                             刪除
                         </Button>
                     </Col>
-                    {/*<Col xs="auto">
+                    <Col xs="auto">
                         <Button
-                            variant="info" // 修改 variant
-                            className="text-white px-4" // warning 配 text-dark 較好
-                            onClick={() => selectedItems.length === 1 && navigate(`/therapy-sell/edit/${selectedItems[0]}`)} // 假設編輯頁路由
+                            variant="info"
+                            className="text-white px-4"
+                            onClick={() => {
+                                if (selectedItems.length === 1) {
+                                    const sale = sales.find(s => s.Order_ID === selectedItems[0]);
+                                    navigate('/therapy-sell/add', { state: { editSale: sale } });
+                                }
+                            }}
                             disabled={loading || selectedItems.length !== 1}
                         >
                             修改
                         </Button>
-                    </Col>*/}
+                    </Col>
                     <Col xs="auto">
                         <Button
                             variant="info" // 修改 variant


### PR DESCRIPTION
## Summary
- display member ID on therapy record form and lock when pre-filled
- enable therapy sell modification by reusing add form for edits

## Testing
- `npm run lint` *(fails: Irregular whitespace, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ad1ec6dc48329a38c75d753e33b10