### PR TITLE
Fix staff dropdown to respect admin permissions

### DIFF
--- a/client/src/services/TherapyDropdownService.ts
+++ b/client/src/services/TherapyDropdownService.ts
@@ -47,7 +47,14 @@ export const getTherapyPackages = async (): Promise<TherapyPackage[]> => {
 // 獲取員工 (選項資料)
 export const getStaffMembers = async (storeId?: number): Promise<StaffMember[]> => {
     try {
-        const params = storeId ? { store_id: storeId } : undefined;
+        const perm = localStorage.getItem('permission');
+        let params;
+        if (perm === 'admin') {
+            params = undefined;
+        } else {
+            const resolvedStoreId = storeId ?? Number(localStorage.getItem('store_id'));
+            params = resolvedStoreId ? { store_id: resolvedStoreId } : undefined;
+        }
         const response = await axios.get(`${API_URL}/staff`, { params });
 
         // 處理返回數據，確保與預期格式一致

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -128,7 +128,14 @@ export const getAllTherapyPackages = async (): Promise<ApiResponse<TherapyPackag
 // 員工相關 API - 根據分店取得員工資料
 export const getStaffMembers = async (storeId?: number): Promise<ApiResponse<StaffMember[]>> => {
     try {
-        const params = storeId ? { store_id: storeId } : undefined;
+        const perm = localStorage.getItem('permission');
+        let params;
+        if (perm === 'admin') {
+            params = undefined;
+        } else {
+            const resolvedStoreId = storeId ?? Number(localStorage.getItem('store_id'));
+            params = resolvedStoreId ? { store_id: resolvedStoreId } : undefined;
+        }
         const response = await axios.get(`${API_URL}/staff`, { params });
 
         if (response.data && Array.isArray(response.data)) {


### PR DESCRIPTION
## Summary
- ensure staff queries ignore store filter for admins so dropdowns show all staff
- default to current store for basic users when fetching staff options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint reported 575 errors, 13 warnings)*
- `npm run build` *(fails: TypeScript reported multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ddf351cdc8329867f27ea704d2ce3