### PR TITLE
Handle staff FK inserts and marital status

### DIFF
--- a/client/src/pages/backend/AddStaff.tsx
+++ b/client/src/pages/backend/AddStaff.tsx
@@ -20,22 +20,27 @@ const AddStaff: React.FC = () => {
         name: "",
         gender: "",
         birthday: "",
-        nationality: "", 
-        education: "", 
-        maritalStatus: "", // Figma 是 "婚否"
-        applyPosition: "", 
+        nationality: "",
+        education: "",
+        maritalStatus: "Single", // Figma 是 "婚否"
+        applyPosition: "",
         positionLevel: "", // Figma 是 "入職職位"
-        phone: "", 
+        phone: "",
         idNumber: "",
         address1: "", // 戶籍地
         contactPhone1: "", // 連絡電話 (戶籍地旁)
         address2: "", // 通訊地
         contactPhone2: "", // 連絡電話 (通訊地旁)
 
+        family_information_id: null as number | null,
+        emergency_contact_id: null as number | null,
+        work_experience_id: null as number | null,
+        hiring_information_id: null as number | null,
+
         // 步驟 2: 家庭與學歷
         familyName: "", familyRelation: "", familyAge: "",
         familyJobUnit: "", familyJob: "", familyPhone: "",
-        emergencyName: "", emergencyRelation: "", emergencyAge: "", 
+        emergencyName: "", emergencyRelation: "", emergencyAge: "",
         emergencyJobUnit: "", emergencyJob: "", emergencyPhone: "",
         graduationDegree: "", // 學籍
         graduationSchool: "", // 學校
@@ -44,21 +49,21 @@ const AddStaff: React.FC = () => {
 
         // 步驟 3: 工作經驗與公司內部資料
         workPeriod: "", // 工作總時間
-        companyName: "", 
+        companyName: "",
         deptJob: "", // 部門/職務
         supervisor: "", // 主管名稱
-        workPhone: "", 
+        workPhone: "",
         salary: "", // 月薪金額
         hasOtherJob: "No", // 是否有其他工作 (預設為 'No')
         otherJobUnit: "",
-        
+
         // 公司填寫部分
         probationPeriod: "", // 試用期
         probationTime: "",   // 時間
         probationSalary: "", // 薪資
         officialPeriod: "",  // 正式錄用期 (Figma 有此欄位)
         probationRemark: "", // 備註
-        
+
         licenseApprovedDate: "", // 批准日期
         licenseNotApprovedDate: "", // 不適用日期
     };
@@ -75,31 +80,54 @@ const AddStaff: React.FC = () => {
                 const res = await getStaffDetails(Number(staffId));
                 if (res.success && res.data && res.data.basic_info) {
                     const info = res.data.basic_info;
-                    const family = res.data.family_members?.[0] || {};
-                    const work = res.data.work_experience?.[0] || {};
+                    const family = res.data.family_information || {};
+                    const emergency = res.data.emergency_contact || {};
+                    const work = res.data.work_experience || {};
+                    const hiring = res.data.hiring_information || {};
                     setFormData(prev => ({
                         ...prev,
-                        onboardDate: info.Staff_JoinDate || "",
-                        name: info.Staff_Name || "",
-                        gender: info.Staff_Sex || "",
-                        birthday: info.Staff_Birthday || "",
-                        nationality: info.Staff_Nationality || "",
-                        education: info.Staff_Education || "",
-                        maritalStatus: info.Staff_MaritalStatus || "",
-                        applyPosition: info.Staff_ApplyPosition || "",
-                        positionLevel: info.Staff_PositionLevel || "",
-                        phone: info.Staff_Phone || "",
-                        idNumber: info.Staff_ID_Number || "",
-                        address1: info.Staff_Address || "",
-                        address2: info.Staff_Address || "",
-                        emergencyName: info.Staff_EmergencyContact || "",
-                        emergencyPhone: info.Staff_EmergencyPhone || "",
-                        familyName: family.Family_Name || "",
-                        familyRelation: family.Family_Relation || "",
-                        familyPhone: family.Family_Phone || "",
-                        companyName: work.Work_Company || "",
-                        deptJob: work.Work_Position || "",
-                        probationRemark: work.Work_Description || "",
+                        fillDate: info.fill_date || "",
+                        onboardDate: info.onboard_date || "",
+                        name: info.name || "",
+                        gender: info.gender || "",
+                        nationality: info.nationality || "",
+                        education: info.education || "",
+                        maritalStatus: info.married === 1 ? "Married" : "Single",
+                        applyPosition: info.position || "",
+                        phone: info.phone || "",
+                        idNumber: info.national_id || "",
+                        address1: info.registered_address || "",
+                        address2: info.mailing_address || "",
+                        familyName: family.name || "",
+                        familyRelation: family.relationship || "",
+                        familyAge: family.age ? String(family.age) : "",
+                        familyJobUnit: family.company || "",
+                        familyJob: family.occupation || "",
+                        familyPhone: family.phone || "",
+                        emergencyName: emergency.name || "",
+                        emergencyRelation: emergency.relationship || "",
+                        emergencyAge: emergency.age ? String(emergency.age) : "",
+                        emergencyJobUnit: emergency.company || "",
+                        emergencyJob: emergency.occupation || "",
+                        emergencyPhone: emergency.phone || "",
+                        companyName: work.company_name || "",
+                        deptJob: work.job_title || "",
+                        supervisor: work.supervise_name || "",
+                        workPhone: work.department_telephone || "",
+                        salary: work.salary ? String(work.salary) : "",
+                        hasOtherJob: work.is_still_on_work ? "Yes" : "No",
+                        otherJobUnit: work.working_department || "",
+                        probationPeriod: hiring.probation_period ? String(hiring.probation_period) : "",
+                        probationTime: hiring.duration ? String(hiring.duration) : "",
+                        probationSalary: hiring.salary ? String(hiring.salary) : "",
+                        officialPeriod: hiring.official_employment_date || "",
+                        probationRemark: hiring.note || "",
+                        licenseApprovedDate: hiring.approval_date || "",
+                        licenseNotApprovedDate: hiring.disqualification_date || "",
+                        family_information_id: info.family_information_id || null,
+                        emergency_contact_id: info.emergency_contact_id || null,
+                        work_experience_id: info.work_experience_id || null,
+                        hiring_information_id: info.hiring_information_id || null,
                     }));
                 } else {
                     setError("載入員工資料失敗");
@@ -140,35 +168,81 @@ const AddStaff: React.FC = () => {
         try {
             const payload: any = {
                 basic_info: {
-                    Staff_Name: formData.name,
-                    Staff_Phone: formData.phone,
-                    Staff_Sex: formData.gender,
-                    Staff_ID_Number: formData.idNumber,
-                    Staff_Birthday: formData.birthday || null,
-                    Staff_Address: formData.address2 || formData.address1 || "",
-                    Staff_JoinDate: formData.onboardDate || null,
-                    Staff_EmergencyContact: formData.emergencyName || "",
-                    Staff_EmergencyPhone: formData.emergencyPhone || "",
+                    family_information_id: formData.family_information_id,
+                    emergency_contact_id: formData.emergency_contact_id,
+                    work_experience_id: formData.work_experience_id,
+                    hiring_information_id: formData.hiring_information_id,
+                    name: formData.name,
+                    phone: formData.phone,
+                    gender: formData.gender,
+                    national_id: formData.idNumber,
+                    fill_date: formData.fillDate || null,
+                    onboard_date: formData.onboardDate || null,
+                    nationality: formData.nationality || "",
+                    education: formData.education || "",
+                    married: formData.maritalStatus === "Married" ? 1 : 0,
+                    position: formData.applyPosition || "",
+                    mailing_address: formData.address2 || "",
+                    registered_address: formData.address1 || "",
+                    account: null,
+                    password: null,
+                    store_id: null,
+                    permission: null,
                 },
-                family_members: [],
-                work_experience: [],
             };
 
             if (formData.familyName) {
-                payload.family_members.push({
-                    Family_Name: formData.familyName,
-                    Family_Relation: formData.familyRelation,
-                    Family_Phone: formData.familyPhone,
-                    Family_Address: formData.address1,
-                });
+                payload.family_information = {
+                    name: formData.familyName,
+                    relationship: formData.familyRelation,
+                    age: formData.familyAge ? parseInt(formData.familyAge) : null,
+                    company: formData.familyJobUnit,
+                    occupation: formData.familyJob,
+                    phone: formData.familyPhone,
+                };
+            }
+
+            if (formData.emergencyName) {
+                payload.emergency_contact = {
+                    name: formData.emergencyName,
+                    relationship: formData.emergencyRelation,
+                    age: formData.emergencyAge ? parseInt(formData.emergencyAge) : null,
+                    company: formData.emergencyJobUnit,
+                    occupation: formData.emergencyJob,
+                    phone: formData.emergencyPhone,
+                };
             }
 
             if (formData.companyName) {
-                payload.work_experience.push({
-                    Work_Company: formData.companyName,
-                    Work_Position: formData.deptJob,
-                    Work_Description: formData.probationRemark || "",
-                });
+                payload.work_experience = {
+                    company_name: formData.companyName,
+                    job_title: formData.deptJob,
+                    supervise_name: formData.supervisor,
+                    department_telephone: formData.workPhone,
+                    salary: formData.salary ? parseFloat(formData.salary) : null,
+                    is_still_on_work: formData.hasOtherJob === "Yes" ? 1 : 0,
+                    working_department: formData.otherJobUnit,
+                };
+            }
+
+            if (
+                formData.probationPeriod ||
+                formData.probationTime ||
+                formData.probationSalary ||
+                formData.officialPeriod ||
+                formData.probationRemark ||
+                formData.licenseApprovedDate ||
+                formData.licenseNotApprovedDate
+            ) {
+                payload.hiring_information = {
+                    probation_period: formData.probationPeriod ? parseInt(formData.probationPeriod) : null,
+                    duration: formData.probationTime ? parseInt(formData.probationTime) : null,
+                    salary: formData.probationSalary ? parseFloat(formData.probationSalary) : null,
+                    official_employment_date: formData.officialPeriod || null,
+                    approval_date: formData.licenseApprovedDate || null,
+                    disqualification_date: formData.licenseNotApprovedDate || null,
+                    note: formData.probationRemark || "",
+                };
             }
 
             let res;

--- a/client/src/services/StaffService.ts
+++ b/client/src/services/StaffService.ts
@@ -14,14 +14,21 @@ const isAdmin = (): boolean => {
 
 // 定義員工接口
 export interface Staff {
-  Staff_ID: number;
-  Staff_Name: string;
-  Staff_ID_Number: string;
+  Staff_ID?: number;
+  staff_id?: number;
+  Staff_Name?: string;
+  name?: string;
+  Staff_ID_Number?: string;
+  national_id?: string;
   Staff_Phone?: string;
+  phone?: string;
   Staff_Status?: string;
+  permission?: string;
   Staff_Email?: string;
   Staff_Sex?: string;
+  gender?: string;
   Staff_Store?: string;
+  store_id?: number;
   Staff_PermissionLevel?: string;
   Staff_IdNumber?: string;
 }

--- a/server/app/models/staff_model.py
+++ b/server/app/models/staff_model.py
@@ -56,7 +56,8 @@ def get_all_staff_for_dropdown():
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
-            sql = "SELECT Staff_ID AS staff_id, Staff_Name AS name FROM Staff ORDER BY Staff_Name"
+            # 使用正確的欄位名稱 name
+            sql = "SELECT staff_id, name FROM staff ORDER BY name"
             cursor.execute(sql)
             return cursor.fetchall()
     finally:
@@ -73,7 +74,7 @@ def search_staff(keyword, store_level=None, store_id=None):
                 st.store_name
             FROM staff s
             LEFT JOIN store st ON s.store_id = st.store_id
-            WHERE (s.name LIKE %s OR s.phone LIKE %s OR s.email LIKE %s)
+            WHERE (s.name LIKE %s OR s.phone LIKE %s OR s.account LIKE %s)
             """
             params = [f"%{keyword}%", f"%{keyword}%", f"%{keyword}%"]
             if store_level == '分店':
@@ -114,41 +115,50 @@ def get_staff_details(staff_id):
     connection = connect_to_db()
     result = {
         "basic_info": None,
-        "family_members": [],
-        "work_experience": []
+        "family_information": None,
+        "emergency_contact": None,
+        "work_experience": None,
+        "hiring_information": None
     }
-    
+
     try:
         with connection.cursor() as cursor:
-            # 獲取基本資料
-            query = """
-            SELECT s.*, 
-                   DATE_FORMAT(s.Staff_Birthday, '%Y-%m-%d') as Staff_Birthday,
-                   DATE_FORMAT(s.Staff_JoinDate, '%Y-%m-%d') as Staff_JoinDate
-            FROM Staff s
-            WHERE s.Staff_ID = %s
-            """
+            # 使用新欄位從 staff 表取得基本資料
+            query = "SELECT * FROM staff WHERE staff_id = %s"
             cursor.execute(query, (staff_id,))
             result["basic_info"] = cursor.fetchone()
             
-            # 獲取家庭成員
-            query = """
-            SELECT * FROM Staff_Family 
-            WHERE Staff_ID = %s
-            """
-            cursor.execute(query, (staff_id,))
-            result["family_members"] = cursor.fetchall()
-            
-            # 獲取工作經驗
-            query = """
-            SELECT *, 
-                   DATE_FORMAT(Work_StartDate, '%Y-%m-%d') as Work_StartDate,
-                   DATE_FORMAT(Work_EndDate, '%Y-%m-%d') as Work_EndDate
-            FROM Staff_WorkExperience 
-            WHERE Staff_ID = %s
-            """
-            cursor.execute(query, (staff_id,))
-            result["work_experience"] = cursor.fetchall()
+            # 取得家庭資料
+            if result["basic_info"] and result["basic_info"].get("family_information_id"):
+                cursor.execute(
+                    "SELECT * FROM family_information WHERE family_information_id = %s",
+                    (result["basic_info"]["family_information_id"],)
+                )
+                result["family_information"] = cursor.fetchone()
+
+            # 取得緊急聯絡人資料
+            if result["basic_info"] and result["basic_info"].get("emergency_contact_id"):
+                cursor.execute(
+                    "SELECT * FROM emergency_contact WHERE emergency_contact_id = %s",
+                    (result["basic_info"]["emergency_contact_id"],)
+                )
+                result["emergency_contact"] = cursor.fetchone()
+
+            # 取得工作經驗資料
+            if result["basic_info"] and result["basic_info"].get("work_experience_id"):
+                cursor.execute(
+                    "SELECT *, DATE_FORMAT(start_date, '%Y-%m-%d') AS start_date, DATE_FORMAT(end_date, '%Y-%m-%d') AS end_date FROM work_experience WHERE work_experience_id = %s",
+                    (result["basic_info"]["work_experience_id"],)
+                )
+                result["work_experience"] = cursor.fetchone()
+
+            # 取得錄用資料
+            if result["basic_info"] and result["basic_info"].get("hiring_information_id"):
+                cursor.execute(
+                    "SELECT *, DATE_FORMAT(official_employment_date, '%Y-%m-%d') AS official_employment_date, DATE_FORMAT(approval_date, '%Y-%m-%d') AS approval_date, DATE_FORMAT(disqualification_date, '%Y-%m-%d') AS disqualification_date FROM hiring_information WHERE hiring_information_id = %s",
+                    (result["basic_info"]["hiring_information_id"],)
+                )
+                result["hiring_information"] = cursor.fetchone()
     except Exception as e:
         print(f"獲取員工詳細資料錯誤: {e}")
     finally:
@@ -164,98 +174,179 @@ def create_staff(data):
     
     try:
         with connection.cursor() as cursor:
-            # 1. 新增基本資料
             basic_info = data.get("basic_info", {})
-            
-            # 處理日期格式
-            if "Staff_Birthday" in basic_info and basic_info["Staff_Birthday"]:
-                basic_info["Staff_Birthday"] = datetime.strptime(basic_info["Staff_Birthday"], "%Y-%m-%d")
-            else:
-                basic_info["Staff_Birthday"] = None
-                
-            if "Staff_JoinDate" in basic_info and basic_info["Staff_JoinDate"]:
-                basic_info["Staff_JoinDate"] = datetime.strptime(basic_info["Staff_JoinDate"], "%Y-%m-%d")
-            else:
-                basic_info["Staff_JoinDate"] = datetime.now()
-            
-            # 插入基本資料
-            query = """
-            INSERT INTO Staff (
-                Staff_Name, Staff_Phone, Staff_Email, Staff_Sex, 
-                Staff_Birthday, Staff_Address, Staff_Store, 
-                Staff_PermissionLevel, Staff_Salary, Staff_JoinDate,
-                Staff_EmergencyContact, Staff_EmergencyPhone,
-                Staff_Note, Staff_Status
-            ) VALUES (
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
-            )
-            """
-            cursor.execute(query, (
-                basic_info.get("Staff_Name"),
-                basic_info.get("Staff_Phone"),
-                basic_info.get("Staff_Email"),
-                basic_info.get("Staff_Sex"),
-                basic_info.get("Staff_Birthday"),
-                basic_info.get("Staff_Address"),
-                basic_info.get("Staff_Store"),
-                basic_info.get("Staff_PermissionLevel"),
-                basic_info.get("Staff_Salary"),
-                basic_info.get("Staff_JoinDate"),
-                basic_info.get("Staff_EmergencyContact"),
-                basic_info.get("Staff_EmergencyPhone"),
-                basic_info.get("Staff_Note"),
-                basic_info.get("Staff_Status", "在職")
-            ))
-            
-            # 獲取新增員工的ID
-            staff_id = connection.insert_id()
-            
-            # 2. 新增家庭成員
-            family_members = data.get("family_members", [])
-            if family_members and len(family_members) > 0:
-                for member in family_members:
-                    query = """
-                    INSERT INTO Staff_Family (
-                        Staff_ID, Family_Name, Family_Relation, 
-                        Family_Phone, Family_Address
-                    ) VALUES (%s, %s, %s, %s, %s)
+            family_info = data.get("family_information")
+            emergency_info = data.get("emergency_contact")
+            work_info = data.get("work_experience")
+            hiring_info = data.get("hiring_information")
+
+            # 先寫入各個外鍵表格並取得 ID
+            family_id = None
+            if family_info:
+                cursor.execute(
+                    "INSERT INTO family_information (name, relationship, age, company, occupation, phone) VALUES (%s, %s, %s, %s, %s, %s)",
+                    (
+                        family_info.get("name"),
+                        family_info.get("relationship"),
+                        family_info.get("age"),
+                        family_info.get("company"),
+                        family_info.get("occupation"),
+                        family_info.get("phone"),
+                    ),
+                )
+                family_id = connection.insert_id()
+
+            emergency_id = None
+            if emergency_info:
+                cursor.execute(
+                    "INSERT INTO emergency_contact (name, relationship, age, company, occupation, phone) VALUES (%s, %s, %s, %s, %s, %s)",
+                    (
+                        emergency_info.get("name"),
+                        emergency_info.get("relationship"),
+                        emergency_info.get("age"),
+                        emergency_info.get("company"),
+                        emergency_info.get("occupation"),
+                        emergency_info.get("phone"),
+                    ),
+                )
+                emergency_id = connection.insert_id()
+
+            work_id = None
+            if work_info:
+                start_date = (
+                    datetime.strptime(work_info.get("start_date"), "%Y-%m-%d")
+                    if work_info.get("start_date")
+                    else None
+                )
+                end_date = (
+                    datetime.strptime(work_info.get("end_date"), "%Y-%m-%d")
+                    if work_info.get("end_date")
+                    else None
+                )
+                cursor.execute(
                     """
-                    cursor.execute(query, (
-                        staff_id,
-                        member.get("Family_Name"),
-                        member.get("Family_Relation"),
-                        member.get("Family_Phone"),
-                        member.get("Family_Address")
-                    ))
-            
-            # 3. 新增工作經驗
-            work_experience = data.get("work_experience", [])
-            if work_experience and len(work_experience) > 0:
-                for experience in work_experience:
-                    # 處理日期格式
-                    start_date = None
-                    if "Work_StartDate" in experience and experience["Work_StartDate"]:
-                        start_date = datetime.strptime(experience["Work_StartDate"], "%Y-%m-%d")
-                    
-                    end_date = None
-                    if "Work_EndDate" in experience and experience["Work_EndDate"]:
-                        end_date = datetime.strptime(experience["Work_EndDate"], "%Y-%m-%d")
-                    
-                    query = """
-                    INSERT INTO Staff_WorkExperience (
-                        Staff_ID, Work_Company, Work_Position, 
-                        Work_StartDate, Work_EndDate, Work_Description
-                    ) VALUES (%s, %s, %s, %s, %s, %s)
-                    """
-                    cursor.execute(query, (
-                        staff_id,
-                        experience.get("Work_Company"),
-                        experience.get("Work_Position"),
+                    INSERT INTO work_experience (
+                        start_date, end_date, company_name, department, job_title,
+                        supervise_name, department_telephone, salary, is_still_on_work, working_department
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
                         start_date,
                         end_date,
-                        experience.get("Work_Description")
-                    ))
-            
+                        work_info.get("company_name"),
+                        work_info.get("department"),
+                        work_info.get("job_title"),
+                        work_info.get("supervise_name"),
+                        work_info.get("department_telephone"),
+                        work_info.get("salary"),
+                        work_info.get("is_still_on_work"),
+                        work_info.get("working_department"),
+                    ),
+                )
+                work_id = connection.insert_id()
+
+            hiring_id = None
+            if hiring_info:
+                official_date = (
+                    datetime.strptime(hiring_info.get("official_employment_date"), "%Y-%m-%d")
+                    if hiring_info.get("official_employment_date")
+                    else None
+                )
+                approval_date = (
+                    datetime.strptime(hiring_info.get("approval_date"), "%Y-%m-%d")
+                    if hiring_info.get("approval_date")
+                    else None
+                )
+                disqualification_date = (
+                    datetime.strptime(hiring_info.get("disqualification_date"), "%Y-%m-%d")
+                    if hiring_info.get("disqualification_date")
+                    else None
+                )
+                cursor.execute(
+                    """
+                    INSERT INTO hiring_information (
+                        probation_period, duration, salary, official_employment_date,
+                        approval_date, disqualification_date, note
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        hiring_info.get("probation_period"),
+                        hiring_info.get("duration"),
+                        hiring_info.get("salary"),
+                        official_date,
+                        approval_date,
+                        disqualification_date,
+                        hiring_info.get("note"),
+                    ),
+                )
+                hiring_id = connection.insert_id()
+
+            # 處理 staff 表日期與 married 值
+            if basic_info.get("fill_date"):
+                basic_info["fill_date"] = datetime.strptime(
+                    basic_info["fill_date"], "%Y-%m-%d"
+                )
+            else:
+                basic_info["fill_date"] = None
+
+            if basic_info.get("onboard_date"):
+                basic_info["onboard_date"] = datetime.strptime(
+                    basic_info["onboard_date"], "%Y-%m-%d"
+                )
+            else:
+                basic_info["onboard_date"] = None
+
+            married = basic_info.get("married")
+            if isinstance(married, str):
+                married_str = married.strip().lower()
+                married = 1 if married_str in ["1", "married", "yes", "true", "已婚"] else 0
+            basic_info["married"] = married
+
+            if not basic_info.get("account"):
+                basic_info["account"] = None
+            if not basic_info.get("password"):
+                basic_info["password"] = None
+            if basic_info.get("store_id") is None:
+                basic_info["store_id"] = None
+            if not basic_info.get("permission"):
+                basic_info["permission"] = None
+
+            cursor.execute(
+                """
+                INSERT INTO staff (
+                    family_information_id, emergency_contact_id, work_experience_id,
+                    hiring_information_id, name, gender, fill_date, onboard_date,
+                    nationality, education, married, position, phone, national_id,
+                    mailing_address, registered_address, account, password, store_id,
+                    permission
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    family_id,
+                    emergency_id,
+                    work_id,
+                    hiring_id,
+                    basic_info.get("name"),
+                    basic_info.get("gender"),
+                    basic_info.get("fill_date"),
+                    basic_info.get("onboard_date"),
+                    basic_info.get("nationality"),
+                    basic_info.get("education"),
+                    basic_info.get("married"),
+                    basic_info.get("position"),
+                    basic_info.get("phone"),
+                    basic_info.get("national_id"),
+                    basic_info.get("mailing_address"),
+                    basic_info.get("registered_address"),
+                    basic_info.get("account"),
+                    basic_info.get("password"),
+                    basic_info.get("store_id"),
+                    basic_info.get("permission"),
+                ),
+            )
+
+            staff_id = connection.insert_id()
+
             connection.commit()
     except Exception as e:
         if connection:
@@ -275,102 +366,264 @@ def update_staff(staff_id, data):
     
     try:
         with connection.cursor() as cursor:
-            # 1. 更新基本資料
             basic_info = data.get("basic_info", {})
-            if basic_info:
-                # 處理日期格式
-                if "Staff_Birthday" in basic_info and basic_info["Staff_Birthday"]:
-                    basic_info["Staff_Birthday"] = datetime.strptime(basic_info["Staff_Birthday"], "%Y-%m-%d")
-                
-                if "Staff_JoinDate" in basic_info and basic_info["Staff_JoinDate"]:
-                    basic_info["Staff_JoinDate"] = datetime.strptime(basic_info["Staff_JoinDate"], "%Y-%m-%d")
-                
-                query = """
-                UPDATE Staff SET 
-                    Staff_Name = %s,
-                    Staff_Phone = %s,
-                    Staff_Email = %s,
-                    Staff_Sex = %s,
-                    Staff_Birthday = %s,
-                    Staff_Address = %s,
-                    Staff_Store = %s,
-                    Staff_PermissionLevel = %s,
-                    Staff_Salary = %s,
-                    Staff_JoinDate = %s,
-                    Staff_EmergencyContact = %s,
-                    Staff_EmergencyPhone = %s,
-                    Staff_Note = %s,
-                    Staff_Status = %s
-                WHERE Staff_ID = %s
+            family_info = data.get("family_information")
+            emergency_info = data.get("emergency_contact")
+            work_info = data.get("work_experience")
+            hiring_info = data.get("hiring_information")
+
+            cursor.execute(
+                "SELECT account, password, store_id, permission FROM staff WHERE staff_id=%s",
+                (staff_id,),
+            )
+            existing = cursor.fetchone() or {}
+            if not basic_info.get("account"):
+                basic_info["account"] = existing.get("account")
+            if not basic_info.get("password"):
+                basic_info["password"] = existing.get("password")
+            if basic_info.get("store_id") is None:
+                basic_info["store_id"] = existing.get("store_id")
+            if not basic_info.get("permission"):
+                basic_info["permission"] = existing.get("permission")
+
+            family_id = basic_info.get("family_information_id")
+            if family_info:
+                if family_id:
+                    cursor.execute(
+                        "UPDATE family_information SET name=%s, relationship=%s, age=%s, company=%s, occupation=%s, phone=%s WHERE family_information_id=%s",
+                        (
+                            family_info.get("name"),
+                            family_info.get("relationship"),
+                            family_info.get("age"),
+                            family_info.get("company"),
+                            family_info.get("occupation"),
+                            family_info.get("phone"),
+                            family_id,
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        "INSERT INTO family_information (name, relationship, age, company, occupation, phone) VALUES (%s,%s,%s,%s,%s,%s)",
+                        (
+                            family_info.get("name"),
+                            family_info.get("relationship"),
+                            family_info.get("age"),
+                            family_info.get("company"),
+                            family_info.get("occupation"),
+                            family_info.get("phone"),
+                        ),
+                    )
+                    family_id = connection.insert_id()
+
+            emergency_id = basic_info.get("emergency_contact_id")
+            if emergency_info:
+                if emergency_id:
+                    cursor.execute(
+                        "UPDATE emergency_contact SET name=%s, relationship=%s, age=%s, company=%s, occupation=%s, phone=%s WHERE emergency_contact_id=%s",
+                        (
+                            emergency_info.get("name"),
+                            emergency_info.get("relationship"),
+                            emergency_info.get("age"),
+                            emergency_info.get("company"),
+                            emergency_info.get("occupation"),
+                            emergency_info.get("phone"),
+                            emergency_id,
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        "INSERT INTO emergency_contact (name, relationship, age, company, occupation, phone) VALUES (%s,%s,%s,%s,%s,%s)",
+                        (
+                            emergency_info.get("name"),
+                            emergency_info.get("relationship"),
+                            emergency_info.get("age"),
+                            emergency_info.get("company"),
+                            emergency_info.get("occupation"),
+                            emergency_info.get("phone"),
+                        ),
+                    )
+                    emergency_id = connection.insert_id()
+
+            work_id = basic_info.get("work_experience_id")
+            if work_info:
+                start_date = (
+                    datetime.strptime(work_info.get("start_date"), "%Y-%m-%d")
+                    if work_info.get("start_date")
+                    else None
+                )
+                end_date = (
+                    datetime.strptime(work_info.get("end_date"), "%Y-%m-%d")
+                    if work_info.get("end_date")
+                    else None
+                )
+                if work_id:
+                    cursor.execute(
+                        """
+                        UPDATE work_experience SET start_date=%s, end_date=%s, company_name=%s, department=%s, job_title=%s,
+                            supervise_name=%s, department_telephone=%s, salary=%s, is_still_on_work=%s, working_department=%s
+                        WHERE work_experience_id=%s
+                        """,
+                        (
+                            start_date,
+                            end_date,
+                            work_info.get("company_name"),
+                            work_info.get("department"),
+                            work_info.get("job_title"),
+                            work_info.get("supervise_name"),
+                            work_info.get("department_telephone"),
+                            work_info.get("salary"),
+                            work_info.get("is_still_on_work"),
+                            work_info.get("working_department"),
+                            work_id,
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        INSERT INTO work_experience (
+                            start_date, end_date, company_name, department, job_title,
+                            supervise_name, department_telephone, salary, is_still_on_work, working_department
+                        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                        """,
+                        (
+                            start_date,
+                            end_date,
+                            work_info.get("company_name"),
+                            work_info.get("department"),
+                            work_info.get("job_title"),
+                            work_info.get("supervise_name"),
+                            work_info.get("department_telephone"),
+                            work_info.get("salary"),
+                            work_info.get("is_still_on_work"),
+                            work_info.get("working_department"),
+                        ),
+                    )
+                    work_id = connection.insert_id()
+
+            hiring_id = basic_info.get("hiring_information_id")
+            if hiring_info:
+                official_date = (
+                    datetime.strptime(hiring_info.get("official_employment_date"), "%Y-%m-%d")
+                    if hiring_info.get("official_employment_date")
+                    else None
+                )
+                approval_date = (
+                    datetime.strptime(hiring_info.get("approval_date"), "%Y-%m-%d")
+                    if hiring_info.get("approval_date")
+                    else None
+                )
+                disqualification_date = (
+                    datetime.strptime(hiring_info.get("disqualification_date"), "%Y-%m-%d")
+                    if hiring_info.get("disqualification_date")
+                    else None
+                )
+                if hiring_id:
+                    cursor.execute(
+                        """
+                        UPDATE hiring_information SET probation_period=%s, duration=%s, salary=%s, official_employment_date=%s,
+                            approval_date=%s, disqualification_date=%s, note=%s WHERE hiring_information_id=%s
+                        """,
+                        (
+                            hiring_info.get("probation_period"),
+                            hiring_info.get("duration"),
+                            hiring_info.get("salary"),
+                            official_date,
+                            approval_date,
+                            disqualification_date,
+                            hiring_info.get("note"),
+                            hiring_id,
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        """
+                        INSERT INTO hiring_information (
+                            probation_period, duration, salary, official_employment_date,
+                            approval_date, disqualification_date, note
+                        ) VALUES (%s,%s,%s,%s,%s,%s,%s)
+                        """,
+                        (
+                            hiring_info.get("probation_period"),
+                            hiring_info.get("duration"),
+                            hiring_info.get("salary"),
+                            official_date,
+                            approval_date,
+                            disqualification_date,
+                            hiring_info.get("note"),
+                        ),
+                    )
+                    hiring_id = connection.insert_id()
+
+            if basic_info.get("fill_date"):
+                basic_info["fill_date"] = datetime.strptime(
+                    basic_info["fill_date"], "%Y-%m-%d"
+                )
+            else:
+                basic_info["fill_date"] = None
+
+            if basic_info.get("onboard_date"):
+                basic_info["onboard_date"] = datetime.strptime(
+                    basic_info["onboard_date"], "%Y-%m-%d"
+                )
+            else:
+                basic_info["onboard_date"] = None
+
+            married = basic_info.get("married")
+            if isinstance(married, str):
+                married_str = married.strip().lower()
+                married = 1 if married_str in ["1", "married", "yes", "true", "已婚"] else 0
+            basic_info["married"] = married
+
+            cursor.execute(
                 """
-                cursor.execute(query, (
-                    basic_info.get("Staff_Name"),
-                    basic_info.get("Staff_Phone"),
-                    basic_info.get("Staff_Email"),
-                    basic_info.get("Staff_Sex"),
-                    basic_info.get("Staff_Birthday"),
-                    basic_info.get("Staff_Address"),
-                    basic_info.get("Staff_Store"),
-                    basic_info.get("Staff_PermissionLevel"),
-                    basic_info.get("Staff_Salary"),
-                    basic_info.get("Staff_JoinDate"),
-                    basic_info.get("Staff_EmergencyContact"),
-                    basic_info.get("Staff_EmergencyPhone"),
-                    basic_info.get("Staff_Note"),
-                    basic_info.get("Staff_Status"),
-                    staff_id
-                ))
-            
-            # 2. 更新家庭成員 - 先刪除原有記錄，再新增新記錄
-            family_members = data.get("family_members", [])
-            cursor.execute("DELETE FROM Staff_Family WHERE Staff_ID = %s", (staff_id,))
-            
-            if family_members and len(family_members) > 0:
-                for member in family_members:
-                    query = """
-                    INSERT INTO Staff_Family (
-                        Staff_ID, Family_Name, Family_Relation, 
-                        Family_Phone, Family_Address
-                    ) VALUES (%s, %s, %s, %s, %s)
-                    """
-                    cursor.execute(query, (
-                        staff_id,
-                        member.get("Family_Name"),
-                        member.get("Family_Relation"),
-                        member.get("Family_Phone"),
-                        member.get("Family_Address")
-                    ))
-            
-            # 3. 更新工作經驗 - 先刪除原有記錄，再新增新記錄
-            work_experience = data.get("work_experience", [])
-            cursor.execute("DELETE FROM Staff_WorkExperience WHERE Staff_ID = %s", (staff_id,))
-            
-            if work_experience and len(work_experience) > 0:
-                for experience in work_experience:
-                    # 處理日期格式
-                    start_date = None
-                    if "Work_StartDate" in experience and experience["Work_StartDate"]:
-                        start_date = datetime.strptime(experience["Work_StartDate"], "%Y-%m-%d")
-                    
-                    end_date = None
-                    if "Work_EndDate" in experience and experience["Work_EndDate"]:
-                        end_date = datetime.strptime(experience["Work_EndDate"], "%Y-%m-%d")
-                    
-                    query = """
-                    INSERT INTO Staff_WorkExperience (
-                        Staff_ID, Work_Company, Work_Position, 
-                        Work_StartDate, Work_EndDate, Work_Description
-                    ) VALUES (%s, %s, %s, %s, %s, %s)
-                    """
-                    cursor.execute(query, (
-                        staff_id,
-                        experience.get("Work_Company"),
-                        experience.get("Work_Position"),
-                        start_date,
-                        end_date,
-                        experience.get("Work_Description")
-                    ))
-            
+                UPDATE staff SET
+                    family_information_id=%s,
+                    emergency_contact_id=%s,
+                    work_experience_id=%s,
+                    hiring_information_id=%s,
+                    name=%s,
+                    gender=%s,
+                    fill_date=%s,
+                    onboard_date=%s,
+                    nationality=%s,
+                    education=%s,
+                    married=%s,
+                    position=%s,
+                    phone=%s,
+                    national_id=%s,
+                    mailing_address=%s,
+                    registered_address=%s,
+                    account=%s,
+                    password=%s,
+                    store_id=%s,
+                    permission=%s
+                WHERE staff_id=%s
+                """,
+                (
+                    family_id,
+                    emergency_id,
+                    work_id,
+                    hiring_id,
+                    basic_info.get("name"),
+                    basic_info.get("gender"),
+                    basic_info.get("fill_date"),
+                    basic_info.get("onboard_date"),
+                    basic_info.get("nationality"),
+                    basic_info.get("education"),
+                    basic_info.get("married"),
+                    basic_info.get("position"),
+                    basic_info.get("phone"),
+                    basic_info.get("national_id"),
+                    basic_info.get("mailing_address"),
+                    basic_info.get("registered_address"),
+                    basic_info.get("account"),
+                    basic_info.get("password"),
+                    basic_info.get("store_id"),
+                    basic_info.get("permission"),
+                    staff_id,
+                ),
+            )
+
             connection.commit()
             success = True
     except Exception as e:
@@ -393,19 +646,38 @@ def delete_staff(staff_id):
             # 0. 刪除對應的登入帳號資料 (若存在)
             cursor.execute("DELETE FROM store_account WHERE account = %s", (str(staff_id),))
 
-            # 1. 刪除家庭成員
-            try:
-                cursor.execute("DELETE FROM Staff_Family WHERE Staff_ID = %s", (staff_id,))
-            except pymysql.err.ProgrammingError as e:
-                # 資料表不存在時略過
-                if e.args[0] != 1146:
-                    raise
+            # 1. 取得外鍵 ID
+            cursor.execute(
+                "SELECT family_information_id, emergency_contact_id, work_experience_id, hiring_information_id FROM staff WHERE staff_id = %s",
+                (staff_id,),
+            )
+            fk_ids = cursor.fetchone()
 
-            # 2. 刪除工作經驗
-            cursor.execute("DELETE FROM Staff_WorkExperience WHERE Staff_ID = %s", (staff_id,))
+            # 2. 刪除基本資料
+            cursor.execute("DELETE FROM staff WHERE staff_id = %s", (staff_id,))
 
-            # 3. 刪除基本資料
-            cursor.execute("DELETE FROM Staff WHERE Staff_ID = %s", (staff_id,))
+            # 3. 刪除相關表格資料
+            if fk_ids:
+                if fk_ids.get("family_information_id"):
+                    cursor.execute(
+                        "DELETE FROM family_information WHERE family_information_id = %s",
+                        (fk_ids["family_information_id"],),
+                    )
+                if fk_ids.get("emergency_contact_id"):
+                    cursor.execute(
+                        "DELETE FROM emergency_contact WHERE emergency_contact_id = %s",
+                        (fk_ids["emergency_contact_id"],),
+                    )
+                if fk_ids.get("work_experience_id"):
+                    cursor.execute(
+                        "DELETE FROM work_experience WHERE work_experience_id = %s",
+                        (fk_ids["work_experience_id"],),
+                    )
+                if fk_ids.get("hiring_information_id"):
+                    cursor.execute(
+                        "DELETE FROM hiring_information WHERE hiring_information_id = %s",
+                        (fk_ids["hiring_information_id"],),
+                    )
             
             connection.commit()
             success = True
@@ -427,12 +699,12 @@ def get_store_list():
     try:
         with connection.cursor() as cursor:
             query = """
-            SELECT DISTINCT Staff_Store FROM Staff 
-            WHERE Staff_Store IS NOT NULL AND Staff_Store != ''
+            SELECT DISTINCT store_id FROM staff
+            WHERE store_id IS NOT NULL
             """
             cursor.execute(query)
             stores = cursor.fetchall()
-            store_list = [store["Staff_Store"] for store in stores]
+            store_list = [store["store_id"] for store in stores]
     except Exception as e:
         print(f"獲取分店列表錯誤: {e}")
     finally:


### PR DESCRIPTION
## Summary
- send null account, password, permission from AddStaff form to avoid duplicate key errors
- default blank account details to NULL and retain existing account fields when updating staff
- treat Chinese "已婚" as married when saving staff

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a193fa043483299084db16fdc3f978