### PR TITLE
Fix missing unit price and amount in inventory detail

### DIFF
--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -25,7 +25,7 @@ interface RecordRow {
   SaleStaff?: string;
   Buyer?: string;
   Voucher?: string;
-  price?: number;
+  Price?: number;
 }
 
 const InventoryDetail: React.FC = () => {
@@ -151,9 +151,9 @@ const InventoryDetail: React.FC = () => {
                 <td>{r.Inventory_ID}</td>
                 <td>{r.Name}</td>
                 <td></td>
-                <td>{r.price ?? ''}</td>
+                <td>{r.Price ?? ''}</td>
                 <td>{r.quantity}</td>
-                <td>{r.price ? r.price * r.quantity : ''}</td>
+                <td>{r.Price ? r.Price * r.quantity : ''}</td>
                 <td></td>
                 <td></td>
                 <td>{formatDate(r.Date)}</td>


### PR DESCRIPTION
## Summary
- Display unit price and amount for each inventory record

## Testing
- `npm run lint` *(fails: Irregular whitespace and other lint errors in unrelated files)*
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5e4dc4b48329acc0dde26fa0aa44