### PR TITLE
Fix missing StockOut in inventory search

### DIFF
--- a/server/app/models/inventory_model.py
+++ b/server/app/models/inventory_model.py
@@ -44,6 +44,10 @@ def get_all_inventory(store_id=None):
 
             cursor.execute(query, params)
             result = cursor.fetchall()
+            for row in result:
+                stock_in = row.get('StockIn') or 0
+                stock_qty = row.get('StockQuantity') or 0
+                row['StockOut'] = stock_in - stock_qty
             return result
     except Exception as e:
         print(f"獲取庫存記錄錯誤: {e}")
@@ -90,6 +94,10 @@ def search_inventory(keyword, store_id=None):
 
             cursor.execute(query, params)
             result = cursor.fetchall()
+            for row in result:
+                stock_in = row.get('StockIn') or 0
+                stock_qty = row.get('StockQuantity') or 0
+                row['StockOut'] = stock_in - stock_qty
             return result
     except Exception as e:
         print(f"搜尋庫存記錄錯誤: {e}")


### PR DESCRIPTION
## Summary
- derive StockOut by subtracting current stock from StockIn

## Testing
- `PYENV_VERSION=3.12.10 venv/bin/python -m pytest -q` *(fails: connection refused to localhost:5000, plus DB connection errors)*
- `npm test` *(fails: Missing script "test")*
- `cd client && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac62a5a9c8832987d51a8aa9e05392