### PR TITLE
feat: allow manual member codes with duplicate check

### DIFF
--- a/client/src/services/MemberService.ts
+++ b/client/src/services/MemberService.ts
@@ -259,6 +259,19 @@ export const checkMemberExists = async (memberId: string): Promise<boolean> => {
 };
 
 /**
+ * Check if a member code already exists
+ */
+export const checkMemberCodeExists = async (memberCode: string): Promise<boolean> => {
+  try {
+    const response = await authAxios.get(`/check-code/${memberCode}`);
+    return response.data.exists;
+  } catch (error) {
+    console.error(`Failed to check if member code ${memberCode} exists:`, error);
+    return false;
+  }
+};
+
+/**
  * next member inedex
  */
 export const getNextMemberCode = async (): Promise<ApiResponse<string>> => {

--- a/server/app/models/member_model.py
+++ b/server/app/models/member_model.py
@@ -198,6 +198,21 @@ def check_member_exists(member_id: int):
     finally:
         conn.close()
 
+
+def check_member_code_exists(member_code: str):
+    """Check if the given member_code already exists in the database."""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) as count FROM member WHERE member_code = %s",
+                (member_code,),
+            )
+            result = cursor.fetchone()
+        return result["count"] > 0
+    finally:
+        conn.close()
+
 def get_next_member_code():
     conn = connect_to_db()
     try:

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -12,6 +12,7 @@ from app.models.member_model import (
     update_member,
     get_member_by_id,
     check_member_exists,
+    check_member_code_exists,
     get_next_member_code,
     delete_member_and_related_data as delete_member_model
 )
@@ -61,6 +62,12 @@ def create_member_route():
     try:
         # 獲取當前使用者的 store_id
         user_store_id = request.store_id
+
+        member_code = data.get("member_code")
+        if not member_code:
+            return jsonify({"error": "會員代碼為必填欄位。"}), 400
+        if check_member_code_exists(member_code):
+            return jsonify({"error": "會員代碼已存在，請使用其他代碼。"}), 400
 
         # --- 介紹人 ID 的驗證邏輯 ---
         inferrer_id = data.get("inferrer_id")
@@ -219,6 +226,17 @@ def check_member_exists_route(member_id):
     """檢查會員是否存在"""
     try:
         exists = check_member_exists(member_id)
+        return jsonify({"exists": exists})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@member_bp.route('/check-code/<string:member_code>', methods=['GET'])
+@auth_required  # 加上認證，避免被惡意查詢
+def check_member_code_route(member_code):
+    """檢查會員代碼是否存在"""
+    try:
+        exists = check_member_code_exists(member_code)
         return jsonify({"exists": exists})
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- allow custom member_code input on add member page with duplicate checks
- validate member_code uniqueness on the backend and expose check API

## Testing
- `PYENV_VERSION=3.11.12 pytest` *(errors: ModuleNotFoundError: No module named 'flask')*
- `npm run build` *(fails: Could not resolve entry module "index.html" )*

------
https://chatgpt.com/codex/tasks/task_e_689dc3245a3883299da3a44eefab9a76