### PR TITLE
Deduplicate store list and add printable sales order

### DIFF
--- a/client/src/global.css
+++ b/client/src/global.css
@@ -51,3 +51,15 @@ body {
   z-index: 90;
   width: 100%;
 }
+
+@media print {
+  .app-sidebar,
+  .app-header,
+  .no-print {
+    display: none !important;
+  }
+  .print-container {
+    width: 100% !important;
+    margin: 0 !important;
+  }
+}

--- a/client/src/pages/finance/AddSalesOrder.tsx
+++ b/client/src/pages/finance/AddSalesOrder.tsx
@@ -229,9 +229,9 @@ const AddSalesOrder: React.FC = () => {
         }
     };
 
-    // 列印功能尚未實作，點擊僅顯示提示
+    // 列印銷售單內容
     const handlePrint = () => {
-        alert('列印功能待實現');
+        window.print();
     };
     
     // --- JSX 部分 ---
@@ -292,7 +292,7 @@ const AddSalesOrder: React.FC = () => {
                         </Col>
                     </Row>
                 </Card.Body>
-                <Card.Footer className="text-center">
+                <Card.Footer className="text-center no-print">
                     <Button variant="info" className="mx-1 text-white" onClick={handlePrint}>列印</Button>
                     <Button variant="info" className="mx-1 text-white" onClick={() => setItems([{}])}>刪除</Button>
                     <Button variant="info" className="mx-1 text-white">修改</Button>
@@ -307,7 +307,7 @@ const AddSalesOrder: React.FC = () => {
     return (
         <div className="d-flex flex-column min-vh-100 bg-light">
             <Header />
-            <DynamicContainer content={content} />
+            <DynamicContainer content={content} className="print-container" />
         </div>
     );
 };

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -71,15 +71,16 @@ const AddProductSell: React.FC = () => {
       if (userRole === 'admin') {
         try {
           const data = await fetchAllStores();
-          setStores(data);
+          const uniqueStores = Array.from(new Map(data.map(s => [s.store_name, s])).values());
+          setStores(uniqueStores);
           const map: { [name: string]: number } = {};
-          data.forEach(s => { map[s.store_name] = s.store_id; });
+          uniqueStores.forEach(s => { map[s.store_name] = s.store_id; });
           nameToIdMap = map;
           setStoreNameToId(map);
           if (!localStorage.getItem('productSellFormState')) {
-            if (data.length > 0) {
-              setSelectedStore(data[0].store_name);
-              setStoreId(data[0].store_id.toString());
+            if (uniqueStores.length > 0) {
+              setSelectedStore(uniqueStores[0].store_name);
+              setStoreId(uniqueStores[0].store_id.toString());
             }
           }
         } catch (err) {


### PR DESCRIPTION
## Summary
- Avoid duplicate store names in product sale form for admin users
- Implement sales order printing and hide sidebar/action buttons when printing
- Add global CSS rules for cleaner print layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type 'ChangeEvent<FormControlElement>' is not assignable to type 'ChangeEvent<HTMLInputElement | HTMLSelectElement>'.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68ad57e3c51883298f7614a751883978