### PR TITLE
Display bundle contents on separate lines in product selection

### DIFF
--- a/client/src/pages/product/ProductSelection.tsx
+++ b/client/src/pages/product/ProductSelection.tsx
@@ -283,7 +283,11 @@ const ProductSelection: React.FC = () => {
                 </Button>
               </td>
               <td className="align-middle">
-                {item.type === 'bundle' ? item.content : '-'}
+                {item.type === 'bundle' && item.content
+                  ? item.content.split(',').map((contentItem, idx) => (
+                      <div key={idx}>{contentItem}</div>
+                    ))
+                  : '-'}
               </td>
               <td className="align-middle text-end fw-bold">
                 {item.type === 'product' && item.stock_quantity !== undefined ? item.stock_quantity : '-'}


### PR DESCRIPTION
## Summary
- Split bundle contents by commas into separate lines on the product selection page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ab213e76f88329b6ca9b358fce2e55