### PR TITLE
feat: show used therapy sessions

### DIFF
--- a/client/src/pages/therapy/TherapyRecord.tsx
+++ b/client/src/pages/therapy/TherapyRecord.tsx
@@ -210,6 +210,7 @@ const TherapyRecord: React.FC = () => {
                             <th>療程日期</th>
                             <th>方案</th>
                             <th>使用療程內容</th>
+                            <th>用掉堂數</th>
                             <th>療程剩餘數</th>
                             <th>療癒師</th>
                             <th>備註</th>
@@ -218,7 +219,7 @@ const TherapyRecord: React.FC = () => {
                     tableBody={
                         loading ? (
                             <tr>
-                                <td colSpan={9} className="text-center py-5">
+                                <td colSpan={10} className="text-center py-5">
                                     <div className="spinner-border text-info" role="status">
                                         <span className="visually-hidden">Loading...</span>
                                     </div>
@@ -239,6 +240,7 @@ const TherapyRecord: React.FC = () => {
                                     <td className="align-middle">{formatDate(record.date)}</td>
                                     <td className="align-middle">{record.package_name || "-"}</td>
                                     <td className="align-middle">{record.therapy_content || "-"}</td>
+                                    <td className="align-middle">{formatNumber(record.deduct_sessions)}</td>
                                     <td className="align-middle">{formatNumber(record.remaining_sessions)}</td>
                                     <td className="align-middle">{record.staff_name || "-"}</td>
                                     <td className="align-middle">{record.note ? truncateText(record.note, 30) : "-"}</td>
@@ -246,7 +248,7 @@ const TherapyRecord: React.FC = () => {
                             ))
                         ) : (
                             <tr>
-                                <td colSpan={9} className="text-center text-muted py-5">
+                                <td colSpan={10} className="text-center text-muted py-5">
                                     尚無資料
                                 </td>
                             </tr>

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -44,6 +44,7 @@ def get_all_therapy_records():
                     tr.member_id, m.member_code, m.name AS member_name,
                     tr.therapy_id, t.name AS package_name, t.content AS therapy_content,
                     tr.staff_id, s.name AS staff_name,
+                    tr.deduct_sessions,
                     tr.remaining_sessions_at_time AS remaining_sessions
                 FROM therapy_record tr
                 LEFT JOIN member m ON tr.member_id = m.member_id
@@ -112,6 +113,7 @@ def search_therapy_records(filters):
                     tr.member_id, m.member_code, m.name AS member_name,
                     tr.therapy_id, t.name AS package_name, t.content AS therapy_content,
                     tr.staff_id, s.name AS staff_name,
+                    tr.deduct_sessions,
                     tr.remaining_sessions_at_time AS remaining_sessions
                 FROM therapy_record tr
                 LEFT JOIN member m ON tr.member_id = m.member_id


### PR DESCRIPTION
## Summary
- include deducted session count in therapy record queries
- display "用掉堂數" column on therapy record page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `python -m py_compile server/app/models/therapy_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab383df4488329aa7ddeda0cea7453