### PR TITLE
Allow therapist store access and fix inventory selection

### DIFF
--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -159,11 +159,20 @@ const InventoryDetail: React.FC = () => {
             </tr>
           ) : (
             records.map((r) => (
-              <tr key={r.Inventory_ID}>
+              <tr
+                key={r.Inventory_ID}
+                onClick={() =>
+                  setSelectedId(
+                    selectedId === r.Inventory_ID ? null : r.Inventory_ID
+                  )
+                }
+                style={{ cursor: "pointer" }}
+              >
                 <td>
                   <Form.Check
                     type="checkbox"
                     checked={selectedId === r.Inventory_ID}
+                    onClick={(e) => e.stopPropagation()}
                     onChange={() =>
                       setSelectedId(
                         selectedId === r.Inventory_ID ? null : r.Inventory_ID

--- a/client/src/services/TherapyDropdownService.ts
+++ b/client/src/services/TherapyDropdownService.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { base_url } from "./BASE_URL";
+import { getAuthHeaders } from "./AuthUtils";
 
 const API_URL = `${base_url}/therapy-sell`;
 
@@ -55,7 +56,7 @@ export const getStaffMembers = async (storeId?: number): Promise<StaffMember[]> 
             const resolvedStoreId = storeId ?? Number(localStorage.getItem('store_id'));
             params = resolvedStoreId ? { store_id: resolvedStoreId } : undefined;
         }
-        const response = await axios.get(`${API_URL}/staff`, { params });
+        const response = await axios.get(`${API_URL}/staff`, { params, headers: getAuthHeaders() });
 
         // 處理返回數據，確保與預期格式一致
         if (response.data && Array.isArray(response.data)) {

--- a/client/src/services/TherapyService.ts
+++ b/client/src/services/TherapyService.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { base_url } from "./BASE_URL";
 import { TherapySearchParams } from "../hooks/useTherapyRecord";
+import { getAuthHeaders } from "./AuthUtils";
 
 const API_URL = `${base_url}/therapy`;
 
@@ -25,18 +26,23 @@ export interface TherapyRecord {
 
 // 療程紀錄 API
 export const getAllTherapyRecords = async (): Promise<TherapyRecord[]> => {
-    const response = await axios.get(`${API_URL}/record`);
+    const response = await axios.get(`${API_URL}/record`, {
+        headers: getAuthHeaders()
+    });
     return response.data;
 };
 
 export const getTherapyRecordById = async (recordId: number): Promise<TherapyRecord> => {
-    const response = await axios.get(`${API_URL}/record/${recordId}`);
+    const response = await axios.get(`${API_URL}/record/${recordId}`, {
+        headers: getAuthHeaders()
+    });
     return response.data;
 };
 
 export const searchTherapyRecords = async (params: TherapySearchParams): Promise<TherapyRecord[]> => {
     const response = await axios.get(`${API_URL}/record/search`, {
-        params: params
+        params: params,
+        headers: getAuthHeaders()
     });
     return response.data;
 };
@@ -50,7 +56,9 @@ export const addTherapyRecord = async (data: {
     date: string;
     note?: string;
 }) => {
-    return axios.post(`${API_URL}/record`, data);
+    return axios.post(`${API_URL}/record`, data, {
+        headers: getAuthHeaders()
+    });
 };
 
 export const updateTherapyRecord = async (
@@ -65,29 +73,37 @@ export const updateTherapyRecord = async (
         note?: string;
     }
 ) => {
-    return axios.put(`${API_URL}/record/${recordId}`, data);
+    return axios.put(`${API_URL}/record/${recordId}`, data, {
+        headers: getAuthHeaders()
+    });
 };
 
 export const deleteTherapyRecord = async (recordId: number) => {
-    return axios.delete(`${API_URL}/record/${recordId}`);
+    return axios.delete(`${API_URL}/record/${recordId}`, {
+        headers: getAuthHeaders()
+    });
 };
 
 export const exportTherapyRecords = async () => {
     const response = await axios.get(`${API_URL}/record/export`, {
-        responseType: "blob"
+        responseType: "blob",
+        headers: getAuthHeaders()
     });
     return response.data;
 };
 
 // 療程銷售 API
 export const getAlltherapySells = async () => {
-    const response = await axios.get(`${API_URL}/sale`);
+    const response = await axios.get(`${API_URL}/sale`, {
+        headers: getAuthHeaders()
+    });
     return response.data;
 };
 
 export const searchtherapySells = async (keyword: string) => {
     const response = await axios.get(`${API_URL}/sale/search`, {
-        params: { keyword }
+        params: { keyword },
+        headers: getAuthHeaders()
     });
     return response.data;
 };
@@ -103,7 +119,9 @@ export const addtherapySell = async (data: {
     staffId: string;
     saleCategory: string;
 }) => {
-    return axios.post(`${API_URL}/add-sale`, data);
+    return axios.post(`${API_URL}/add-sale`, data, {
+        headers: getAuthHeaders()
+    });
 };
 
 export const updatetherapySell = async (
@@ -120,22 +138,29 @@ export const updatetherapySell = async (
         saleCategory: string;
     }
 ) => {
-    return axios.put(`${API_URL}/sale/${saleId}`, data);
+    return axios.put(`${API_URL}/sale/${saleId}`, data, {
+        headers: getAuthHeaders()
+    });
 };
 
 export const deletetherapySell = async (saleId: number) => {
-    return axios.delete(`${API_URL}/sale/${saleId}`);
+    return axios.delete(`${API_URL}/sale/${saleId}`, {
+        headers: getAuthHeaders()
+    });
 };
 
 export const exporttherapySells = async () => {
     const response = await axios.get(`${API_URL}/sale/export`, {
-        responseType: "blob"
+        responseType: "blob",
+        headers: getAuthHeaders()
     });
     return response.data;
-}; 
+};
 
 export const getAllTherapiesForDropdown = async () => {
-    const response = await axios.get(`${API_URL}/for-dropdown`);
+    const response = await axios.get(`${API_URL}/for-dropdown`, {
+        headers: getAuthHeaders()
+    });
     return response.data;
 };
 

--- a/server/app/utils.py
+++ b/server/app/utils.py
@@ -19,8 +19,9 @@ def get_store_based_where_condition(table_alias=None):
     if permission == 'admin':
         return ("", [])
 
-    if permission == 'basic' and store_id:
+    # Treat therapists like basic users: allow access to their own store's data
+    if permission in ('basic', 'therapist') and store_id:
         field = f"{table_alias}.store_id" if table_alias else "store_id"
         return (f" AND {field} = %s ", [store_id])
-    
+
     return (" AND 1=0 ", [])


### PR DESCRIPTION
## Summary
- Allow `therapist` role to view store-scoped data
- Make inventory rows clickable to select entries for deletion
- Attach auth headers to therapy services so therapists can load therapy records

## Testing
- `pytest server/test_therapy_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b04854c9f48329926da8356c033401