### PR TITLE
fix: correct store prefixes for sales orders

### DIFF
--- a/client/src/pages/finance/AddSalesOrder.tsx
+++ b/client/src/pages/finance/AddSalesOrder.tsx
@@ -63,6 +63,12 @@ const AddSalesOrder: React.FC = () => {
         switch (id) {
             case '2':
                 return 'TC';
+            case '3':
+                return 'TP';
+            case '4':
+                return 'PH';
+            case '5':
+                return 'TY';
             case '1':
             default:
                 return 'TP';

--- a/server/app/routes/sales_order_routes.py
+++ b/server/app/routes/sales_order_routes.py
@@ -23,7 +23,7 @@ def add_sales_order_route():
             return f"{prefix}{now.strftime('%Y%m%d%H%M%S%f')[:-3]}"
 
         # 根據 store_id 決定銷售單號前綴
-        prefix_map = {1: "TP", 2: "TC"}
+        prefix_map = {1: "TP", 2: "TC", 3: "TP", 4: "PH", 5: "TY"}
         store_id = order_data.get("store_id")
         prefix = prefix_map.get(store_id, "TP")
         order_data['order_number'] = order_data.get('order_number') or generate_order_number(prefix)


### PR DESCRIPTION
## Summary
- map Taichung, Taipei, Penghu, and Taoyuan stores to proper order number prefixes on the client
- mirror store prefix mapping on the sales order API

## Testing
- `npm test` (fails: Missing script)
- `pytest` (fails: No module named 'app' / 'requests')

------
https://chatgpt.com/codex/tasks/task_e_68ab2975bfb883299009dd3a2cd5cfb8