### PR TITLE
Fix sales order editing and printing integration

### DIFF
--- a/client/src/pages/finance/SalesOrderList.tsx
+++ b/client/src/pages/finance/SalesOrderList.tsx
@@ -105,7 +105,7 @@ const SalesOrderList: React.FC = () => {
                 <Row className="justify-content-end g-2">
                     <Col xs="auto"><Button variant="info" className="text-white" disabled={true}>報表匯出</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={handleDelete} disabled={loading || selectedIds.length === 0}>刪除</Button></Col>
-                    <Col xs="auto"><Button variant="info" className="text-white" onClick={() => navigate(`/finance/sales/edit/${selectedIds[0]}`)} disabled={loading || selectedIds.length !== 1}>修改</Button></Col>
+                    <Col xs="auto"><Button variant="info" className="text-white" onClick={() => navigate(`/finance/sales/add?order_id=${selectedIds[0]}`)} disabled={loading || selectedIds.length !== 1}>修改</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={() => navigate("/finance")}>確認</Button></Col>
                 </Row>
             </Container>

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -291,7 +291,9 @@ const AddProductSell: React.FC = () => {
         saleUnit: selectedStore,
         saleCategory,
         buyer: memberName,
+        buyerId: memberId,
         salesperson: staffName,
+        staffId: selectedStaffId,
       };
       localStorage.setItem('preSaleData', JSON.stringify(preSaleData));
       navigate('/finance/sales/add');

--- a/client/src/services/SalesOrderService.ts
+++ b/client/src/services/SalesOrderService.ts
@@ -86,3 +86,27 @@ export const deleteSalesOrders = async (ids: number[]): Promise<{success: boolea
         throw new Error(error.response?.data?.error || "刪除銷售單時發生錯誤");
     }
 };
+export interface SalesOrderDetail {
+    order_id: number;
+    order_number: string;
+    order_date: string;
+    member_id: number | null;
+    staff_id: number | null;
+    store_id: number;
+    subtotal: number;
+    total_discount: number;
+    grand_total: number;
+    sale_category?: string;
+    note?: string;
+    items: SalesOrderItemData[];
+}
+
+export const getSalesOrderById = async (orderId: number): Promise<SalesOrderDetail> => {
+    try {
+        const response = await axios.get(`${API_URL}/${orderId}`);
+        return response.data;
+    } catch (error: any) {
+        console.error(`獲取銷售單 ${orderId} 失敗:`, error.response?.data || error.message);
+        throw new Error(error.response?.data?.error || '無法獲取銷售單');
+    }
+};

--- a/server/app/models/sales_order_model.py
+++ b/server/app/models/sales_order_model.py
@@ -158,3 +158,24 @@ def delete_sales_orders_by_ids(order_ids: list[int]):
         return {"success": False, "error": str(e)}
     finally:
         if conn: conn.close()
+
+def get_sales_order_by_id(order_id: int):
+    """取得單一銷售單與其項目"""
+    conn = None
+    try:
+        conn = connect_to_db()
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT * FROM sales_orders WHERE order_id = %s", (order_id,))
+            order = cursor.fetchone()
+            if not order:
+                return None
+            cursor.execute("SELECT * FROM sales_order_items WHERE order_id = %s", (order_id,))
+            items = cursor.fetchall()
+            order['items'] = items
+            return order
+    except Exception as e:
+        print(f"Error getting sales order {order_id}: {e}")
+        return None
+    finally:
+        if conn:
+            conn.close()

--- a/server/app/routes/sales_order_routes.py
+++ b/server/app/routes/sales_order_routes.py
@@ -3,7 +3,8 @@ from flask import Blueprint, request, jsonify
 from app.models.sales_order_model import (
     create_sales_order,
     get_all_sales_orders,
-    delete_sales_orders_by_ids
+    delete_sales_orders_by_ids,
+    get_sales_order_by_id
 )
 from datetime import datetime
 import traceback
@@ -65,3 +66,14 @@ def delete_sales_orders_route():
     except Exception as e:
         print(f"Error in delete_sales_orders_route: {e}")
         return jsonify({"error": "伺服器內部錯誤"}), 500
+
+@sales_order_bp.route('/<int:order_id>', methods=['GET'])
+def get_sales_order_detail_route(order_id):
+    try:
+        order = get_sales_order_by_id(order_id)
+        if not order:
+            return jsonify({'error': '找不到銷售單'}), 404
+        return jsonify(order), 200
+    except Exception as e:
+        print(f"Error in get_sales_order_detail_route: {e}")
+        return jsonify({'error': '伺服器內部錯誤'}), 500


### PR DESCRIPTION
## Summary
- Allow editing sales orders by fetching order details and loading dropdowns for members and staff
- Include member and staff IDs when printing product or therapy sells and redirect to sales order form
- Add API to fetch individual sales orders

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd server && pytest` *(fails: pyenv version `3.11.3` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab25abe08c832986b28889fe9162c3