### PR TITLE
Fix staff name column references

### DIFF
--- a/client/src/pages/backend/AddStaff.tsx
+++ b/client/src/pages/backend/AddStaff.tsx
@@ -80,7 +80,8 @@ const AddStaff: React.FC = () => {
                     setFormData(prev => ({
                         ...prev,
                         onboardDate: info.Staff_JoinDate || "",
-                        name: info.Staff_Name || "",
+                        // 後端欄位已改為 name，為了相容性同時支援舊欄位
+                        name: info.name || info.Staff_Name || "",
                         gender: info.Staff_Sex || "",
                         birthday: info.Staff_Birthday || "",
                         nationality: info.Staff_Nationality || "",

--- a/server/app/models/staff_model.py
+++ b/server/app/models/staff_model.py
@@ -56,7 +56,8 @@ def get_all_staff_for_dropdown():
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
-            sql = "SELECT Staff_ID AS staff_id, Staff_Name AS name FROM Staff ORDER BY Staff_Name"
+            # 使用正確的欄位名稱 name
+            sql = "SELECT staff_id, name FROM staff ORDER BY name"
             cursor.execute(sql)
             return cursor.fetchall()
     finally:
@@ -181,8 +182,8 @@ def create_staff(data):
             # 插入基本資料
             query = """
             INSERT INTO Staff (
-                Staff_Name, Staff_Phone, Staff_Email, Staff_Sex, 
-                Staff_Birthday, Staff_Address, Staff_Store, 
+                name, Staff_Phone, Staff_Email, Staff_Sex,
+                Staff_Birthday, Staff_Address, Staff_Store,
                 Staff_PermissionLevel, Staff_Salary, Staff_JoinDate,
                 Staff_EmergencyContact, Staff_EmergencyPhone,
                 Staff_Note, Staff_Status
@@ -286,8 +287,8 @@ def update_staff(staff_id, data):
                     basic_info["Staff_JoinDate"] = datetime.strptime(basic_info["Staff_JoinDate"], "%Y-%m-%d")
                 
                 query = """
-                UPDATE Staff SET 
-                    Staff_Name = %s,
+                UPDATE Staff SET
+                    name = %s,
                     Staff_Phone = %s,
                     Staff_Email = %s,
                     Staff_Sex = %s,


### PR DESCRIPTION
## Summary
- fix staff insert/update queries to use column `name`
- adjust dropdown query to use `name`
- support new `name` field in AddStaff page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a193fa043483299084db16fdc3f978