### PR TITLE
feat: add inventory detail history view

### DIFF
--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -4,7 +4,7 @@ import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import { getInventoryRecords, exportInventory } from "../../services/InventoryService";
 import { downloadBlob } from "../../utils/downloadBlob";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 const formatDate = (d: string) => {
   const dt = new Date(d);
@@ -30,6 +30,9 @@ interface RecordRow {
 
 const InventoryDetail: React.FC = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const productId = searchParams.get("productId");
+  const productName = searchParams.get("productName");
   const [records, setRecords] = useState<RecordRow[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [startDate, setStartDate] = useState("");
@@ -43,6 +46,7 @@ const InventoryDetail: React.FC = () => {
       end_date: endDate || undefined,
       sale_staff: saleStaff || undefined,
       buyer: buyer || undefined,
+      productId: productId ? Number(productId) : undefined,
     }).then((res) => setRecords(res));
   };
 
@@ -54,6 +58,7 @@ const InventoryDetail: React.FC = () => {
         sale_staff: saleStaff || undefined,
         buyer: buyer || undefined,
         detail: true,
+        productId: productId ? Number(productId) : undefined,
       });
       downloadBlob(blob, `庫存報表_${new Date().toISOString().split('T')[0]}.xlsx`);
     } catch (err) {
@@ -64,11 +69,11 @@ const InventoryDetail: React.FC = () => {
 
   useEffect(() => {
     handleSearch();
-  }, []);
+  }, [productId]);
 
   const content = (
     <Container fluid className="p-4">
-      <h5 className="text-danger mb-3">資料連動總部出貨、分店銷售</h5>
+      <h5 className="text-danger mb-3">{productName ? `${productName} 詳細入庫資訊` : "資料連動總部出貨、分店銷售"}</h5>
 
       {/* 搜尋列 */}
       <Row className="align-items-center mb-3 g-2">

--- a/client/src/pages/inventory/InventorySearch.tsx
+++ b/client/src/pages/inventory/InventorySearch.tsx
@@ -263,12 +263,13 @@ const InventorySearch: React.FC = () => {
                                 <th className="text-end">庫存量</th>
                                 <th className="text-end">庫存預警值</th>
                                 <th>入庫時間</th>
+                                <th>詳細</th>
                             </tr>
                         }
                         tableBody={
                             loading ? (
                                 <tr>
-                                    <td colSpan={9} className="text-center py-4">
+                                    <td colSpan={10} className="text-center py-4">
                                         <Spinner animation="border" variant="info" />
                                         <p>載入中...</p>
                                     </td>
@@ -291,11 +292,20 @@ const InventorySearch: React.FC = () => {
                                         <td className="text-end">{item.StockQuantity}</td>
                                         <td className="text-end">{item.StockThreshold}</td>
                                         <td>{formatDate(item.StockInTime)}</td>
+                                        <td>
+                                            <Button
+                                                variant="link"
+                                                className="p-0"
+                                                onClick={() => navigate(`/inventory/inventory-detail?productId=${item.Product_ID}&productName=${encodeURIComponent(item.ProductName)}`)}
+                                            >
+                                                查看詳細入庫資訊
+                                            </Button>
+                                        </td>
                                     </tr>
                                 ))
                             ) : (
                                 <tr>
-                                    <td colSpan={9} className="text-center text-muted py-5">
+                                    <td colSpan={10} className="text-center text-muted py-5">
                                         尚無資料
                                     </td>
                                 </tr>

--- a/client/src/services/InventoryService.ts
+++ b/client/src/services/InventoryService.ts
@@ -61,6 +61,7 @@ export const getInventoryRecords = async (params?: {
     end_date?: string;
     sale_staff?: string;
     buyer?: string;
+    productId?: number;
 }) => {
     const level = localStorage.getItem('store_level');
     const perm = localStorage.getItem('permission');
@@ -71,6 +72,7 @@ export const getInventoryRecords = async (params?: {
     if (params?.end_date) query.end_date = params.end_date;
     if (params?.sale_staff) query.sale_staff = params.sale_staff;
     if (params?.buyer) query.buyer = params.buyer;
+    if (params?.productId) query.product_id = params.productId;
     if (!isAdmin && params?.storeId !== undefined) {
         query.store_id = params.storeId;
     } else if (isAdmin && params?.storeId !== undefined) {
@@ -141,6 +143,7 @@ export const exportInventory = async (params?: {
     sale_staff?: string;
     buyer?: string;
     detail?: boolean;
+    productId?: number;
 }): Promise<Blob> => {
     const level = localStorage.getItem('store_level');
     const perm = localStorage.getItem('permission');
@@ -152,6 +155,7 @@ export const exportInventory = async (params?: {
     if (params?.sale_staff) query.sale_staff = params.sale_staff;
     if (params?.buyer) query.buyer = params.buyer;
     if (params?.detail) query.detail = params.detail;
+    if (params?.productId) query.product_id = params.productId;
 
     if (!isAdmin && params?.storeId !== undefined) {
         query.store_id = params.storeId;

--- a/server/app/models/inventory_model.py
+++ b/server/app/models/inventory_model.py
@@ -222,8 +222,9 @@ def get_low_stock_inventory(store_id=None):
     finally:
         conn.close()
 
-def get_inventory_history(store_id=None, start_date=None, end_date=None, sale_staff=None, buyer=None):
-    """獲取庫存進出明細，可依店鋪、日期區間、銷售人與購買人篩選。
+def get_inventory_history(store_id=None, start_date=None, end_date=None,
+                          sale_staff=None, buyer=None, product_id=None):
+    """獲取庫存進出明細，可依店鋪、日期區間、銷售人、購買人與產品篩選。
     為了同時呈現銷售(產品與療程)造成的庫存變化，
     此函式會合併 inventory、product_sell 以及 therapy_sell 的紀錄。"""
     conn = connect_to_db()
@@ -265,6 +266,9 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None, sale_st
             if end_date:
                 conditions.append("i.date <= %s")
                 params.append(end_date)
+            if product_id:
+                conditions.append("i.product_id = %s")
+                params.append(product_id)
             if conditions:
                 base_q += " WHERE " + " AND ".join(conditions)
             cursor.execute(base_q, params)
@@ -310,6 +314,9 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None, sale_st
             if buyer:
                 conditions.append("mb.name LIKE %s")
                 params.append(f"%{buyer}%")
+            if product_id:
+                conditions.append("ps.product_id = %s")
+                params.append(product_id)
             if conditions:
                 prod_q += " WHERE " + " AND ".join(conditions)
             cursor.execute(prod_q, params)
@@ -355,6 +362,9 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None, sale_st
             if buyer:
                 conditions.append("mb.name LIKE %s")
                 params.append(f"%{buyer}%")
+            if product_id:
+                conditions.append("ts.therapy_id = %s")
+                params.append(product_id)
             if conditions:
                 therapy_q += " WHERE " + " AND ".join(conditions)
             cursor.execute(therapy_q, params)

--- a/server/app/routes/inventory.py
+++ b/server/app/routes/inventory.py
@@ -84,6 +84,7 @@ def get_inventory_records():
     end_date = request.args.get("end_date")
     sale_staff = request.args.get("sale_staff")
     buyer = request.args.get("buyer")
+    product_id = request.args.get("product_id")
     try:
         user_store_level = request.store_level
         user_store_id = request.store_id
@@ -92,7 +93,7 @@ def get_inventory_records():
 
         target_store = store_id_param if is_admin else user_store_id
 
-        records = get_inventory_history(target_store, start_date, end_date, sale_staff, buyer)
+        records = get_inventory_history(target_store, start_date, end_date, sale_staff, buyer, product_id)
         return jsonify(records)
     except Exception as e:
         print(e)
@@ -219,11 +220,12 @@ def export_inventory():
         sale_staff = request.args.get('sale_staff')
         buyer = request.args.get('buyer')
         detail = request.args.get('detail')
+        product_id = request.args.get('product_id')
 
         target_store = None if is_admin and not store_id_param else (store_id_param or user_store_id)
 
         if detail:
-            inventory_data = get_inventory_history(target_store, start_date, end_date, sale_staff, buyer)
+            inventory_data = get_inventory_history(target_store, start_date, end_date, sale_staff, buyer, product_id)
         else:
             inventory_data = export_inventory_data(target_store)
         


### PR DESCRIPTION
## Summary
- show per-product inventory totals with link to detail history
- support product filter in inventory history APIs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html".)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6f2c9c1c8329881663276d1e5884