### PR TITLE
feat: allow member code input for stress tests

### DIFF
--- a/client/src/pages/health/stress_test/StressTestForm.tsx
+++ b/client/src/pages/health/stress_test/StressTestForm.tsx
@@ -4,7 +4,7 @@ import { Button, Col, Form, Row, Card, Alert } from "react-bootstrap";
 import { useNavigate, useParams } from "react-router-dom";
 import Header from "../../../components/Header";
 import DynamicContainer from "../../../components/DynamicContainer";
-import { getAllMembers, Member } from '../../../services/MemberService';
+import { getMemberByCode } from '../../../services/MemberService';
 import { getStressTestByIdWithAnswers, addStressTestWithAnswers, updateStressTestWithAnswers } from '../../../services/StressTestService';
 
 // 問卷題目（1-20題）
@@ -37,17 +37,13 @@ const StressTestForm: React.FC = () => {
     const navigate = useNavigate();
     const { id } = useParams<{ id: string }>(); // id 有值就是編輯，沒值就是新增
     const isEditMode = !!id;
-    const [members, setMembers] = useState([]);
+    const [memberCode, setMemberCode] = useState("");
     const [memberId, setMemberId] = useState("");
+    const [memberName, setMemberName] = useState("");
     const [testDate, setTestDate] = useState("");
     const [answers, setAnswers] = useState<Record<string, string>>({});
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
-  
-    // 取會員
-    useEffect(() => {
-      getAllMembers().then(setMembers).catch(() => setMembers([]));
-    }, []);
   
     // 編輯模式：自動帶入舊資料
     useEffect(() => {
@@ -55,17 +51,38 @@ const StressTestForm: React.FC = () => {
         setLoading(true);
         getStressTestByIdWithAnswers(id)
           .then((data) => {
+            const fetchedMemberId = data.member_id?.toString() || "";
+            const fetchedMemberCode = data.member_code?.toString() || "";
+            setMemberId(fetchedMemberId);
+            setMemberCode(fetchedMemberCode);
+            setMemberName(data.name || "");
             setTestDate((typeof data.test_date === "string" && data.test_date.length >= 10)
                 ? data.test_date.slice(0, 10)
                 : "");
-            setMemberId(data.member_id?.toString() || "");
-            setTestDate(data.test_date || "");
             setAnswers(data.answers || {});
           })
           .catch(() => setError("載入失敗"))
           .finally(() => setLoading(false));
       }
     }, [isEditMode, id]);
+
+    // 根據會員代碼自動取得會員資訊
+    useEffect(() => {
+      if (!memberCode) {
+        setMemberName("");
+        setMemberId("");
+        return;
+      }
+      getMemberByCode(memberCode)
+        .then(member => {
+          setMemberName(member?.Name || "");
+          setMemberId(member?.Member_ID || "");
+        })
+        .catch(() => {
+          setMemberName("");
+          setMemberId("");
+        });
+    }, [memberCode]);
   
     // 填答
     const handleAnswerChange = (qid: string, val: string) => {
@@ -79,7 +96,7 @@ const StressTestForm: React.FC = () => {
       setError("");
       try {
         if (!memberId || !testDate) {
-          setError("請選擇會員並填寫檢測日期！");
+          setError("請輸入會員編號並填寫檢測日期！");
           setLoading(false);
           return;
         }
@@ -112,24 +129,24 @@ const StressTestForm: React.FC = () => {
                 </Card.Header>
                 <Card.Body>
                   <Row className="g-3">
-                    <Col md={6}>
+                    <Col md={4}>
                       <Form.Group>
-                        <Form.Label>選擇會員</Form.Label>
-                        <Form.Select
-                          value={memberId}
-                          onChange={e => setMemberId(e.target.value)}
+                        <Form.Label>會員編號</Form.Label>
+                        <Form.Control
+                          type="text"
+                          value={memberCode}
+                          onChange={e => setMemberCode(e.target.value)}
                           disabled={isEditMode}
-                        >
-                          <option value="" disabled>請選擇一位會員</option>
-                          {members.map((m: any) => (
-                            <option key={m.Member_ID} value={m.Member_ID}>
-                              {m.Name} (ID: {m.Member_ID})
-                            </option>
-                          ))}
-                        </Form.Select>
+                        />
                       </Form.Group>
                     </Col>
-                    <Col md={6}>
+                    <Col md={4}>
+                      <Form.Group>
+                        <Form.Label>姓名</Form.Label>
+                        <Form.Control type="text" value={memberName} disabled />
+                      </Form.Group>
+                    </Col>
+                    <Col md={4}>
                       <Form.Group>
                         <Form.Label>檢測日期</Form.Label>
                         <Form.Control

--- a/client/src/services/MemberService.ts
+++ b/client/src/services/MemberService.ts
@@ -168,6 +168,19 @@ export const getMemberById = async (memberId: string): Promise<Member | null> =>
 };
 
 /**
+ * Get a single member by member_code
+ */
+export const getMemberByCode = async (memberCode: string): Promise<Member | null> => {
+  try {
+    const response = await authAxios.get(`/code/${memberCode}`);
+    return transformBackendToFrontend(response.data);
+  } catch (error) {
+    console.error("Failed to get member by code:", error);
+    return null;
+  }
+};
+
+/**
  * Add a new member
  */
 export const addMember = async (memberData: Omit<Member, 'Member_ID'>) => {


### PR DESCRIPTION
## Summary
- replace member selector with manual member code entry and auto-loaded name
- add `getMemberByCode` helper to fetch member information by code

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html")*


------
https://chatgpt.com/codex/tasks/task_e_68af05d8c65483298263a6801964e941