### PR TITLE
Fix staff selection scope and stress test title

### DIFF
--- a/client/src/config/pageTitles.ts
+++ b/client/src/config/pageTitles.ts
@@ -32,6 +32,7 @@ export const pageTitles: PageTitleMap = {
   // Health
   '/health-data-analysis': { basic: '健康數據分析 1.1.1.4', admin: '健康數據分析 1.2.1.4' },
   '/health-data-analysis/stress-test/': { basic: 'iPN壓力源測試 1.1.1.4.1', admin: 'iPN壓力源測試 1.2.1.4.1' },
+  '/health-data-analysis/stress-test/add': { basic: '新增iPN壓力源測試 1.1.1.4.1.1', admin: '新增iPN壓力源測試 1.2.1.4.1.1' },
   '/health-data-analysis/stress-test/add/page1': { basic: '新增iPN壓力源測試 1.1.1.4.1.1', admin: '新增iPN壓力源測試 1.2.1.4.1.1' },
   '/health-data-analysis/stress-test/add/page2': { basic: '新增iPN壓力源測試 1.1.1.4.1.1.1', admin: '新增iPN壓力源測試 1.1.1.4.1.1.1' },
   '/health-data-analysis/stress-test/edit/:id': { basic: '編輯iPN壓力源測試 1.1.4.1.1.1', admin: '編輯iPN壓力源測試 1.2.4.1.1.1' },

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -60,14 +60,14 @@ const AddProductSell: React.FC = () => {
 
     const fetchStaffMembers = async () => {
       try {
-        const data = await getStaffMembers();
+        const data = await getStaffMembers(currentStoreId ? parseInt(currentStoreId) : undefined);
         setStaffMembers(data);
         if (data.length > 0 && !localStorage.getItem('productSellFormState')) {
           setSelectedStaffId(data[0].staff_id.toString());
         }
-      } catch (err) { 
-        console.error("載入銷售人員資料失敗：", err); 
-        setError("載入銷售人員資料失敗"); 
+      } catch (err) {
+        console.error("載入銷售人員資料失敗：", err);
+        setError("載入銷售人員資料失敗");
       }
     };
     fetchStaffMembers();

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -63,7 +63,8 @@ const AddTherapySell: React.FC = () => {
     const fetchInitialData = async () => {
       try {
         setLoading(true);
-        const staffRes = await getStaffMembers();
+        const storeId = localStorage.getItem('store_id');
+        const staffRes = await getStaffMembers(storeId ? Number(storeId) : undefined);
         if (staffRes.success && staffRes.data) {
           setStaffList(staffRes.data.map(s => ({ id: s.staff_id, name: s.name })));
         }

--- a/client/src/services/TherapyDropdownService.ts
+++ b/client/src/services/TherapyDropdownService.ts
@@ -45,10 +45,11 @@ export const getTherapyPackages = async (): Promise<TherapyPackage[]> => {
 };
 
 // 獲取員工 (選項資料)
-export const getStaffMembers = async (): Promise<StaffMember[]> => {
+export const getStaffMembers = async (storeId?: number): Promise<StaffMember[]> => {
     try {
-        const response = await axios.get(`${API_URL}/staff`);
-        
+        const params = storeId ? { store_id: storeId } : undefined;
+        const response = await axios.get(`${API_URL}/staff`, { params });
+
         // 處理返回數據，確保與預期格式一致
         if (response.data && Array.isArray(response.data)) {
             // 統一字段名稱
@@ -59,10 +60,10 @@ export const getStaffMembers = async (): Promise<StaffMember[]> => {
                 Staff_Name: staff.Staff_Name || staff.name || ""
             }));
         }
-        
+
         return [];
     } catch (error) {
         console.error("獲取員工資料失敗:", error);
         return [];
     }
-}; 
+};

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -125,19 +125,25 @@ export const getAllTherapyPackages = async (): Promise<ApiResponse<TherapyPackag
     }
 };
 
-// 員工相關 API - 重命名為 getStaffMembers 並使用正確的 API 端點
-export const getStaffMembers = async (): Promise<ApiResponse<StaffMember[]>> => {
+// 員工相關 API - 根據分店取得員工資料
+export const getStaffMembers = async (storeId?: number): Promise<ApiResponse<StaffMember[]>> => {
     try {
-        const response = await axios.get(`${API_URL}/staff`); // 使用 API_URL
-        
+        const params = storeId ? { store_id: storeId } : undefined;
+        const response = await axios.get(`${API_URL}/staff`, { params });
+
         if (response.data && Array.isArray(response.data)) {
             const staffData = response.data.map((staff: any) => ({
                 staff_id: staff.staff_id || staff.Staff_ID,
                 name: staff.name || staff.Staff_Name || "未知員工",
             }));
             return { success: true, data: staffData };
-        } else if (response.data && typeof response.data === 'object' && response.data.hasOwnProperty('data') && Array.isArray(response.data.data)) {
-             const staffData = response.data.data.map((staff: any) => ({
+        } else if (
+            response.data &&
+            typeof response.data === 'object' &&
+            response.data.hasOwnProperty('data') &&
+            Array.isArray(response.data.data)
+        ) {
+            const staffData = response.data.data.map((staff: any) => ({
                 staff_id: staff.staff_id || staff.Staff_ID,
                 name: staff.name || staff.Staff_Name || "未知員工",
             }));


### PR DESCRIPTION
## Summary
- filter staff dropdown by current store on product and therapy sales pages
- add missing title for stress test add page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Irregular whitespace, unused vars, no-explicit-any, etc.)*
- `npm run build` *(fails: TypeScript errors like missing props and unused variables)*


------
https://chatgpt.com/codex/tasks/task_e_689dd4aea4308329930bfdfb99c28958