### PR TITLE
Fix undefined memberData reference in therapy sell page

### DIFF
--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -290,13 +290,13 @@ const AddTherapySell: React.FC = () => {
                       memberCode={formData.memberCode}
                       name={memberName}
                       isEditMode={false}
-                      onMemberChange={(code, name, data) => {
-                        setFormData(prev => ({ ...prev, memberCode: code, memberId: data?.member_id?.toString() || "" }));
-                        setMemberName(name);
-                        if (memberData) {
-                          setError(null);
-                        }
-                      }}
+                        onMemberChange={(code, name, data) => {
+                          setFormData(prev => ({ ...prev, memberCode: code, memberId: data?.member_id?.toString() || "" }));
+                          setMemberName(name);
+                          if (data) {
+                            setError(null);
+                          }
+                        }}
                       onError={(msg) => setError(msg)}
                     />
                   </Col>


### PR DESCRIPTION
## Summary
- fix therapy sell form crash by referencing data parameter instead of undefined memberData

## Testing
- `npm run build` (fails: Type 'FormControlElement' is not assignable... etc)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689dda27fce48329ba8f0f6c002287d2