### PR TITLE
Add employee type selection and role-based sidebar

### DIFF
--- a/client/src/components/Siderbar/Sidebar.tsx
+++ b/client/src/components/Siderbar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@iconify/react";
 import './Sidebar.css';
 import { logout } from "../../services/LoginService";
 import { formatStoreName } from "../../utils/authUtils";
+import { getUserRole } from "../../utils/authUtils";
 
 interface StoreInfo {
   store_id: number;
@@ -18,6 +19,7 @@ const Sidebar: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [storeName, setStoreName] = useState<string>("");
+  const userRole = getUserRole();
   
   // 新增狀態儲存 header 高度
   const [headerHeight, setHeaderHeight] = useState<number>(0); // 默認高度
@@ -159,12 +161,14 @@ const Sidebar: React.FC = () => {
             <span>帳務管理</span>
           </Button>
         </div>
-        <div className="nav-item-wrapper w-100">
-          <Button variant="light" className="nav-button w-100 d-flex align-items-center" onClick={() => navigate("/backend")}>
-            <img src="/group.svg" alt="" className="sidebar-icon me-2" />
-            <span>後台管理系統</span>
-          </Button>
-        </div>
+        {userRole === 'admin' && (
+          <div className="nav-item-wrapper w-100">
+            <Button variant="light" className="nav-button w-100 d-flex align-items-center" onClick={() => navigate("/backend")}> 
+              <img src="/group.svg" alt="" className="sidebar-icon me-2" />
+              <span>後台管理系統</span>
+            </Button>
+          </div>
+        )}
         <div className="nav-item-wrapper w-100 mt-auto">
           <Button variant="danger" className="nav-button w-100 d-flex align-items-center" onClick={handleLogout}>
             <span>登出</span>

--- a/client/src/pages/backend/AddEditUserAccount.tsx
+++ b/client/src/pages/backend/AddEditUserAccount.tsx
@@ -27,6 +27,7 @@ const AddEditUserAccount: React.FC = () => {
     const [staffList, setStaffList] = useState<StaffDropdownItem[]>([]);
     const [selectedStore, setSelectedStore] = useState('');
     const [selectedStaff, setSelectedStaff] = useState('');
+    const [employeeType, setEmployeeType] = useState('');
     const [account, setAccount] = useState('');
     const [password, setPassword] = useState('');
     
@@ -53,7 +54,7 @@ const AddEditUserAccount: React.FC = () => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (!selectedStaff || !account || !password) {
+        if (!selectedStaff || !employeeType || !account || !password) {
             setError("請填寫所有欄位");
             return;
         }
@@ -62,7 +63,7 @@ const AddEditUserAccount: React.FC = () => {
         setError(null);
         
         try {
-            const payload = { account, password };
+            const payload = { account, password, permission: employeeType };
             await updateStaffAccount(parseInt(selectedStaff), payload);
             alert('帳號設定成功！');
             navigate('/backend/user-accounts');
@@ -107,7 +108,18 @@ const AddEditUserAccount: React.FC = () => {
                                 </Form.Select>
                             </Col>
                         </Form.Group>
-                        
+
+                        <Form.Group as={Row} className="mb-3 align-items-center">
+                            <Form.Label column sm={3}>員工類型</Form.Label>
+                            <Col sm={9}>
+                                <Form.Select value={employeeType} onChange={e => setEmployeeType(e.target.value)} required disabled={!selectedStaff}>
+                                    <option value="">請選擇員工類型...</option>
+                                    <option value="admin">管理者</option>
+                                    <option value="basic">療癒師</option>
+                                </Form.Select>
+                            </Col>
+                        </Form.Group>
+
                         <hr/>
 
                         <Form.Group as={Row} className="mb-3 align-items-center">

--- a/client/src/services/StaffService.ts
+++ b/client/src/services/StaffService.ts
@@ -270,6 +270,7 @@ export interface StaffAccount {
     password?: string;
     store_id?: number;
     store_name?: string;
+    permission?: string;
 }
 
 // 2. 新增：分店列表的介面 (保持不變)

--- a/server/app/models/staff_model.py
+++ b/server/app/models/staff_model.py
@@ -525,19 +525,21 @@ def update_staff_account(staff_id, data):
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
-            # 準備參數，只包含我們需要的 account 和 password
+            # 準備參數，包含帳號、密碼與權限
             # 注意：這裡應該對密碼進行加密，為了簡化，我們先用明文
             params = {
                 "account": data.get("account"),
                 "password": data.get("password"),
+                "permission": data.get("permission"),
                 "staff_id": staff_id
             }
 
-            # 修正後的 SQL，只更新帳號和密碼
+            # 更新帳號、密碼與權限
             query = """
             UPDATE staff SET
                 account = %(account)s,
-                password = %(password)s
+                password = %(password)s,
+                permission = %(permission)s
             WHERE staff_id = %(staff_id)s
             """
             


### PR DESCRIPTION
## Summary
- add employee type dropdown when creating staff accounts and include permission in payload
- support permission field in staff service and model
- show backend management link in sidebar only for admin users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Irregular whitespace / numerous errors)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68a175adc9588329b42cb864e5d2c904