### PR TITLE
Highlight password reset requests in user account management

### DIFF
--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -2,9 +2,6 @@ import React, { useState } from "react";
 import { Container, Form, Button, Alert, Spinner } from "react-bootstrap";
 import { forgotPassword } from "../services/LoginService";
 import { useNavigate } from "react-router-dom";
-import { base_url } from "../services/BASE_URL";
-
-const API_URL = `${base_url}/auth`;
 
 const ForgotPassword: React.FC = () => {
   const navigate = useNavigate();
@@ -42,25 +39,12 @@ const ForgotPassword: React.FC = () => {
 
     setIsLoading(true);
     try {
-      await forgotPassword(account);
-      
-      // 由於後端直接返回 token，我們需要模擬一個請求來獲取 token
-      // 實際應用中，這個 token 應該由後端通過郵件發送給用戶
-      const mockRequest = await fetch(`${API_URL}/forgot-password`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ account }),
-      });
-      
-      const result = await mockRequest.json();
-      
+      const result = await forgotPassword(account);
+
       setAlertMsg("重設密碼連結已產生，請前往重設密碼");
       setAlertVariant("success");
       setResetToken(result.token);
       setIsTokenReceived(true);
-
     } catch (err: any) {
       const msg = err.response?.data?.error || "請求失敗，請稍後再試";
       setAlertMsg(msg);

--- a/client/src/pages/backend/UserAccountManagement.tsx
+++ b/client/src/pages/backend/UserAccountManagement.tsx
@@ -110,15 +110,16 @@ const UserAccountManagement: React.FC = () => {
                         <th>帳號</th>
                         <th>權限</th>
                         <th>密碼</th>
+                        <th>備註</th>
                     </tr>
                 </thead>
                 <tbody>
                     {loading ? (
-                        <tr><td colSpan={7} className="text-center py-5"><Spinner animation="border" /></td></tr>
+                        <tr><td colSpan={8} className="text-center py-5"><Spinner animation="border" /></td></tr>
                     ) : accounts.length === 0 ? (
-                        <tr><td colSpan={7} className="text-center text-muted py-5">尚無資料</td></tr>
+                        <tr><td colSpan={8} className="text-center text-muted py-5">尚無資料</td></tr>
                     ) : accounts.map(acc => (
-                        <tr key={acc.staff_id}>
+                        <tr key={acc.staff_id} className={acc.reset_requested ? 'table-warning' : ''}>
                             <td className="text-center align-middle"><Form.Check type="checkbox" checked={selectedIds.includes(acc.staff_id)} onChange={e => handleCheckboxChange(acc.staff_id, e.target.checked)} /></td>
                             <td className="align-middle">{acc.name}</td>
                             <td className="align-middle">{acc.phone || '-'}</td>
@@ -126,6 +127,7 @@ const UserAccountManagement: React.FC = () => {
                             <td className="align-middle">{acc.account || '-'}</td>
                             <td className="align-middle">{acc.permission ? PERMISSION_LABELS[acc.permission] || acc.permission : '-'}</td>
                             <td className="align-middle">{'******'}</td>
+                            <td className="align-middle text-danger">{acc.reset_requested ? '此員工已申請密碼重設' : '-'}</td>
                         </tr>
                     ))}
                 </tbody>

--- a/client/src/services/StaffService.ts
+++ b/client/src/services/StaffService.ts
@@ -272,6 +272,7 @@ export interface StaffAccount {
     store_id?: number;
     store_name?: string;
     permission?: string;
+    reset_requested?: boolean;
 }
 
 // 2. 新增：分店列表的介面 (保持不變)


### PR DESCRIPTION
## Summary
- Track password reset requests on the server and clear them after reset
- Surface reset request flag through staff account API and client service
- Highlight accounts requesting password reset with warning styling and message
- Fix forgot password flow by removing extra fetch and using service response

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68b049f0de908329a2fe7aa77a5d4e4f