### PR TITLE
Add therapist role and permission field

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -34,7 +34,9 @@ const Header: React.FC<HeaderProps> = ({ title }) => {
 
         if (matchedPath && userRole) {
             const titleMapping = pageTitles[matchedPath];
-            return titleMapping[userRole]; // Return 'branch' or 'main_office' title
+            // 只有 'admin' 擁有獨立標題，其餘角色共用 basic 標題
+            const roleForTitle = userRole === 'admin' ? 'admin' : 'basic';
+            return titleMapping[roleForTitle];
         }
 
         return '全崴國際管理系統'; // Fallback title

--- a/client/src/components/Siderbar/Sidebar.tsx
+++ b/client/src/components/Siderbar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@iconify/react";
 import './Sidebar.css';
 import { logout } from "../../services/LoginService";
 import { formatStoreName } from "../../utils/authUtils";
+import { getUserRole } from "../../utils/authUtils";
 
 interface StoreInfo {
   store_id: number;
@@ -18,6 +19,7 @@ const Sidebar: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [storeName, setStoreName] = useState<string>("");
+  const userRole = getUserRole();
   
   // 新增狀態儲存 header 高度
   const [headerHeight, setHeaderHeight] = useState<number>(0); // 默認高度
@@ -154,17 +156,19 @@ const Sidebar: React.FC = () => {
           </Button>
         </div>
         <div className="nav-item-wrapper w-100">
-          <Button variant="light" className="nav-button w-100 d-flex align-items-center" onClick={() => navigate("/finance")}>
+          <Button variant="light" className="nav-button w-100 d-flex align-items-center" onClick={() => navigate("/finance")}> 
             <img src="/group.svg" alt="" className="sidebar-icon me-2" />
             <span>帳務管理</span>
           </Button>
         </div>
-        <div className="nav-item-wrapper w-100">
-          <Button variant="light" className="nav-button w-100 d-flex align-items-center" onClick={() => navigate("/backend")}>
-            <img src="/group.svg" alt="" className="sidebar-icon me-2" />
-            <span>後台管理系統</span>
-          </Button>
-        </div>
+        {userRole !== 'therapist' && (
+          <div className="nav-item-wrapper w-100">
+            <Button variant="light" className="nav-button w-100 d-flex align-items-center" onClick={() => navigate("/backend")}> 
+              <img src="/group.svg" alt="" className="sidebar-icon me-2" />
+              <span>後台管理系統</span>
+            </Button>
+          </div>
+        )}
         <div className="nav-item-wrapper w-100 mt-auto">
           <Button variant="danger" className="nav-button w-100 d-flex align-items-center" onClick={handleLogout}>
             <span>登出</span>

--- a/client/src/pages/backend/AddEditUserAccount.tsx
+++ b/client/src/pages/backend/AddEditUserAccount.tsx
@@ -27,6 +27,7 @@ const AddEditUserAccount: React.FC = () => {
     const [staffList, setStaffList] = useState<StaffDropdownItem[]>([]);
     const [selectedStore, setSelectedStore] = useState('');
     const [selectedStaff, setSelectedStaff] = useState('');
+    const [employeeType, setEmployeeType] = useState('');
     const [account, setAccount] = useState('');
     const [password, setPassword] = useState('');
     
@@ -53,7 +54,7 @@ const AddEditUserAccount: React.FC = () => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (!selectedStaff || !account || !password) {
+        if (!selectedStaff || !employeeType || !account || !password) {
             setError("請填寫所有欄位");
             return;
         }
@@ -62,7 +63,7 @@ const AddEditUserAccount: React.FC = () => {
         setError(null);
         
         try {
-            const payload = { account, password };
+            const payload = { account, password, permission: employeeType };
             await updateStaffAccount(parseInt(selectedStaff), payload);
             alert('帳號設定成功！');
             navigate('/backend/user-accounts');
@@ -107,7 +108,18 @@ const AddEditUserAccount: React.FC = () => {
                                 </Form.Select>
                             </Col>
                         </Form.Group>
-                        
+
+                        <Form.Group as={Row} className="mb-3 align-items-center">
+                            <Form.Label column sm={3}>員工類型</Form.Label>
+                            <Col sm={9}>
+                                <Form.Select value={employeeType} onChange={e => setEmployeeType(e.target.value)} required disabled={!selectedStaff}>
+                                    <option value="">請選擇員工類型...</option>
+                                    <option value="admin">管理者</option>
+                                    <option value="therapist">療癒師</option>
+                                </Form.Select>
+                            </Col>
+                        </Form.Group>
+
                         <hr/>
 
                         <Form.Group as={Row} className="mb-3 align-items-center">

--- a/client/src/services/StaffService.ts
+++ b/client/src/services/StaffService.ts
@@ -270,6 +270,7 @@ export interface StaffAccount {
     password?: string;
     store_id?: number;
     store_name?: string;
+    permission?: string;
 }
 
 // 2. 新增：分店列表的介面 (保持不變)

--- a/client/src/utils/authUtils.ts
+++ b/client/src/utils/authUtils.ts
@@ -13,18 +13,16 @@ export const setupAxiosInterceptors = () => {
     });
 };
 
-// **修改後的 setUserRole**
+// **設定使用者角色**
 export const setUserRole = (token: string): void => {
     try {
-        // 解碼 Token，並告知 TypeScript permission 的類型是 string
+        // Token 中會包含使用者的 permission 欄位
         const decoded: { permission: string } = jwtDecode(token);
-        
-        // **核心改動**：直接使用 permission 的值 ('admin' 或 'basic') 作為角色
-        const role = decoded.permission; 
-        
+        const role = decoded.permission; // 可能是 'admin'、'basic' 或 'therapist'
+
         if (role) {
             localStorage.setItem('userRole', role);
-            console.log(`User role set based on permission: ${role}`); // 新增日誌
+            console.log(`User role set based on permission: ${role}`);
         } else {
             console.error('permission not found in token!');
         }
@@ -33,10 +31,10 @@ export const setUserRole = (token: string): void => {
     }
 };
 
-// **修改後的 getUserRole**
-export const getUserRole = (): 'admin' | 'basic' | null => {
-    // 返回 'admin', 'basic', 或 null
-    return localStorage.getItem('userRole') as 'admin' | 'basic' | null;
+// **取得使用者角色**
+export const getUserRole = (): 'admin' | 'basic' | 'therapist' | null => {
+    // 可能的角色：'admin'、'basic'、'therapist'
+    return localStorage.getItem('userRole') as 'admin' | 'basic' | 'therapist' | null;
 };
 
 // 登出函式

--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -148,6 +148,7 @@ CREATE TABLE staff (
     `national_id` VARCHAR(20),
     `mailing_address` TEXT,
     `registered_address` TEXT,
+    `permission` VARCHAR(50) DEFAULT 'therapist',
     FOREIGN KEY (`family_information_id`) REFERENCES family_information(`family_information_id`),
     FOREIGN KEY (`emergency_contact_id`) REFERENCES emergency_contact(`emergency_contact_id`),
     FOREIGN KEY (`work_experience_id`) REFERENCES work_experience(`work_experience_id`),
@@ -380,6 +381,7 @@ ALTER COLUMN `store_id` DROP DEFAULT;
 ALTER TABLE `staff`
 ADD COLUMN `account` VARCHAR(50) NULL UNIQUE COMMENT '員工登入帳號',
 ADD COLUMN `password` VARCHAR(255) NULL COMMENT '員工登入密碼(應加密儲存)',
+ADD COLUMN `permission` VARCHAR(50) NULL DEFAULT 'therapist' COMMENT '員工權限',
 ADD COLUMN `store_id` INT NULL COMMENT '員工所屬分店ID',
 ADD CONSTRAINT `fk_staff_store` FOREIGN KEY (`store_id`) REFERENCES `store`(`store_id`);
 

--- a/server/app/models/staff_model.py
+++ b/server/app/models/staff_model.py
@@ -449,12 +449,12 @@ def get_permission_list():
     try:
         with connection.cursor() as cursor:
             query = """
-            SELECT DISTINCT Staff_PermissionLevel FROM Staff 
-            WHERE Staff_PermissionLevel IS NOT NULL AND Staff_PermissionLevel != ''
+            SELECT DISTINCT permission FROM staff
+            WHERE permission IS NOT NULL AND permission != ''
             """
             cursor.execute(query)
             permissions = cursor.fetchall()
-            permission_list = [permission["Staff_PermissionLevel"] for permission in permissions]
+            permission_list = [permission["permission"] for permission in permissions]
     except Exception as e:
         print(f"獲取權限列表錯誤: {e}")
     finally:
@@ -525,19 +525,21 @@ def update_staff_account(staff_id, data):
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
-            # 準備參數，只包含我們需要的 account 和 password
+            # 準備參數，包含帳號、密碼與權限
             # 注意：這裡應該對密碼進行加密，為了簡化，我們先用明文
             params = {
                 "account": data.get("account"),
                 "password": data.get("password"),
+                "permission": data.get("permission"),
                 "staff_id": staff_id
             }
 
-            # 修正後的 SQL，只更新帳號和密碼
+            # 更新帳號、密碼與權限
             query = """
             UPDATE staff SET
                 account = %(account)s,
-                password = %(password)s
+                password = %(password)s,
+                permission = %(permission)s
             WHERE staff_id = %(staff_id)s
             """
             

--- a/server/app/routes/staff.py
+++ b/server/app/routes/staff.py
@@ -120,7 +120,7 @@ def export_staff_route():
             'work_experience_id', 'hiring_information_id', 'name', 'gender',
             'fill_date', 'onboard_date', 'nationality', 'education', 'married',
             'position', 'phone', 'national_id', 'mailing_address',
-            'registered_address', 'account', 'password', 'store_id'
+            'registered_address', 'account', 'password', 'permission', 'store_id'
         ]
 
         df = pd.DataFrame(staff_list)


### PR DESCRIPTION
## Summary
- allow therapists to be set separately from basic users and hide backend link only for therapist role
- add permission column for staff in database schema and include in exports
- support therapist role in auth utilities and user account setup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Irregular whitespace not allowed / 588 problems)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a175adc9588329b42cb864e5d2c904