### PR TITLE
feat: add store-specific member code generation

### DIFF
--- a/client/src/services/MemberService.ts
+++ b/client/src/services/MemberService.ts
@@ -281,7 +281,7 @@ export const checkMemberCodeExists = async (memberCode: string): Promise<boolean
  */
 export const getNextMemberCode = async (): Promise<ApiResponse<string>> => {
     try {
-        const response = await axios.get(`${API_URL}/next-code`);
+        const response = await authAxios.get('/next-code');
         return response.data;
     } catch (error: any) {
         console.error("獲取下一個會員編號失敗:", error);

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -265,7 +265,8 @@ def check_member_code_route(member_code):
 def get_next_code_route():
     """提供下一個可用的會員編號"""
     try:
-        result = get_next_member_code()
+        user_store_id = request.store_id
+        result = get_next_member_code(user_store_id)
         if result.get("success"):
             return jsonify(result)
         else:


### PR DESCRIPTION
## Summary
- generate next member code based on store-specific patterns
- return next code using authenticated user's store id
- ensure frontend service sends auth headers when requesting next member code

## Testing
- `python -m py_compile server/app/models/member_model.py server/app/routes/member.py`
- `npm run build` (failed: Could not resolve entry module "index.html" / TypeScript errors)
- `pytest` (failed: ModuleNotFoundError: No module named 'requests')


------
https://chatgpt.com/codex/tasks/task_e_68aaf6c506608329999c82eb9652f3f7