### PR TITLE
feat: support therapy bundles in sales

### DIFF
--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -92,6 +92,7 @@ const AddTherapySell: React.FC = () => {
         setTherapyPackages([
           {
             therapy_id: editSale.therapy_id,
+            type: 'therapy',
             TherapyName: editSale.PackageName,
             TherapyContent: editSale.PackageName,
             TherapyPrice: editSale.Price || 0,
@@ -220,7 +221,8 @@ const AddTherapySell: React.FC = () => {
         }
         const payload = {
           memberId: Number(formData.memberId),
-          therapy_id: pkg.therapy_id,
+          therapy_id: pkg.type === 'bundle' ? undefined : pkg.therapy_id,
+          bundle_id: pkg.type === 'bundle' ? pkg.bundle_id : undefined,
           staffId: Number(formData.staffId),
           purchaseDate: formData.date,
           amount: Number(pkg.userSessions),
@@ -244,7 +246,8 @@ const AddTherapySell: React.FC = () => {
           }
           return {
             memberId: Number(formData.memberId),
-            therapy_id: pkg.therapy_id,
+            therapy_id: pkg.type === 'bundle' ? undefined : pkg.therapy_id,
+            bundle_id: pkg.type === 'bundle' ? pkg.bundle_id : undefined,
             staffId: Number(formData.staffId),
             purchaseDate: formData.date,
             amount: Number(pkg.userSessions),

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -17,7 +17,9 @@ export interface StaffMember {
 }
 
 export interface TherapyPackage { // 這是基礎的 TherapyPackage 型別
-  therapy_id: number;
+  therapy_id?: number; // 個別療程 ID
+  bundle_id?: number;  // 若為組合則使用 bundle_id
+  type?: 'therapy' | 'bundle';
   TherapyCode: string;
   TherapyName?: string;
   TherapyContent: string;
@@ -44,8 +46,9 @@ export interface AddTherapySellPayload {
   storeId?: number;
   staffId: number;
   purchaseDate: string;
-  therapy_id?: number | null; // 療程套餐的實際 ID
-  amount: number;           // 對應堂數
+  therapy_id?: number | null; // 單一療程的 ID
+  bundle_id?: number | null;  // 若為組合則帶入 bundle_id
+  amount: number;           // 對應堂數或組合數量
   paymentMethod: string;    // 英文 ENUM 值
   saleCategory?: string;   // 英文 ENUM 值
   transferCode?: string;
@@ -77,10 +80,10 @@ export interface TherapySellRow {
 
 // 新增並導出 SelectedTherapyPackageUIData
 export interface SelectedTherapyPackageUIData extends TherapyPackage { // 直接繼承 TherapyPackage
-  userSessions: string; 
-  itemOriginalTotal?: number; 
-  calculatedItemDiscount?: number; 
-  calculatedItemFinalPrice?: number; 
+  userSessions: string; // 單堂數量或組合數量
+  itemOriginalTotal?: number;
+  calculatedItemDiscount?: number;
+  calculatedItemFinalPrice?: number;
 }
 // API 回應的通用結構
 interface ApiResponse<T> {


### PR DESCRIPTION
## Summary
- allow therapy sales API to expand bundle items into individual therapy records
- expose bundle metadata through therapy selling services and components
- integrate therapy bundles into package selection and sale submission flow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; No module named 'requests')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab1e54e3148329a4d4c42aab675eb5