### PR TITLE
feat: add member info to therapy record and enable therapy sell editing

### DIFF
--- a/client/src/pages/therapy/AddTherapyRecord.tsx
+++ b/client/src/pages/therapy/AddTherapyRecord.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Form, Button, Container, Row, Col, Alert, Spinner } from 'react-bootstrap';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Header from '../../components/Header';
 import DynamicContainer from '../../components/DynamicContainer';
 import { getAllStaffForDropdown } from '../../services/StaffService';
@@ -19,13 +19,16 @@ interface DropdownItem {
 
 const AddTherapyRecord: React.FC = () => {
     const navigate = useNavigate();
+    const location = useLocation();
+    const presetMemberId = (location.state as { memberId?: string } | undefined)?.memberId || '';
     const [formData, setFormData] = useState({
-        member_id: '',
+        member_id: presetMemberId,
         staff_id: '',
         therapy_id: '',
         date: new Date().toISOString().split('T')[0],
         note: '',
     });
+    const [memberLocked] = useState(Boolean(presetMemberId));
 
     const [members, setMembers] = useState<Member[]>([]);
     const [staffList, setStaffList] = useState<DropdownItem[]>([]);
@@ -111,12 +114,18 @@ const AddTherapyRecord: React.FC = () => {
                 <Row className="mb-3">
                     <Form.Group as={Col} controlId="formMember">
                         <Form.Label>會員姓名</Form.Label>
-                        <Form.Select name="member_id" value={formData.member_id} onChange={handleChange} required disabled={loading}>
+                        <Form.Select name="member_id" value={formData.member_id} onChange={handleChange} required disabled={loading || memberLocked}>
                             <option value="" disabled>{loading ? '載入中...' : '請選擇會員'}</option>
                             {members.map((member) => (
                                 <option key={member.Member_ID} value={member.Member_ID}>{member.Name}</option>
                             ))}
                         </Form.Select>
+                    </Form.Group>
+                </Row>
+                <Row className="mb-3">
+                    <Form.Group as={Col} controlId="formMemberId">
+                        <Form.Label>會員編號</Form.Label>
+                        <Form.Control type="text" value={formData.member_id} disabled readOnly />
                     </Form.Group>
                 </Row>
                 <Row className="mb-3">

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -27,6 +27,7 @@ export interface TherapySellRow { // 更改 interface 名稱以避免與組件�
     StaffName: string;      // 銷售人員
     SaleCategory?: string;  // 銷售類別 (有些 API 可能返回 sale_category)
     Note?: string;          // 備註 - API 需返回此欄位
+    therapy_id?: number;    // 對應的療程 ID
 }
 
 // --- 新增/修改映射表 ---
@@ -279,16 +280,21 @@ const TherapySell: React.FC = () => {
                             刪除
                         </Button>
                     </Col>
-                    {/*<Col xs="auto">
+                    <Col xs="auto">
                         <Button
-                            variant="info" // 修改 variant
-                            className="text-white px-4" // warning 配 text-dark 較好
-                            onClick={() => selectedItems.length === 1 && navigate(`/therapy-sell/edit/${selectedItems[0]}`)} // 假設編輯頁路由
+                            variant="info"
+                            className="text-white px-4"
+                            onClick={() => {
+                                if (selectedItems.length === 1) {
+                                    const sale = sales.find(s => s.Order_ID === selectedItems[0]);
+                                    navigate('/therapy-sell/add', { state: { editSale: sale } });
+                                }
+                            }}
                             disabled={loading || selectedItems.length !== 1}
                         >
                             修改
                         </Button>
-                    </Col>*/}
+                    </Col>
                     <Col xs="auto">
                         <Button
                             variant="info" // 修改 variant

--- a/server/app/models/therapy_sell_model.py
+++ b/server/app/models/therapy_sell_model.py
@@ -63,14 +63,15 @@ def get_all_therapy_sells(store_id=None):
                        t.name as PackageName, 
                        t.code as TherapyCode, 
                        ts.amount as Sessions,
-                       ts.payment_method as PaymentMethod, 
-                       s.name as StaffName, 
+                       ts.payment_method as PaymentMethod,
+                       s.name as StaffName,
                        ts.sale_category as SaleCategory,
                        t.price as Price,
                        ts.note as Note,
                        ts.staff_id as Staff_ID,
                        st.store_name as store_name,
                        ts.store_id as store_id,
+                       ts.therapy_id as therapy_id,
                        ts.note
                 FROM therapy_sell ts
                 LEFT JOIN member m ON ts.member_id = m.member_id
@@ -108,24 +109,27 @@ def search_therapy_sells(keyword, store_id=None):
     try:
         with conn.cursor() as cursor:
             query = """
-                SELECT ts.therapy_sell_id as Order_ID, 
-                       m.member_id as Member_ID, 
-                       m.name as MemberName, 
+                SELECT ts.therapy_sell_id as Order_ID,
+                       m.member_id as Member_ID,
+                       m.name as MemberName,
                        ts.date as PurchaseDate,
-                       'Default Package' as PackageName, 
-                       'TP001' as TherapyCode, 
+                       t.name as PackageName,
+                       t.code as TherapyCode,
                        ts.amount as Sessions,
-                       'Cash' as PaymentMethod, 
-                       s.name as StaffName, 
-                       'Regular' as SaleCategory,
+                       ts.payment_method as PaymentMethod,
+                       s.name as StaffName,
+                       ts.sale_category as SaleCategory,
+                       t.price as Price,
                        ts.staff_id as Staff_ID,
                        st.store_name as store_name,
                        ts.store_id as store_id,
+                       ts.therapy_id as therapy_id,
                        ts.note
                 FROM therapy_sell ts
                 LEFT JOIN member m ON ts.member_id = m.member_id
                 LEFT JOIN staff s ON ts.staff_id = s.staff_id
                 LEFT JOIN store st ON ts.store_id = st.store_id
+                LEFT JOIN therapy t ON ts.therapy_id = t.therapy_id
                 WHERE (m.name LIKE %s OR m.member_id LIKE %s OR s.name LIKE %s)
             """
             


### PR DESCRIPTION
## Summary
- display member ID on therapy record form and lock when pre-filled
- enable therapy sell modification by reusing add form for edits
- preload therapy sale edit form with existing therapy items

## Testing
- `npm run lint` *(fails: Irregular whitespace not allowed, @typescript-eslint/no-unused-vars)*
- `pytest server/test_therapy_sell_api.py` *(fails: HTTPConnectionPool errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ad1ec6dc48329a38c75d753e33b10