### PR TITLE
Prevent editing sales inventory records

### DIFF
--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -181,11 +181,15 @@ const InventoryDetail: React.FC = () => {
             variant="info"
             className="text-white px-4"
             onClick={() => {
-              if (selectedId) {
-                navigate(`/inventory/inventory-update?id=${selectedId}`);
-              } else {
+              if (!selectedId) {
                 alert('請先勾選要修改的資料');
+                return;
               }
+              if (selectedId >= 1000000) {
+                alert('銷售資料無法做更動\n銷售資料要做更動請至銷售產品/銷售療程做修改');
+                return;
+              }
+              navigate(`/inventory/inventory-update?id=${selectedId}`);
             }}
           >
             修改

--- a/server/app/routes/inventory.py
+++ b/server/app/routes/inventory.py
@@ -104,6 +104,9 @@ def get_inventory_records():
 def get_inventory_item(inventory_id):
     """根據ID獲取庫存記錄"""
     try:
+        if inventory_id >= 1000000:
+            return jsonify({"error": "銷售資料無法做更動，銷售資料要做更動請至銷售產品/銷售療程做修改"}), 400
+
         inventory_item = get_inventory_by_id(inventory_id)
         if not inventory_item:
             return jsonify({"error": "找不到該庫存記錄"}), 404
@@ -125,6 +128,9 @@ def update_inventory(inventory_id):
     """更新庫存記錄"""
     data = request.json
     try:
+        if inventory_id >= 1000000:
+            return jsonify({"error": "銷售資料無法做更動，銷售資料要做更動請至銷售產品/銷售療程做修改"}), 400
+
         existing = get_inventory_by_id(inventory_id)
         if not existing:
             return jsonify({"error": "找不到該庫存記錄"}), 404


### PR DESCRIPTION
## Summary
- block editing of sales records from inventory detail
- guard inventory API against sales record IDs

## Testing
- `npm run lint` *(fails: Irregular whitespace not allowed, no-unused-vars)*
- `python3 -m pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68ad978441208329ad1cb0c5f994330c