### PR TITLE
feat: improve user account edit

### DIFF
--- a/client/src/config/pageTitles.ts
+++ b/client/src/config/pageTitles.ts
@@ -69,6 +69,7 @@ export const pageTitles: PageTitleMap = {
   '/backend/add-staff': { basic: '分店後台管理-新增入職簡歷 1.1.6.1.1', admin: '總部後台管理-新增入職簡歷 1.2.6.1.1' },
   '/backend/user-accounts': { basic: '無權限', admin: '使用者帳號管理 1.2.6.2' },
   '/backend/user-accounts/add': { basic: '無權限', admin: '新增/修改使用者帳號 1.2.6.2.1' },
+  '/backend/user-accounts/edit/:staffId': { basic: '無權限', admin: '新增/修改使用者帳號 1.2.6.2.1' },
   '/backend/product-bundles': { basic: '無權限', admin: '產品組合管理 1.2.6.3' },
   '/backend/stores': { basic: '無權限', admin: '分店管理 1.2.6.4' },
   '/backend/add-store': { basic: '無權限', admin: '建立新的分店帳號 1.2.6.4.1' },

--- a/client/src/pages/backend/AddEditUserAccount.tsx
+++ b/client/src/pages/backend/AddEditUserAccount.tsx
@@ -3,11 +3,12 @@
 import React, { useState, useEffect } from 'react';
 import { Container, Form, Button, Card, Spinner, Alert, Row, Col } from 'react-bootstrap';
 import { useNavigate, useParams } from 'react-router-dom';
-import { 
-    updateStaffAccount, 
+import {
+    updateStaffAccount,
     fetchStoresForDropdown,
     getStaffByStore,
-    Store 
+    getStaffById,
+    Store
 } from '../../services/StaffService';
 import Header from '../../components/Header'; // 1. 引入 Header
 import DynamicContainer from '../../components/DynamicContainer'; // 2. 引入 DynamicContainer
@@ -44,13 +45,33 @@ const AddEditUserAccount: React.FC = () => {
         if (selectedStore) {
             setLoading(true);
             setStaffList([]);
-            setSelectedStaff('');
+            if (!isEditMode) setSelectedStaff('');
             getStaffByStore(parseInt(selectedStore))
                 .then(setStaffList)
                 .catch(() => setError("無法載入該分店的員工列表"))
                 .finally(() => setLoading(false));
         }
-    }, [selectedStore]);
+    }, [selectedStore, isEditMode]);
+
+    useEffect(() => {
+        if (isEditMode && staffId) {
+            setLoading(true);
+            getStaffById(parseInt(staffId))
+                .then((staff: any) => {
+                    if (staff) {
+                        if (staff.store_id) setSelectedStore(String(staff.store_id));
+                        setSelectedStaff(String(staff.staff_id));
+                        setEmployeeType(staff.permission || '');
+                        setAccount(staff.account || '');
+                        setPassword(staff.password || '');
+                    } else {
+                        setError('找不到該員工');
+                    }
+                })
+                .catch(() => setError('無法載入員工資料'))
+                .finally(() => setLoading(false));
+        }
+    }, [isEditMode, staffId]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/server/app/routes/staff.py
+++ b/server/app/routes/staff.py
@@ -242,10 +242,11 @@ def update_account_route(staff_id):
         else:
             return jsonify({"error": "更新失敗或無此員工"}), 404
     except Exception as e:
-        # 處理帳號重複的錯誤
-        if "Duplicate entry" in str(e) and "for key 'account'" in str(e):
-             return jsonify({"error": f"帳號 '{data.get('account')}' 已被使用，請更換一個。"}), 400
-        return jsonify({"error": str(e)}), 500
+        # 處理帳號重複的錯誤，避免回傳資料庫明碼
+        error_message = str(e)
+        if "Duplicate entry" in error_message and "account" in error_message:
+            return jsonify({"error": "使用者帳號重複"}), 400
+        return jsonify({"error": error_message}), 500
 
 
 # 總部專用：獲取所有分店列表，用於下拉式選單


### PR DESCRIPTION
## Summary
- apply correct title to user account edit pages
- preload existing data when editing user accounts
- show friendly error when creating duplicate user accounts

## Testing
- `npm --prefix client test` *(fails: Missing script: "test")*
- `cd server && pytest` *(fails: pyenv version `3.11.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1896fcd088329986cf1ba0cb06a76