### PR TITLE
Allow therapist store access and fix inventory selection

### DIFF
--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -159,11 +159,20 @@ const InventoryDetail: React.FC = () => {
             </tr>
           ) : (
             records.map((r) => (
-              <tr key={r.Inventory_ID}>
+              <tr
+                key={r.Inventory_ID}
+                onClick={() =>
+                  setSelectedId(
+                    selectedId === r.Inventory_ID ? null : r.Inventory_ID
+                  )
+                }
+                style={{ cursor: "pointer" }}
+              >
                 <td>
                   <Form.Check
                     type="checkbox"
                     checked={selectedId === r.Inventory_ID}
+                    onClick={(e) => e.stopPropagation()}
                     onChange={() =>
                       setSelectedId(
                         selectedId === r.Inventory_ID ? null : r.Inventory_ID

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -19,8 +19,9 @@ def get_store_based_where_condition(table_alias=None):
     if permission == 'admin':
         return ("", [])
 
-    if permission == 'basic' and store_id:
+    # Treat therapists like basic users: allow access to their own store's data
+    if permission in ('basic', 'therapist') and store_id:
         field = f"{table_alias}.store_id" if table_alias else "store_id"
         return (f" AND {field} = %s ", [store_id])
-    
+
     return (" AND 1=0 ", [])


### PR DESCRIPTION
## Summary
- Allow `therapist` role to view store-scoped data
- Make inventory rows clickable to select entries for deletion

## Testing
- `pytest server/test_therapy_api.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68b04854c9f48329926da8356c033401