### PR TITLE
Fix store-aware sales orders and handle missing therapy_id

### DIFF
--- a/server/app/models/sales_order_model.py
+++ b/server/app/models/sales_order_model.py
@@ -59,9 +59,21 @@ def create_sales_order(order_data: dict):
                 )
             """
             for item in items_data:
-                item['order_id'] = order_id
-                # item_values_dict 的鍵名與 item_query 的佔位符匹配，這部分邏輯是正確的
-                cursor.execute(item_query, item)
+                # 確保所有必要的鍵都存在，即使其值為 None
+                item_for_sql = {
+                    "order_id": order_id,
+                    "product_id": item.get("product_id"),
+                    "therapy_id": item.get("therapy_id"),
+                    "item_description": item.get("item_description"),
+                    "item_type": item.get("item_type"),
+                    "unit": item.get("unit"),
+                    "unit_price": item.get("unit_price"),
+                    "quantity": item.get("quantity"),
+                    "subtotal": item.get("subtotal"),
+                    "category": item.get("category"),
+                    "note": item.get("note")
+                }
+                cursor.execute(item_query, item_for_sql)
         
         conn.commit()
         return {"success": True, "order_id": order_id, "message": "銷售單新增成功"}

--- a/server/app/routes/sales_order_routes.py
+++ b/server/app/routes/sales_order_routes.py
@@ -21,7 +21,11 @@ def add_sales_order_route():
             now = datetime.now()
             return f"{prefix}{now.strftime('%Y%m%d%H%M%S%f')[:-3]}"
 
-        order_data['order_number'] = order_data.get('order_number') or generate_order_number()
+        # 根據 store_id 決定銷售單號前綴
+        prefix_map = {1: "TP", 2: "TC"}
+        store_id = order_data.get("store_id")
+        prefix = prefix_map.get(store_id, "TP")
+        order_data['order_number'] = order_data.get('order_number') or generate_order_number(prefix)
 
         result = create_sales_order(order_data)
         return jsonify(result), 201


### PR DESCRIPTION
## Summary
- Ensure each sales order item includes required keys to avoid therapy_id KeyError
- Generate order numbers based on store and use logged-in store_id when submitting orders
- Populate store_id and items consistently on the front-end

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd server && pytest` *(fails: pyenv: version `3.11.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab22e11cc08329bc11a73bf404cc10