### PR TITLE
Use member number instead of member code

### DIFF
--- a/client/src/components/MemberColumn.tsx
+++ b/client/src/components/MemberColumn.tsx
@@ -53,7 +53,7 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
                     // 找到會員，呼叫 onMemberChange 更新父元件的表單
                     onMemberChange(memberCode, member.name, member);
                 } else {
-                    if (onError) onError(`會員代碼 ${memberCode} 不存在`);
+                    if (onError) onError(`會員編號 ${memberCode} 不存在`);
                     onMemberChange(memberCode, "未找到會員", null);
                 }
             } catch (err) {
@@ -76,7 +76,7 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
         <Row>
             <Col md={6}>
                 <Form.Group className="mb-3">
-                    <Form.Label>會員代碼</Form.Label>
+                    <Form.Label>會員編號</Form.Label>
                     <Form.Control
                         type="text"
                         name="memberCode"
@@ -89,7 +89,7 @@ const MemberColumn: React.FC<MemberColumnProps> = ({
                         disabled={isEditMode}
                     />
                     <Form.Control.Feedback type="invalid">
-                        請輸入會員代碼
+                        請輸入會員編號
                     </Form.Control.Feedback>
                 </Form.Group>
             </Col>

--- a/client/src/pages/health/pure_medical_record/AddPureMedicalRecord.tsx
+++ b/client/src/pages/health/pure_medical_record/AddPureMedicalRecord.tsx
@@ -241,6 +241,7 @@ const AddPureMedicalRecord: React.FC = () => {
             <MemberColumn
                 memberCode={formData.會員代碼}
                 name={formData.姓名}
+                isEditMode={false}
                 onMemberChange={handleMemberChange}
                 onError={handleError}
             />

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -66,9 +66,9 @@ def create_member_route():
 
         member_code = data.get("member_code")
         if not member_code:
-            return jsonify({"error": "會員代碼為必填欄位。"}), 400
+            return jsonify({"error": "會員編號為必填欄位。"}), 400
         if check_member_code_exists(member_code):
-            return jsonify({"error": "會員代碼已存在，請使用其他代碼。"}), 400
+            return jsonify({"error": "會員編號已存在，請使用其他編號。"}), 400
 
         # --- 介紹人 ID 的驗證邏輯 ---
         inferrer_id = data.get("inferrer_id")
@@ -168,7 +168,7 @@ def export_members():
         df = pd.DataFrame(members)
         
         column_mapping = {
-            'member_id': '會員編號', 'member_code': '會員代碼', 'name': '姓名',
+            'member_id': '會員編號', 'member_code': '會員編號', 'name': '姓名',
             'birthday': '生日', 'address': '地址', 'phone': '電話', 'gender': '性別',
             'blood_type': '血型', 'line_id': 'Line ID', 'inferrer_id': '推薦人編號',
             'occupation': '職業', 'note': '備註', 'store_id': '所屬分店ID'
@@ -253,7 +253,7 @@ def check_member_exists_route(member_id):
 @member_bp.route('/check-code/<string:member_code>', methods=['GET'])
 @auth_required  # 加上認證，避免被惡意查詢
 def check_member_code_route(member_code):
-    """檢查會員代碼是否存在"""
+    """檢查會員編號是否存在"""
     try:
         exists = check_member_code_exists(member_code)
         return jsonify({"exists": exists})

--- a/server/app/routes/therapy.py
+++ b/server/app/routes/therapy.py
@@ -162,7 +162,7 @@ def export_records():
         # 過濾和重命名欄位以適合匯出
         export_data = [{
             '療程記錄ID': r.get('therapy_record_id'),
-            '會員代碼': r.get('member_code'),
+            '會員編號': r.get('member_code'),
             '會員姓名': r.get('member_name'),
             '商店名稱': r.get('store_name'),
             '服務人員': r.get('staff_name'),


### PR DESCRIPTION
## Summary
- Rename MemberColumn labels and feedback from 會員代碼 to 會員編號
- Allow manual member_code entry with auto-filled name when adding therapy records
- Update server exports and messages to use 會員編號 terminology

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type 'ChangeEvent<FormControlElement>' ... and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae777574bc83298180ebfadd5c784f