### PR TITLE
feat: support member code display and lookup

### DIFF
--- a/client/src/components/MemberColumn.tsx
+++ b/client/src/components/MemberColumn.tsx
@@ -2,21 +2,21 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { Form, Col, Row } from "react-bootstrap";
-import { getMemberById } from "../services/MedicalService"; // 確保路徑正確
+import { getMemberByCode } from "../services/MedicalService"; // 確保路徑正確
 import { MemberData } from "../types/medicalTypes"; // 確保路徑正確
 
 // ***** 修正 1：在 Props 中加入 isEditMode *****
 interface MemberColumnProps {
-    memberId: string;
+    memberCode: string;
     name: string;
     isEditMode: boolean; // 接收來自父元件的「修改模式」旗標
-    onMemberChange: (memberId: string, name: string, memberData: MemberData | null) => void;
+    onMemberChange: (memberCode: string, name: string, memberData: MemberData | null) => void;
     onError?: (error: string) => void;
 }
 
 const MemberColumn: React.FC<MemberColumnProps> = ({ 
-    memberId, 
-    name, 
+    memberCode,
+    name,
     isEditMode, // 解構出 isEditMode
     onMemberChange,
     onError,
@@ -35,8 +35,8 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
 
         // --- 以下的邏輯只會在「新增模式」下執行 ---
 
-        // 如果 memberId 是空的，也不執行
-        if (!memberId) {
+        // 如果 memberCode 是空的，也不執行
+        if (!memberCode) {
             return;
         }
 
@@ -48,18 +48,18 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
         // 設置新的計時器，延遲 500ms 後才去 call API
         debounceTimeoutRef.current = setTimeout(async () => {
             try {
-                const member = await getMemberById(memberId);
+                const member = await getMemberByCode(memberCode);
                 if (member) {
                     // 找到會員，呼叫 onMemberChange 更新父元件的表單
-                    onMemberChange(memberId, member.name, member);
+                    onMemberChange(memberCode, member.name, member);
                 } else {
-                    if (onError) onError(`會員編號 ${memberId} 不存在`);
-                    onMemberChange(memberId, "未找到會員", null);
+                    if (onError) onError(`會員代碼 ${memberCode} 不存在`);
+                    onMemberChange(memberCode, "未找到會員", null);
                 }
             } catch (err) {
                 console.error("獲取會員資料失敗", err);
                 if (onError) onError("獲取會員資料失敗");
-                onMemberChange(memberId, "查詢失敗", null);
+                onMemberChange(memberCode, "查詢失敗", null);
             }
         }, 500);
 
@@ -70,17 +70,17 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
             }
         };
     // 依賴項現在更簡潔
-    }, [memberId, isEditMode, onMemberChange, onError]);
+    }, [memberCode, isEditMode, onMemberChange, onError]);
 
     return (
         <Row>
             <Col md={6}>
                 <Form.Group className="mb-3">
-                    <Form.Label>會員編號</Form.Label>
+                    <Form.Label>會員代碼</Form.Label>
                     <Form.Control
                         type="text"
-                        name="memberId"
-                        value={memberId} // 直接使用 props 傳入的 memberId
+                        name="memberCode"
+                        value={memberCode} // 直接使用 props 傳入的 memberCode
                         // ***** 修正 3：在 onChange 中直接呼叫 onMemberChange *****
                         // 這樣父元件的狀態才能即時更新
                         onChange={(e) => onMemberChange(e.target.value, name, null)}
@@ -89,7 +89,7 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
                         disabled={isEditMode}
                     />
                     <Form.Control.Feedback type="invalid">
-                        請輸入會員編號
+                        請輸入會員代碼
                     </Form.Control.Feedback>
                 </Form.Group>
             </Col>

--- a/client/src/hooks/useMedicalRecordForm.ts
+++ b/client/src/hooks/useMedicalRecordForm.ts
@@ -88,6 +88,7 @@ export const useMedicalRecordForm = (id?: string) => {
     const [isContraindicated, setIsContraindicated] = useState(false);
 
     const initialFormState: MedicalFormType = {
+        memberCode: "",
         memberId: "",
         name: "",
         height: "",
@@ -249,8 +250,8 @@ export const useMedicalRecordForm = (id?: string) => {
     }, [form.healthStatus, form.symptom, form.familyHistory]);
 
 
-    const handleMemberChange = (memberId: string, name: string, memberDataResult: MemberData | null) => {
-        setForm(prev => ({ ...prev, memberId, name }));
+    const handleMemberChange = (memberCode: string, name: string, memberDataResult: MemberData | null) => {
+        setForm(prev => ({ ...prev, memberCode, memberId: memberDataResult?.member_id?.toString() || "", name }));
         setMemberData(memberDataResult);
     };
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/client/src/pages/health/pure_medical_record/AddPureMedicalRecord.tsx
+++ b/client/src/pages/health/pure_medical_record/AddPureMedicalRecord.tsx
@@ -13,7 +13,8 @@ import { calculateBMI, getTodayDateString } from "../../../utils/pureMedicalUtil
 // 更新 interface 以匹配新的欄位名稱
 interface PureMedicalFormRow {
   姓名: string;
-  會員ID: string;
+  會員ID: string; // 數值 ID
+  會員代碼: string; // 顯示用代碼
   血壓: string;
   日期: string;
   // 身高: string; // <--- 1) 刪除 身高
@@ -36,6 +37,7 @@ interface Staff {
 
 interface MemberData { // MemberColumn 會返回這個結構
   member_id: number;
+  member_code?: string;
   name: string;
 }
 
@@ -48,6 +50,7 @@ const AddPureMedicalRecord: React.FC = () => {
   const initialFormData: PureMedicalFormRow = {
     姓名: "",
     會員ID: "",
+    會員代碼: "",
     血壓: "",
     日期: getTodayDateString(),
     體重: "", 
@@ -130,20 +133,20 @@ const AddPureMedicalRecord: React.FC = () => {
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
-  const handleMemberChange = (memberId: string, name: string) => {
-   setFormData(prev => ({ ...prev, 會員ID: memberId, 姓名: name }));
-    if(error) setError(null);
-   };
+  const handleMemberChange = (memberCode: string, name: string, data: MemberData | null) => {
+    setFormData(prev => ({ ...prev, 會員代碼: memberCode, 會員ID: data?.member_id?.toString() || "", 姓名: name }));
+    if (error) setError(null);
+  };
 
   const handleError = (errorMessage: string) => {
     setError(errorMessage);
   };
 
   useEffect(() => {
-    if (error && error.includes("會員") && formData.會員ID) {
+    if (error && error.includes("會員") && formData.會員代碼) {
       setError(null);
     }
-  }, [formData.會員ID, error]);
+  }, [formData.會員代碼, error]);
 
   const convertFormDataToApiData = () => {
     const selectedStaff = staffList.find(staff =>
@@ -168,8 +171,8 @@ const AddPureMedicalRecord: React.FC = () => {
 
   // "確認" 按鈕的功能 - 即儲存
   const handleConfirmSubmit = async () => {
-    if (!formData.姓名 || !formData.會員ID) {
-      setError("姓名和會員ID為必填欄位");
+    if (!formData.姓名 || !formData.會員代碼) {
+      setError("姓名和會員代碼為必填欄位");
       // 自動滾動到 MemberColumn 附近或頂部
       const memberColumnElement = document.getElementById("member-column-section"); // 假設 MemberColumn 有 id
       if (memberColumnElement) {
@@ -209,8 +212,8 @@ const AddPureMedicalRecord: React.FC = () => {
             // 或者，直接操作 MemberColumn 的輸入框 (不推薦)
             // 最好的方式是 MemberColumn 能接收一個重置信號或空的 memberId/name
         }
-        // 簡易做法：直接清空 formData 中的姓名和會員ID，MemberColumn 會響應
-        setFormData(prev => ({...initialFormData, 姓名: "", 會員ID: ""}));
+        // 簡易做法：直接清空 formData 中的姓名和會員資訊，MemberColumn 會響應
+        setFormData(prev => ({...initialFormData, 姓名: "", 會員ID: "", 會員代碼: ""}));
 
     }
   };
@@ -236,7 +239,7 @@ const AddPureMedicalRecord: React.FC = () => {
         
         <div id="member-column-section"> {/* 給 MemberColumn 一個 ID 以便滾動定位 */}
             <MemberColumn
-                memberId={formData.會員ID}
+                memberCode={formData.會員代碼}
                 name={formData.姓名}
                 onMemberChange={handleMemberChange}
                 onError={handleError}

--- a/client/src/pages/medical_record/AddMedicalRecord.tsx
+++ b/client/src/pages/medical_record/AddMedicalRecord.tsx
@@ -45,7 +45,7 @@ const AddMedicalRecord = () => {
                     <Form noValidate validated={validated} onSubmit={formHook.handleSubmit}>
                         {/* ... (MemberColumn, 身高, 體重, 血壓, 備註, 健康狀態, 平時症狀, 家族病史, 微整型等欄位保持不變) ... */}
                         <MemberColumn
-                            memberId={form.memberId}
+                            memberCode={form.memberCode}
                             name={form.name}
                             onMemberChange={handleMemberChange}
                             onError={setError}

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import MemberColumn from "../../components/MemberColumn";
+import { MemberData } from "../../types/medicalTypes";
 import { addProductSell, ProductSellData } from "../../services/ProductSellService";
 import { getStoreId } from "../../services/LoginService";
 import { getStaffMembers, StaffMember } from "../../services/TherapyDropdownService";
@@ -31,6 +32,7 @@ const AddProductSell: React.FC = () => {
   const navigate = useNavigate();
 
   const [storeId, setStoreId] = useState<string>("");
+  const [memberCode, setMemberCode] = useState<string>("");
   const [memberId, setMemberId] = useState<string>("");
   const [memberName, setMemberName] = useState<string>("");
   const [purchaseDate, setPurchaseDate] = useState<string>(new Date().toISOString().split("T")[0]);
@@ -91,6 +93,7 @@ const AddProductSell: React.FC = () => {
     if (formStateData) {
       try {
         const formState = JSON.parse(formStateData);
+        if (formState.memberCode) setMemberCode(formState.memberCode);
         if (formState.memberId) setMemberId(formState.memberId);
         if (formState.memberName) setMemberName(formState.memberName);
         if (formState.purchaseDate) setPurchaseDate(formState.purchaseDate);
@@ -127,18 +130,27 @@ const AddProductSell: React.FC = () => {
     setFinalPayableAmount(productsOriginalTotal - orderDiscountAmount);
   }, [productsOriginalTotal, orderDiscountAmount]);
 
-  const handleMemberChange = (id: string, name: string) => {
-    setMemberId(id);
+  const handleMemberChange = (code: string, name: string, data: MemberData | null) => {
+    setMemberCode(code);
     setMemberName(name);
+    setMemberId(data?.member_id?.toString() || "");
     setError(null);
   };
   const handleError = (errorMsg: string) => setError(errorMsg);
   const openProductSelection = () => {
     const formState = {
       selectedStore,
-      memberId, memberName, purchaseDate, paymentMethod,
-      transferCode, cardNumber, saleCategory, note,
-      selectedStaffId, discountAmount: orderDiscountAmount,
+      memberCode,
+      memberId,
+      memberName,
+      purchaseDate,
+      paymentMethod,
+      transferCode,
+      cardNumber,
+      saleCategory,
+      note,
+      selectedStaffId,
+      discountAmount: orderDiscountAmount,
     };
     localStorage.setItem('productSellFormState', JSON.stringify(formState));
     localStorage.setItem('selectedProducts', JSON.stringify(selectedProducts));
@@ -158,7 +170,7 @@ const AddProductSell: React.FC = () => {
 
     if (selectedDate > today) { setError("購買日期不能選擇未來日期。"); return; }
     if (!storeId) { setError("無法獲取門市資訊，請重新登入。"); return; }
-    if (!memberId || !memberName) { setError("請選擇會員並確認姓名。"); return; }
+    if (!memberCode || !memberId) { setError("請選擇會員並確認姓名。"); return; }
     if (selectedProducts.length === 0) { setError("請選擇至少一項購買品項。"); return; }
     if (!paymentMethod) { setError("請選擇付款方式。"); return; }
     if (!selectedStaffId) { setError("請選擇銷售人員。"); return; }
@@ -246,8 +258,8 @@ const AddProductSell: React.FC = () => {
             </Form.Group>
             <Form.Group className="mb-3">
               <Form.Label>購買人姓名</Form.Label>
-              <MemberColumn memberId={memberId} name={memberName} onMemberChange={handleMemberChange} onError={handleError} triggerSearchOnMount={false} />
-              {formSubmitted && (!memberId || !memberName) && <div className="text-danger d-block small mt-1">請選擇購買會員</div>}
+              <MemberColumn memberCode={memberCode} name={memberName} isEditMode={false} onMemberChange={handleMemberChange} onError={handleError} />
+              {formSubmitted && (!memberCode || !memberId) && <div className="text-danger d-block small mt-1">請選擇購買會員</div>}
             </Form.Group>
             <Form.Group className="mb-3">
               <Form.Label>購買品項</Form.Label>

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -29,6 +29,7 @@ const AddTherapySell: React.FC = () => {
   const isEditMode = Boolean(editSale);
   const [formData, setFormData] = useState({
     memberId: "",
+    memberCode: "",
     staffId: "",
     date: new Date().toISOString().split("T")[0],
     paymentMethod: "Cash",
@@ -79,6 +80,7 @@ const AddTherapySell: React.FC = () => {
         setFormData(prev => ({
           ...prev,
           memberId: editSale.Member_ID?.toString() || "",
+          memberCode: editSale.member_code || "",
           staffId: editSale.Staff_ID?.toString() || "",
           date: editSale.PurchaseDate?.split("T")[0] || prev.date,
           paymentMethod: editSale.PaymentMethod || prev.paymentMethod,
@@ -103,6 +105,7 @@ const AddTherapySell: React.FC = () => {
         try {
           const formState = JSON.parse(formStateData);
           if (formState.memberId) setFormData(prev => ({ ...prev, memberId: formState.memberId }));
+          if (formState.memberCode) setFormData(prev => ({ ...prev, memberCode: formState.memberCode }));
           if (formState.memberName) setMemberName(formState.memberName);
           if (formState.staffId) setFormData(prev => ({ ...prev, staffId: formState.staffId }));
           if (formState.date) setFormData(prev => ({ ...prev, date: formState.date }));
@@ -161,6 +164,7 @@ const AddTherapySell: React.FC = () => {
   const openPackageSelection = () => {
     const formState = {
       memberId: formData.memberId,
+      memberCode: formData.memberCode,
       memberName,
       staffId: formData.staffId,
       date: formData.date,
@@ -282,11 +286,11 @@ const AddTherapySell: React.FC = () => {
                 <Row className="mb-3">
                   <Col>
                     <MemberColumn
-                      memberId={formData.memberId}
+                      memberCode={formData.memberCode}
                       name={memberName}
                       isEditMode={false}
-                      onMemberChange={(id, name) => {
-                        setFormData(prev => ({ ...prev, memberId: id }));
+                      onMemberChange={(code, name, data) => {
+                        setFormData(prev => ({ ...prev, memberCode: code, memberId: data?.member_id?.toString() || "" }));
                         setMemberName(name);
                       }}
                       onError={(msg) => setError(msg)}

--- a/client/src/pages/therapy/TherapyRecord.tsx
+++ b/client/src/pages/therapy/TherapyRecord.tsx
@@ -80,7 +80,7 @@ const TherapyRecord: React.FC = () => {
                 <Row className="align-items-center mb-3">
                     <Col md={6}>
                         <Form.Group>
-                            <Form.Label>姓名/電話/會員編號</Form.Label>
+                            <Form.Label>姓名/電話/會員代碼</Form.Label>
                             <Form.Control
                                 type="text"
                                 value={keyword}
@@ -206,7 +206,7 @@ const TherapyRecord: React.FC = () => {
                         <tr>
                             <th style={{ width: '50px' }}>勾選</th>
                             <th>姓名</th>
-                            <th>會員編號</th>
+                            <th>會員代碼</th>
                             <th>療程日期</th>
                             <th>方案</th>
                             <th>使用療程內容</th>
@@ -235,7 +235,7 @@ const TherapyRecord: React.FC = () => {
                                         />
                                     </td>
                                     <td className="align-middle">{record.member_name || "-"}</td>
-                                    <td className="align-middle">{record.member_id || "-"}</td>
+                                    <td className="align-middle">{record.member_code || "-"}</td>
                                     <td className="align-middle">{formatDate(record.date)}</td>
                                     <td className="align-middle">{record.package_name || "-"}</td>
                                     <td className="align-middle">{record.therapy_content || "-"}</td>

--- a/client/src/services/MedicalService.ts
+++ b/client/src/services/MedicalService.ts
@@ -55,6 +55,16 @@ export const getMemberById = async (memberId: string) => {
     throw error;
   }
 };
+
+export const getMemberByCode = async (memberCode: string) => {
+  try {
+    const res = await axios.get(`${base_url}/member/code/${memberCode}`);
+    return res.data;
+  } catch (error) {
+    console.error("透過代碼獲取會員資料失敗", error);
+    throw error;
+  }
+};
 // 根據 ID 獲取單筆健康檢查記錄
 export const getMedicalRecordById = async (recordId: number) => {
   const response = await axios.get(`${API_URL}/${recordId}`);

--- a/client/src/services/TherapyService.ts
+++ b/client/src/services/TherapyService.ts
@@ -8,6 +8,7 @@ const API_URL = `${base_url}/therapy`;
 export interface TherapyRecord {
     therapy_record_id: number;
     member_id: number;
+    member_code: string;
     member_name: string;
     store_id: number;
     store_name: string;

--- a/client/src/types/medicalTypes.ts
+++ b/client/src/types/medicalTypes.ts
@@ -1,6 +1,7 @@
 // 定義會員資料類型
 export interface MemberData {
     member_id: number;
+    member_code?: string;
     name: string;
     address: string;
     birthday: string;
@@ -25,6 +26,7 @@ export interface SelectedHealthStatusData {
 }
 // 擴展表單類型定義
 export interface MedicalFormType {
+    memberCode: string;
     memberId: string;
     name: string;
     height: string;

--- a/server/app/models/member_model.py
+++ b/server/app/models/member_model.py
@@ -188,6 +188,24 @@ def get_member_by_id(member_id: int):
     finally:
         conn.close()
 
+def get_member_by_code(member_code: str):
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT member_id, member_code, name, birthday, address, phone, gender, blood_type,
+                       line_id, inferrer_id, occupation, note, store_id
+                FROM member
+                WHERE member_code = %s
+                """,
+                (member_code,),
+            )
+            result = cursor.fetchone()
+        return result
+    finally:
+        conn.close()
+
 def check_member_exists(member_id: int):
     conn = connect_to_db()
     try:

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -39,9 +39,9 @@ def get_all_therapy_records():
         with conn.cursor() as cursor:
             # --- SQL查詢簡化：直接選取 remaining_sessions_at_time 欄位 ---
             sql = """
-                SELECT 
+                SELECT
                     tr.therapy_record_id, tr.date, tr.note,
-                    tr.member_id, m.name AS member_name,
+                    tr.member_id, m.member_code, m.name AS member_name,
                     tr.therapy_id, t.name AS package_name, t.content AS therapy_content,
                     tr.staff_id, s.name AS staff_name,
                     tr.remaining_sessions_at_time AS remaining_sessions
@@ -61,10 +61,11 @@ def get_therapy_records_by_store(store_id):
     conn = connect_to_db()
     with conn.cursor() as cursor:
         query = """
-            SELECT 
-                tr.therapy_record_id, 
-                m.member_id, 
-                m.name as member_name, 
+            SELECT
+                tr.therapy_record_id,
+                m.member_id,
+                m.member_code,
+                m.name as member_name,
                 s.store_id,
                 s.store_name as store_name,
                 st.staff_id,
@@ -105,9 +106,9 @@ def search_therapy_records(filters):
         with conn.cursor() as cursor:
             # SQL 查詢本身不變
             sql = """
-                SELECT 
+                SELECT
                     tr.therapy_record_id, tr.date, tr.note,
-                    tr.member_id, m.name AS member_name,
+                    tr.member_id, m.member_code, m.name AS member_name,
                     tr.therapy_id, t.name AS package_name, t.content AS therapy_content,
                     tr.staff_id, s.name AS staff_name,
                     tr.remaining_sessions_at_time AS remaining_sessions
@@ -122,9 +123,9 @@ def search_therapy_records(filters):
             
             # 動態組合 WHERE 篩選條件 (邏輯不變)
             if filters.get('keyword'):
-                sql += " AND (m.name LIKE %s OR m.phone LIKE %s OR tr.member_id LIKE %s)"
+                sql += " AND (m.name LIKE %s OR m.phone LIKE %s OR tr.member_id LIKE %s OR m.member_code LIKE %s)"
                 like_keyword = f"%{filters['keyword']}%"
-                sql_params.extend([like_keyword, like_keyword, like_keyword])
+                sql_params.extend([like_keyword, like_keyword, like_keyword, like_keyword])
             
             if filters.get('startDate'):
                 sql += " AND tr.date >= %s"
@@ -160,10 +161,11 @@ def get_therapy_record_by_id(record_id):
     conn = connect_to_db()
     with conn.cursor() as cursor:
         query = """
-            SELECT 
-                tr.therapy_record_id, 
-                m.member_id, 
-                m.name as member_name, 
+            SELECT
+                tr.therapy_record_id,
+                m.member_id,
+                m.member_code,
+                m.name as member_name,
                 s.store_id,
                 s.store_name as store_name,
                 st.staff_id,
@@ -286,9 +288,10 @@ def export_therapy_records(store_id=None):
         with conn.cursor() as cursor:
             if store_id:
                 query = """
-                    SELECT tr.therapy_record_id, 
-                           m.member_id, 
-                           m.name as member_name, 
+                    SELECT tr.therapy_record_id,
+                           m.member_id,
+                           m.member_code,
+                           m.name as member_name,
                            s.name as store_name,
                            st.name as staff_name,
                            tr.date,
@@ -303,9 +306,10 @@ def export_therapy_records(store_id=None):
                 cursor.execute(query, (store_id,))
             else:
                 query = """
-                    SELECT tr.therapy_record_id, 
-                           m.member_id, 
-                           m.name as member_name, 
+                    SELECT tr.therapy_record_id,
+                           m.member_id,
+                           m.member_code,
+                           m.name as member_name,
                            s.name as store_name,
                            st.name as staff_name,
                            tr.date,

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -11,6 +11,7 @@ from app.models.member_model import (
     create_member,
     update_member,
     get_member_by_id,
+    get_member_by_code,
     check_member_exists,
     check_member_code_exists,
     get_next_member_code,
@@ -213,6 +214,24 @@ def get_member_route(member_id):
             return jsonify({"error": "權限不足，無法查看非本店會員資料"}), 403
         # --- 權限檢查結束 ---
             
+        return jsonify(member)
+    except Exception as e:
+        traceback.print_exc()
+        return jsonify({"error": f"獲取會員資料時發生錯誤: {str(e)}"}), 500
+
+@member_bp.route("/code/<string:member_code>", methods=["GET"])
+@auth_required
+def get_member_by_code_route(member_code):
+    try:
+        member = get_member_by_code(member_code)
+        if not member:
+            return jsonify({"error": "會員不存在"}), 404
+
+        user_store_level = request.store_level
+        user_store_id = request.store_id
+        if user_store_level == '分店' and member['store_id'] != user_store_id:
+            return jsonify({"error": "權限不足，無法查看非本店會員資料"}), 403
+
         return jsonify(member)
     except Exception as e:
         traceback.print_exc()

--- a/server/app/routes/therapy.py
+++ b/server/app/routes/therapy.py
@@ -162,7 +162,7 @@ def export_records():
         # 過濾和重命名欄位以適合匯出
         export_data = [{
             '療程記錄ID': r.get('therapy_record_id'),
-            '會員ID': r.get('member_id'),
+            '會員代碼': r.get('member_code'),
             '會員姓名': r.get('member_name'),
             '商店名稱': r.get('store_name'),
             '服務人員': r.get('staff_name'),


### PR DESCRIPTION
## Summary
- add endpoint to fetch member by code
- include member_code in therapy record queries and export
- update frontend member lookup and displays to use member codes
- enable member-code lookup on product sell page to auto-fill member name

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_689dc4efd5f883298f26312d9c3c4bc8