### PR TITLE
Add staff edit page and routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -58,6 +58,7 @@ import InventoryInsert from "./pages/inventory/InventoryInsert";
 import BranchBackend from "./pages/backend/BranchBackend";
 import Staff from "./pages/backend/Staff";
 import AddStaff from "./pages/backend/AddStaff";
+import EditStaff from "./pages/backend/EditStaff";
 import HeadquartersBackend from './pages/backend/HeadquartersBackend';
 import UserAccountManagement from './pages/backend/UserAccountManagement';
 import AddEditUserAccount from './pages/backend/AddEditUserAccount';
@@ -163,6 +164,7 @@ const App: React.FC = () => {
                     {/* 總部專用的其他後台路徑 */}
                     <Route path="/backend/staff" element={<ProtectedRoute element={<Staff />} />} />
                     <Route path="/backend/add-staff" element={<ProtectedRoute element={<AddStaff />} />} />
+                    <Route path="/backend/edit-staff/:staffId" element={<ProtectedRoute element={<EditStaff />} />} />
                     <Route path="/backend/user-accounts" element={<ProtectedRoute element={<UserAccountManagement />} adminOnly={true} />} />
                     <Route path="/backend/user-accounts/add" element={<ProtectedRoute element={<AddEditUserAccount />} adminOnly={true} />} />
                     <Route path="/backend/user-accounts/edit/:staffId" element={<ProtectedRoute element={<AddEditUserAccount />} adminOnly={true} />} />

--- a/client/src/config/pageTitles.ts
+++ b/client/src/config/pageTitles.ts
@@ -67,6 +67,7 @@ export const pageTitles: PageTitleMap = {
   '/backend': { basic: '分店後台管理 1.1.6', admin: '總部後台管理 1.2.6' },
   '/backend/staff': { basic: '分店後台管理-員工資料 1.1.6.1', admin: '總部後台管理-員工資料 1.2.6.1' },
   '/backend/add-staff': { basic: '分店後台管理-新增入職簡歷 1.1.6.1.1', admin: '總部後台管理-新增入職簡歷 1.2.6.1.1' },
+  '/backend/edit-staff/:staffId': { basic: '分店後台管理-編輯員工資料 1.1.6.1.2', admin: '總部後台管理-編輯員工資料 1.2.6.1.2' },
   '/backend/user-accounts': { basic: '無權限', admin: '使用者帳號管理 1.2.6.2' },
   '/backend/user-accounts/add': { basic: '無權限', admin: '新增/修改使用者帳號 1.2.6.2.1' },
   '/backend/product-bundles': { basic: '無權限', admin: '產品組合管理 1.2.6.3' },

--- a/client/src/pages/backend/EditStaff.tsx
+++ b/client/src/pages/backend/EditStaff.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Form, Button, Container, Spinner, Alert } from 'react-bootstrap';
+import Header from '../../components/Header';
+import DynamicContainer from '../../components/DynamicContainer';
+import { getStaffById, updateStaff } from '../../services/StaffService';
+
+interface StaffForm {
+  name: string;
+  national_id: string;
+  phone: string;
+  gender: string;
+}
+
+const EditStaff: React.FC = () => {
+  const { staffId } = useParams<{ staffId: string }>();
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState<StaffForm>({
+    name: '',
+    national_id: '',
+    phone: '',
+    gender: '',
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchStaff = async () => {
+      if (!staffId) return;
+      try {
+        const res = await getStaffById(Number(staffId));
+        if (res.success && res.data) {
+          setFormData({
+            name: res.data.name || '',
+            national_id: res.data.national_id || '',
+            phone: res.data.phone || '',
+            gender: res.data.gender || '',
+          });
+        } else {
+          setError('載入員工資料失敗');
+        }
+      } catch (err) {
+        console.error(err);
+        setError('載入員工資料失敗');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchStaff();
+  }, [staffId]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!staffId) return;
+    setSaving(true);
+    setError('');
+    try {
+      const res = await updateStaff(Number(staffId), {
+        basic_info: {
+          Staff_Name: formData.name,
+          Staff_Phone: formData.phone,
+          Staff_Sex: formData.gender,
+          Staff_ID_Number: formData.national_id,
+        },
+      });
+      if (res.success) {
+        navigate('/backend/staff');
+      } else {
+        setError(res.message || '更新失敗');
+      }
+    } catch (err) {
+      console.error(err);
+      setError('更新失敗');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const content = loading ? (
+    <div className="text-center py-5"><Spinner /></div>
+  ) : (
+    <Container className="my-4" style={{ maxWidth: '600px' }}>
+      {error && <Alert variant="danger" onClose={() => setError('')} dismissible>{error}</Alert>}
+      <Form onSubmit={handleSubmit}>
+        <Form.Group className="mb-3" controlId="name">
+          <Form.Label>姓名</Form.Label>
+          <Form.Control name="name" value={formData.name} onChange={handleChange} required />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="national_id">
+          <Form.Label>身分證字號</Form.Label>
+          <Form.Control name="national_id" value={formData.national_id} onChange={handleChange} />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="phone">
+          <Form.Label>手機號碼</Form.Label>
+          <Form.Control name="phone" value={formData.phone} onChange={handleChange} />
+        </Form.Group>
+        <Form.Group className="mb-3" controlId="gender">
+          <Form.Label>性別</Form.Label>
+          <Form.Select name="gender" value={formData.gender} onChange={handleChange}>
+            <option value="">請選擇</option>
+            <option value="Male">男</option>
+            <option value="Female">女</option>
+            <option value="Other">其他</option>
+          </Form.Select>
+        </Form.Group>
+        <div className="text-end">
+          <Button variant="secondary" className="me-2" onClick={() => navigate('/backend/staff')} disabled={saving}>
+            取消
+          </Button>
+          <Button variant="info" type="submit" className="text-white" disabled={saving}>
+            儲存
+          </Button>
+        </div>
+      </Form>
+    </Container>
+  );
+
+  return (
+    <div className="d-flex flex-column" style={{ minHeight: '100vh' }}>
+      <Header />
+      <DynamicContainer content={content} />
+    </div>
+  );
+};
+
+export default EditStaff;


### PR DESCRIPTION
## Summary
- add new EditStaff component to load and update existing staff details
- wire up `/backend/edit-staff/:staffId` route and page title mapping

## Testing
- `npm run lint` *(fails: multiple lint errors across repository)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68a18870f640832985206ca947cf0d58