### PR TITLE
Use staff table for login

### DIFF
--- a/server/app/middleware.py
+++ b/server/app/middleware.py
@@ -1,7 +1,6 @@
 # server\app\middleware.py
 from flask import request, jsonify, g
 from functools import wraps
-from app.models.login_model import find_store_by_account
 import jwt
 import datetime
 from app.config import JWT_SECRET_KEY
@@ -133,4 +132,4 @@ def get_user_from_token(request):
         # 如果token無效或過期，返回空字典
         pass
     
-    return user_info 
+    return user_info

--- a/server/app/models/login_model.py
+++ b/server/app/models/login_model.py
@@ -1,25 +1,29 @@
 # server\app\models\login_model.py
 import pymysql
 from app.config import DB_CONFIG
+
+
 def connect_to_db():
-    print(f"DEBUG login_model.py: Attempting to connect with DB_CONFIG: {DB_CONFIG}") # <--- ADD THIS LINE
+    print(f"DEBUG login_model.py: Attempting to connect with DB_CONFIG: {DB_CONFIG}")  # <--- ADD THIS LINE
     if not DB_CONFIG.get("database"):
-        print(f"CRITICAL DEBUG login_model.py: DB_CONFIG['database'] is '{DB_CONFIG.get('database')}' (missing or empty)!")
+        print(
+            f"CRITICAL DEBUG login_model.py: DB_CONFIG['database'] is '{DB_CONFIG.get('database')}' (missing or empty)!"
+        )
     return pymysql.connect(**DB_CONFIG, cursorclass=pymysql.cursors.DictCursor)
 
 
-def find_store_by_account(account):
-    """根據登入帳號查找分店與帳號資訊"""
+def find_staff_by_account(account):
+    """根據登入帳號查找員工與其分店資訊"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
             cursor.execute(
                 """
                 SELECT s.store_id, s.store_name, s.store_location,
-                       sa.account, sa.password, sa.permission
-                FROM store_account AS sa
-                JOIN store AS s ON sa.store_id = s.store_id
-                WHERE sa.account = %s
+                       st.staff_id, st.account, st.password, st.permission
+                FROM staff AS st
+                JOIN store AS s ON st.store_id = s.store_id
+                WHERE st.account = %s
                 """,
                 (account,)
             )
@@ -27,14 +31,15 @@ def find_store_by_account(account):
     finally:
         conn.close()
 
-def update_store_password(account, new_password):
-    """更新商店帳號密碼"""
+
+def update_staff_password(account, new_password):
+    """更新員工登入密碼"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
             cursor.execute(
-                "UPDATE store_account SET password = %s WHERE account = %s",
-                (new_password, account)
+                "UPDATE staff SET password = %s WHERE account = %s",
+                (new_password, account),
             )
         conn.commit()
     except Exception as e:
@@ -43,17 +48,18 @@ def update_store_password(account, new_password):
     finally:
         conn.close()
 
+
 def get_store_info(store_id):
-    """根據 store_id 獲取分店與其帳號"""
+    """根據 store_id 獲取分店與其員工帳號"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
             cursor.execute(
                 """
                 SELECT s.store_id, s.store_name, s.store_location,
-                       sa.account, sa.permission
+                       st.staff_id, st.account, st.permission
                 FROM store AS s
-                LEFT JOIN store_account AS sa ON sa.store_id = s.store_id
+                LEFT JOIN staff AS st ON st.store_id = s.store_id
                 WHERE s.store_id = %s
                 """,
                 (store_id,)
@@ -62,17 +68,18 @@ def get_store_info(store_id):
     finally:
         conn.close()
 
+
 def get_all_stores():
-    """獲取所有分店與其帳號資訊"""
+    """獲取所有分店與其員工帳號資訊"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
             cursor.execute(
                 """
                 SELECT s.store_id, s.store_name, s.store_location,
-                       sa.account, sa.permission
+                       st.staff_id, st.account, st.permission
                 FROM store AS s
-                LEFT JOIN store_account AS sa ON sa.store_id = s.store_id
+                LEFT JOIN staff AS st ON st.store_id = s.store_id
                 ORDER BY s.store_id ASC
                 """
             )


### PR DESCRIPTION
## Summary
- check login credentials using `staff` table instead of `store_account`
- include `staff_id` in JWT payloads and responses
- tidy middleware import and JWT helper

## Testing
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68a184c1d71883298d7537b980817287