### PR TITLE
Fix store selection, enhance therapy sales, enable sales order editing

### DIFF
--- a/client/src/pages/finance/AddSalesOrder.tsx
+++ b/client/src/pages/finance/AddSalesOrder.tsx
@@ -4,7 +4,7 @@ import { Container, Row, Col, Form, Button, Card, InputGroup, Alert, Spinner } f
 import { useNavigate, useLocation } from 'react-router-dom';
 import Header from '../../components/Header';
 import DynamicContainer from '../../components/DynamicContainer';
-import { SalesOrderItemData, SalesOrderPayload, addSalesOrder, getSalesOrderById, SalesOrderDetail } from '../../services/SalesOrderService';
+import { SalesOrderItemData, SalesOrderPayload, addSalesOrder, getSalesOrderById, SalesOrderDetail, updateSalesOrder } from '../../services/SalesOrderService';
 import { getAllMembers, Member } from '../../services/MemberService';
 import { getStaffMembers, StaffMember } from '../../services/TherapyDropdownService';
 // 假設您有獲取會員、員工、產品、療程的服務
@@ -18,6 +18,7 @@ const AddSalesOrder: React.FC = () => {
     const location = useLocation();
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [editingOrderId, setEditingOrderId] = useState<number | null>(null);
 
     // 訂單主體資訊
     const [orderDate, setOrderDate] = useState(new Date().toISOString().split('T')[0]);
@@ -119,9 +120,11 @@ const AddSalesOrder: React.FC = () => {
         const params = new URLSearchParams(location.search);
         const oid = params.get('order_id');
         if (oid) {
+            const idNum = Number(oid);
+            setEditingOrderId(idNum);
             const fetchOrder = async () => {
                 try {
-                    const detail = await getSalesOrderById(Number(oid));
+                    const detail = await getSalesOrderById(idNum);
                     setOrderNumber(detail.order_number);
                     setOrderDate(detail.order_date);
                     setMemberId(detail.member_id ? String(detail.member_id) : "");
@@ -193,7 +196,9 @@ const AddSalesOrder: React.FC = () => {
                 items: sanitizedItems,
             };
             
-            const result = await addSalesOrder(orderPayload);
+            const result = editingOrderId
+                ? await updateSalesOrder(editingOrderId, orderPayload)
+                : await addSalesOrder(orderPayload);
             if (result.success) {
                 alert(result.message);
                 navigate('/finance'); // 假設返回帳務管理主頁

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -63,6 +63,7 @@ const AddProductSell: React.FC = () => {
   useEffect(() => {
     const init = async () => {
       const currentStoreId = getStoreId();
+      const currentStoreName = getStoreName();
       if (currentStoreId) setStoreId(currentStoreId);
       else setError("無法獲取當前門市資訊，請重新登入。");
 
@@ -86,8 +87,7 @@ const AddProductSell: React.FC = () => {
           setError("載入分店資料失敗");
         }
       } else {
-        const name = getStoreName();
-        if (name) setSelectedStore(name);
+        if (currentStoreName) setSelectedStore(currentStoreName);
       }
 
       const fetchStaffMembersData = async () => {
@@ -137,10 +137,13 @@ const AddProductSell: React.FC = () => {
           if (formState.saleCategory) setSaleCategory(formState.saleCategory);
           if (formState.note) setNote(formState.note);
           if (formState.selectedStaffId) setSelectedStaffId(formState.selectedStaffId);
-          if (formState.selectedStore) {
+          if (formState.selectedStore && formState.selectedStore === currentStoreName) {
             setSelectedStore(formState.selectedStore);
-            const id = nameToIdMap[formState.selectedStore];
+            const id = nameToIdMap[formState.selectedStore] || currentStoreId;
             if (id) setStoreId(id.toString());
+          } else {
+            if (currentStoreName) setSelectedStore(currentStoreName);
+            if (currentStoreId) setStoreId(currentStoreId);
           }
           if (typeof formState.discountAmount === 'number') {
             currentDiscAmount = formState.discountAmount;

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -288,12 +288,14 @@ const AddTherapySell: React.FC = () => {
     if (success) {
       const itemsForOrder: SalesOrderItemData[] = therapyPackages.map(pkg => ({
         therapy_id: pkg.type === 'bundle' ? undefined : pkg.therapy_id,
-        item_description: pkg.TherapyContent || pkg.TherapyName || '',
+        item_code: pkg.TherapyCode || '',
+        item_description: pkg.TherapyName || '',
         item_type: 'Therapy',
         unit: '次',
         unit_price: pkg.TherapyPrice || 0,
         quantity: Number(pkg.userSessions) || 0,
         subtotal: (pkg.TherapyPrice || 0) * (Number(pkg.userSessions) || 0),
+        note: pkg.TherapyContent || '',
       }));
       localStorage.setItem('selectedSalesOrderItems', JSON.stringify(itemsForOrder));
       const staffName = staffList.find(s => s.id === Number(formData.staffId))?.name || '';

--- a/client/src/services/LoginService.ts
+++ b/client/src/services/LoginService.ts
@@ -100,9 +100,9 @@ export const login = async (account: string, password: string): Promise<LoginRes
     );
     
     const data = response.data;
-    if (data.token) {
-      // --- 核心修改區域 ---
-      // 2. 在您原本儲存 token 的邏輯後面，加上這一行
+   if (data.token) {
+     // --- 核心修改區域 ---
+     // 2. 在您原本儲存 token 的邏輯後面，加上這一行
       localStorage.setItem('token', data.token);
       setUserRole(data.token); // <--- 就是這一行！它會讀取 token 並設定 'userRole'
 
@@ -110,17 +110,26 @@ export const login = async (account: string, password: string): Promise<LoginRes
       localStorage.setItem('store_id', data.store_id.toString());
       localStorage.setItem('store_level', data.store_level);
       localStorage.setItem('store_name', data.store_name);
-      localStorage.setItem('permission', data.permission);
-      
-      const storeInfo = {
-        store_id: data.store_id,
-        store_name: data.store_name,
-        store_level: data.store_level,
-        permission: data.permission
-      };
-      localStorage.setItem('store_info', JSON.stringify(storeInfo));
+     localStorage.setItem('permission', data.permission);
+
+     const storeInfo = {
+       store_id: data.store_id,
+       store_name: data.store_name,
+       store_level: data.store_level,
+       permission: data.permission
+     };
+     localStorage.setItem('store_info', JSON.stringify(storeInfo));
+
+    // 清除與銷售單相關的暫存資料，避免跨店賬號間的残留
+    localStorage.removeItem('productSellFormState');
+    localStorage.removeItem('selectedProducts');
+    localStorage.removeItem('addTherapySellFormState');
+    localStorage.removeItem('selectedTherapyPackages');
+    localStorage.removeItem('selectedTherapyPackagesWithSessions');
+    localStorage.removeItem('selectedSalesOrderItems');
+    localStorage.removeItem('preSaleData');
       // --- 修改結束 ---
-    }
+   }
     
     return data;
   } catch (error) {

--- a/client/src/services/SalesOrderService.ts
+++ b/client/src/services/SalesOrderService.ts
@@ -51,6 +51,16 @@ export const addSalesOrder = async (orderData: SalesOrderPayload): Promise<ApiRe
     }
 };
 
+export const updateSalesOrder = async (orderId: number, orderData: SalesOrderPayload): Promise<ApiResponse<any>> => {
+    try {
+        const response = await axios.put(`${API_URL}/${orderId}`, orderData);
+        return response.data;
+    } catch (error: any) {
+        console.error("更新銷售單失敗:", error.response?.data || error.message);
+        throw error.response?.data || new Error("更新銷售單時發生未知錯誤");
+    }
+};
+
 // ***** 新增：銷售單列表行的型別 *****
 export interface SalesOrderListRow {
     order_id: number;

--- a/server/app/routes/sales_order_routes.py
+++ b/server/app/routes/sales_order_routes.py
@@ -4,7 +4,8 @@ from app.models.sales_order_model import (
     create_sales_order,
     get_all_sales_orders,
     delete_sales_orders_by_ids,
-    get_sales_order_by_id
+    get_sales_order_by_id,
+    update_sales_order
 )
 from datetime import datetime
 import traceback
@@ -77,3 +78,18 @@ def get_sales_order_detail_route(order_id):
     except Exception as e:
         print(f"Error in get_sales_order_detail_route: {e}")
         return jsonify({'error': '伺服器內部錯誤'}), 500
+
+
+@sales_order_bp.route('/<int:order_id>', methods=['PUT'])
+def update_sales_order_route(order_id):
+    order_data = request.json
+    if not order_data or not isinstance(order_data.get('items'), list):
+        return jsonify({"success": False, "error": "請求數據無效或缺少品項列表"}), 400
+    try:
+        result = update_sales_order(order_id, order_data)
+        status_code = 200 if result.get("success") else 400
+        return jsonify(result), status_code
+    except Exception as e:
+        tb_str = traceback.format_exc()
+        print(f"Error in update_sales_order_route: {e}\n{tb_str}")
+        return jsonify({"success": False, "error": "伺服器內部錯誤"}), 500


### PR DESCRIPTION
## Summary
- ensure store selection matches logged-in branch and clear stale form data
- include therapy codes when printing sales from therapy sells
- add sales order update API and support editing orders on frontend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest` *(fails: pyenv: version `3.11.3` is not installed; pytest: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d67a6c8832983cae0b34a4e714d