### PR TITLE
Handle member codes for sales records

### DIFF
--- a/client/src/pages/product/ProductSell.tsx
+++ b/client/src/pages/product/ProductSell.tsx
@@ -58,7 +58,7 @@ const ProductSell: React.FC = () => {
                         onChange={(e) => handleCheckboxChange(sale.product_sell_id, e.target.checked)}
                     />
                 </td>
-                <td className="align-middle">{sale.member_id || "-"}</td>
+                <td className="align-middle">{sale.member_code || "-"}</td>
                 <td className="align-middle">{sale.member_name || "-"}</td>
                 <td className="align-middle">{formatDateToChinese(sale.date) || "-"}</td>
                 <td className="align-middle">{sale.product_name || "-"}</td>

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -17,7 +17,8 @@ import { formatCurrency } from "../../utils/productSellUtils"; // 借用金額�
 // 更新 interface 以符合 Figma 需求
 export interface TherapySellRow { // 更改 interface 名稱以避免與組件名衝突
     Order_ID: number;       // 內部使用 ID
-    Member_ID: number;      // 會員編號
+    Member_ID: number;      // 會員ID
+    MemberCode?: string;    // 會員編號
     MemberName: string;     // 購買人
     PurchaseDate: string;   // 購買日期
     PackageName: string;    // 購買品項 (療程名稱)
@@ -208,7 +209,7 @@ const TherapySell: React.FC = () => {
                         onChange={() => handleCheckboxChange(sale.Order_ID)}
                     />
                 </td>
-                <td className="align-middle">{sale.Member_ID || "-"}</td>
+                <td className="align-middle">{sale.MemberCode || "-"}</td>
                 <td className="align-middle">{sale.MemberName || "-"}</td>
                 <td className="align-middle">{formatDateToChinese(sale.PurchaseDate) || "-"}</td>
                 <td className="align-middle">{sale.PackageName || "-"}</td>

--- a/client/src/services/ProductSellService.ts
+++ b/client/src/services/ProductSellService.ts
@@ -86,6 +86,7 @@ export const addProductSell = async (data: ProductSellData) => {
 };
 
 export interface ProductSell extends ProductSellData {
+  member_code?: string;
   member_name?: string;
   store_name?: string;
   product_name?: string;

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -62,6 +62,7 @@ export interface AddTherapySellPayload {
 export interface TherapySellRow {
     Order_ID: number;       // therapy_sell_id
     Member_ID: number;
+    MemberCode?: string;
     MemberName: string;
     PurchaseDate: string;   // 後端應返回 YYYY-MM-DD 格式字串
     PackageName: string;    // therapy.name

--- a/server/app/models/therapy_sell_model.py
+++ b/server/app/models/therapy_sell_model.py
@@ -58,6 +58,7 @@ def get_all_therapy_sells(store_id=None):
             query = """
                 SELECT ts.therapy_sell_id as Order_ID,
                        m.member_id as Member_ID,
+                       m.member_code as MemberCode,
                        m.name as MemberName,
                        ts.date as PurchaseDate,
                        t.name as PackageName,
@@ -112,6 +113,7 @@ def search_therapy_sells(keyword, store_id=None):
             query = """
                 SELECT ts.therapy_sell_id as Order_ID,
                        m.member_id as Member_ID,
+                       m.member_code as MemberCode,
                        m.name as MemberName,
                        ts.date as PurchaseDate,
                        t.name as PackageName,
@@ -132,7 +134,7 @@ def search_therapy_sells(keyword, store_id=None):
                 LEFT JOIN staff s ON ts.staff_id = s.staff_id
                 LEFT JOIN store st ON ts.store_id = st.store_id
                 LEFT JOIN therapy t ON ts.therapy_id = t.therapy_id
-                WHERE (m.name LIKE %s OR m.member_id LIKE %s OR s.name LIKE %s)
+                WHERE (m.name LIKE %s OR m.member_code LIKE %s OR s.name LIKE %s)
             """
             
             # 如果指定了店鋪ID，則只搜尋該店鋪的銷售記錄


### PR DESCRIPTION
## Summary
- include member_code in product and therapy sell queries
- skip inventory update when product_id is absent
- show member_code in product and therapy sell UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html".)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_68af2ede857483298016e61978d00bb7