### PR TITLE
Fix staff selection scope and stress test title

### DIFF
--- a/client/src/components/MemberColumn.tsx
+++ b/client/src/components/MemberColumn.tsx
@@ -48,8 +48,8 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
         // 設置新的計時器，延遲 500ms 後才去 call API
         debounceTimeoutRef.current = setTimeout(async () => {
             try {
-                const member = await getMemberByCode(memberCode);
-                if (member) {
+                const member: any = await getMemberByCode(memberCode);
+                if (member && !member.error) {
                     // 找到會員，呼叫 onMemberChange 更新父元件的表單
                     onMemberChange(memberCode, member.name, member);
                 } else {
@@ -70,7 +70,7 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
             }
         };
     // 依賴項現在更簡潔
-    }, [memberCode, isEditMode, onMemberChange, onError]);
+    }, [memberCode, isEditMode]);
 
     return (
         <Row>

--- a/client/src/config/pageTitles.ts
+++ b/client/src/config/pageTitles.ts
@@ -32,6 +32,7 @@ export const pageTitles: PageTitleMap = {
   // Health
   '/health-data-analysis': { basic: '健康數據分析 1.1.1.4', admin: '健康數據分析 1.2.1.4' },
   '/health-data-analysis/stress-test/': { basic: 'iPN壓力源測試 1.1.1.4.1', admin: 'iPN壓力源測試 1.2.1.4.1' },
+  '/health-data-analysis/stress-test/add': { basic: '新增iPN壓力源測試 1.1.1.4.1.1', admin: '新增iPN壓力源測試 1.2.1.4.1.1' },
   '/health-data-analysis/stress-test/add/page1': { basic: '新增iPN壓力源測試 1.1.1.4.1.1', admin: '新增iPN壓力源測試 1.2.1.4.1.1' },
   '/health-data-analysis/stress-test/add/page2': { basic: '新增iPN壓力源測試 1.1.1.4.1.1.1', admin: '新增iPN壓力源測試 1.1.1.4.1.1.1' },
   '/health-data-analysis/stress-test/edit/:id': { basic: '編輯iPN壓力源測試 1.1.4.1.1.1', admin: '編輯iPN壓力源測試 1.2.4.1.1.1' },

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -60,14 +60,14 @@ const AddProductSell: React.FC = () => {
 
     const fetchStaffMembers = async () => {
       try {
-        const data = await getStaffMembers();
+        const data = await getStaffMembers(currentStoreId ? parseInt(currentStoreId) : undefined);
         setStaffMembers(data);
         if (data.length > 0 && !localStorage.getItem('productSellFormState')) {
           setSelectedStaffId(data[0].staff_id.toString());
         }
-      } catch (err) { 
-        console.error("載入銷售人員資料失敗：", err); 
-        setError("載入銷售人員資料失敗"); 
+      } catch (err) {
+        console.error("載入銷售人員資料失敗：", err);
+        setError("載入銷售人員資料失敗");
       }
     };
     fetchStaffMembers();

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -63,7 +63,8 @@ const AddTherapySell: React.FC = () => {
     const fetchInitialData = async () => {
       try {
         setLoading(true);
-        const staffRes = await getStaffMembers();
+        const storeId = localStorage.getItem('store_id');
+        const staffRes = await getStaffMembers(storeId ? Number(storeId) : undefined);
         if (staffRes.success && staffRes.data) {
           setStaffList(staffRes.data.map(s => ({ id: s.staff_id, name: s.name })));
         }

--- a/client/src/services/MedicalService.ts
+++ b/client/src/services/MedicalService.ts
@@ -1,6 +1,7 @@
 // client\src\services\ＭedicalService.ts
 import axios from "axios";
 import { base_url } from "./BASE_URL";
+import { getAuthHeaders } from "./AuthUtils";
 
 const API_URL = `${base_url}/medical-record`;
 
@@ -58,7 +59,9 @@ export const getMemberById = async (memberId: string) => {
 
 export const getMemberByCode = async (memberCode: string) => {
   try {
-    const res = await axios.get(`${base_url}/member/code/${memberCode}`);
+    const res = await axios.get(`${base_url}/member/code/${memberCode}` , {
+      headers: getAuthHeaders(),
+    });
     return res.data;
   } catch (error) {
     console.error("透過代碼獲取會員資料失敗", error);

--- a/client/src/services/TherapyDropdownService.ts
+++ b/client/src/services/TherapyDropdownService.ts
@@ -45,10 +45,11 @@ export const getTherapyPackages = async (): Promise<TherapyPackage[]> => {
 };
 
 // 獲取員工 (選項資料)
-export const getStaffMembers = async (): Promise<StaffMember[]> => {
+export const getStaffMembers = async (storeId?: number): Promise<StaffMember[]> => {
     try {
-        const response = await axios.get(`${API_URL}/staff`);
-        
+        const params = storeId ? { store_id: storeId } : undefined;
+        const response = await axios.get(`${API_URL}/staff`, { params });
+
         // 處理返回數據，確保與預期格式一致
         if (response.data && Array.isArray(response.data)) {
             // 統一字段名稱
@@ -59,10 +60,10 @@ export const getStaffMembers = async (): Promise<StaffMember[]> => {
                 Staff_Name: staff.Staff_Name || staff.name || ""
             }));
         }
-        
+
         return [];
     } catch (error) {
         console.error("獲取員工資料失敗:", error);
         return [];
     }
-}; 
+};

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -125,19 +125,25 @@ export const getAllTherapyPackages = async (): Promise<ApiResponse<TherapyPackag
     }
 };
 
-// 員工相關 API - 重命名為 getStaffMembers 並使用正確的 API 端點
-export const getStaffMembers = async (): Promise<ApiResponse<StaffMember[]>> => {
+// 員工相關 API - 根據分店取得員工資料
+export const getStaffMembers = async (storeId?: number): Promise<ApiResponse<StaffMember[]>> => {
     try {
-        const response = await axios.get(`${API_URL}/staff`); // 使用 API_URL
-        
+        const params = storeId ? { store_id: storeId } : undefined;
+        const response = await axios.get(`${API_URL}/staff`, { params });
+
         if (response.data && Array.isArray(response.data)) {
             const staffData = response.data.map((staff: any) => ({
                 staff_id: staff.staff_id || staff.Staff_ID,
                 name: staff.name || staff.Staff_Name || "未知員工",
             }));
             return { success: true, data: staffData };
-        } else if (response.data && typeof response.data === 'object' && response.data.hasOwnProperty('data') && Array.isArray(response.data.data)) {
-             const staffData = response.data.data.map((staff: any) => ({
+        } else if (
+            response.data &&
+            typeof response.data === 'object' &&
+            response.data.hasOwnProperty('data') &&
+            Array.isArray(response.data.data)
+        ) {
+            const staffData = response.data.data.map((staff: any) => ({
                 staff_id: staff.staff_id || staff.Staff_ID,
                 name: staff.name || staff.Staff_Name || "未知員工",
             }));

--- a/server/app/models/therapy_sell_model.py
+++ b/server/app/models/therapy_sell_model.py
@@ -397,13 +397,17 @@ def get_all_members():
     finally:
         conn.close()
 
-def get_all_staff():
-    """獲取所有員工"""
+def get_all_staff(store_id=None):
+    """獲取所有員工，若提供分店則僅回傳該店員工"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
-            query = "SELECT staff_id, name FROM staff ORDER BY name"
-            cursor.execute(query)
+            if store_id:
+                query = "SELECT staff_id, name FROM staff WHERE store_id = %s ORDER BY name"
+                cursor.execute(query, (store_id,))
+            else:
+                query = "SELECT staff_id, name FROM staff ORDER BY name"
+                cursor.execute(query)
             result = cursor.fetchall()
             return result
     except Exception as e:

--- a/server/app/routes/therapy_sell.py
+++ b/server/app/routes/therapy_sell.py
@@ -269,10 +269,12 @@ def get_members():
         return jsonify({"error": str(e)}), 500
 
 @therapy_sell.route('/staff', methods=['GET'])
+@auth_required
 def get_staff():
-    """獲取所有員工"""
+    """依據分店取得員工"""
     try:
-        result = get_all_staff()
+        store_id = request.args.get('store_id')
+        result = get_all_staff(store_id)
         return jsonify(result)
     except Exception as e:
         print(f"獲取員工列表失敗: {e}")


### PR DESCRIPTION
## Summary
- restrict therapy-sell staff endpoint to the requested store so dropdowns only show branch employees
- include auth headers when searching members and handle errors to avoid false "查詢失敗" messages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build` *(fails: Could not resolve entry module "index.html".)*

------
https://chatgpt.com/codex/tasks/task_e_689dd4aea4308329930bfdfb99c28958