### PR TITLE
feat: track final price for therapy sales

### DIFF
--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -219,6 +219,7 @@ const AddTherapySell: React.FC = () => {
         if (packagesOriginalTotal > 0 && formData.discountAmount > 0) {
           itemDiscount = parseFloat((formData.discountAmount).toFixed(2));
         }
+        const itemFinalPrice = itemTotal - itemDiscount;
         const payload = {
           memberId: Number(formData.memberId),
           therapy_id: pkg.type === 'bundle' ? undefined : pkg.therapy_id,
@@ -232,6 +233,7 @@ const AddTherapySell: React.FC = () => {
           transferCode: formData.paymentMethod === '轉帳' ? formData.transferCode : undefined,
           cardNumber: formData.paymentMethod === '信用卡' ? formData.cardNumber : undefined,
           discount: itemDiscount,
+          finalPrice: itemFinalPrice,
           note: formData.note,
         };
         await updateTherapySell(editSale.Order_ID, payload);
@@ -243,6 +245,7 @@ const AddTherapySell: React.FC = () => {
             const proportion = itemTotal / packagesOriginalTotal;
             itemDiscount = parseFloat((formData.discountAmount * proportion).toFixed(2));
           }
+          const itemFinalPrice = itemTotal - itemDiscount;
           return {
             memberId: Number(formData.memberId),
             therapy_id: pkg.type === 'bundle' ? undefined : pkg.therapy_id,
@@ -256,6 +259,7 @@ const AddTherapySell: React.FC = () => {
             transferCode: formData.paymentMethod === '轉帳' ? formData.transferCode : undefined,
             cardNumber: formData.paymentMethod === '信用卡' ? formData.cardNumber : undefined,
             discount: itemDiscount,
+            finalPrice: itemFinalPrice,
             note: formData.note,
           };
         });

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -27,6 +27,7 @@ export interface TherapySellRow { // 更改 interface 名稱以避免與組件�
     StaffName: string;      // 銷售人員
     SaleCategory?: string;  // 銷售類別 (有些 API 可能返回 sale_category)
     Note?: string;          // 備註 - API 需返回此欄位
+    UnitPrice?: number;     // 單價
     therapy_id?: number;    // 對應的療程 ID
 }
 

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -54,6 +54,7 @@ export interface AddTherapySellPayload {
   transferCode?: string;
   cardNumber?: string;
   discount?: number;       // 折扣百分比 (針對此療程項目，或整筆訂單的，需與後端協調)
+  finalPrice?: number;     // 最終價格
   note?: string;
 }
 
@@ -73,6 +74,7 @@ export interface TherapySellRow {
     // 以下是後端 get_all_therapy_sells 返回的其他欄位，按需加入
     TherapyCode?: string;
     Staff_ID?: number;
+    UnitPrice?: number;
     store_name?: string;
     store_id?: number;
     therapy_id?: number;

--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -560,6 +560,7 @@ CREATE TABLE `therapy_sell` (
   `date` date DEFAULT NULL,
   `amount` int DEFAULT NULL,
   `discount` decimal(10,2) DEFAULT NULL,
+  `final_price` decimal(10,2) NOT NULL DEFAULT '0.00',
   `payment_method` enum('Cash','CreditCard','Transfer','Pending','MobilePayment','Others') COLLATE utf8mb4_unicode_ci DEFAULT 'Cash',
   `sale_category` enum('Sell','Gift','Discount','Ticket') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `note` text COLLATE utf8mb4_unicode_ci,

--- a/mysql-init-scripts/02_data.sql
+++ b/mysql-init-scripts/02_data.sql
@@ -178,17 +178,17 @@ INSERT INTO `inventory` (`product_id`, `staff_id`, `date`, `quantity`, `stock_in
 (9, 9, '2023-05-01', 40, 9, 3, 0, 9, 30),
 (10, 10, '2023-05-15', 15, 1, 0, 0, 10, 5);
 
-INSERT INTO `therapy_sell` (`therapy_id`, `member_id`, `store_id`, `staff_id`, `date`, `amount`, `discount`, `payment_method`, `sale_category`, `note`) VALUES
-(1, 1, 1, 1, '2023-01-15', 20, 0, 'Cash', 'Sell', ''),
-(2, 2, 2, 2, '2023-01-20', 20, 300, 'CreditCard', 'Sell', ''),
-(3, 3, 3, 3, '2023-02-05', 20, 0, 'Cash', 'Sell', ''),
-(4, 4, 4, 4, '2023-02-10', 20, 200, 'Cash', 'Sell', ''),
-(5, 5, 5, 5, '2023-03-01', 20, 500, 'Cash', 'Sell', ''),
-(6, 6, 6, 6, '2023-03-20', 20, 0, 'Cash', 'Sell', ''),
-(7, 7, 7, 7, '2023-04-05', 20, 300, 'Cash', 'Sell', ''),
-(8, 8, 8, 8, '2023-04-15', 20, 400, 'Cash', 'Sell', ''),
-(9, 9, 9, 9, '2023-05-01', 20, 600, 'Cash', 'Sell', ''),
-(10, 10, 10, 10, '2023-05-15', 20, 0, 'Cash', 'Sell', '');
+INSERT INTO `therapy_sell` (`therapy_id`, `member_id`, `store_id`, `staff_id`, `date`, `amount`, `discount`, `final_price`, `payment_method`, `sale_category`, `note`) VALUES
+(1, 1, 1, 1, '2023-01-15', 20, 0, 56000.00, 'Cash', 'Sell', ''),
+(2, 2, 2, 2, '2023-01-20', 20, 300, 35700.00, 'CreditCard', 'Sell', ''),
+(3, 3, 3, 3, '2023-02-05', 20, 0, 30000.00, 'Cash', 'Sell', ''),
+(4, 4, 4, 4, '2023-02-10', 20, 200, 49800.00, 'Cash', 'Sell', ''),
+(5, 5, 5, 5, '2023-03-01', 20, 500, 63500.00, 'Cash', 'Sell', ''),
+(6, 6, 6, 6, '2023-03-20', 20, 0, 70000.00, 'Cash', 'Sell', ''),
+(7, 7, 7, 7, '2023-04-05', 20, 300, 23700.00, 'Cash', 'Sell', ''),
+(8, 8, 8, 8, '2023-04-15', 20, 400, 31600.00, 'Cash', 'Sell', ''),
+(9, 9, 9, 9, '2023-05-01', 20, 600, 43400.00, 'Cash', 'Sell', ''),
+(10, 10, 10, 10, '2023-05-15', 20, 0, 40000.00, 'Cash', 'Sell', '');
 
 INSERT INTO `therapy_record` (`therapy_id`, `member_id`, `store_id`, `staff_id`, `date`, `note`, `deduct_sessions`, `remaining_sessions_at_time`) VALUES
 (1, 1, 1, 1, '2023-01-20', '客戶反應良好，肩頸壓力明顯舒緩', 1, 19),


### PR DESCRIPTION
## Summary
- add `final_price` to therapy_sell schema and seed data
- compute and store final prices for therapy sales
- allow client to submit total price for therapy sale items

## Testing
- `pytest` *(fails: No module named 'app' / 'pandas')*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac5f9a8db083299ca7e2e26f3c158e