### PR TITLE
Add export endpoints and tests for reports

### DIFF
--- a/client/src/hooks/useStressTest.ts
+++ b/client/src/hooks/useStressTest.ts
@@ -1,6 +1,7 @@
 // ./src/hooks/useStressTest.ts
 import { useState, useEffect, useCallback } from 'react';
-import { getAllStressTests, deleteStressTest, StressTestData } from '../services/StressTestService';
+import { getAllStressTests, deleteStressTest, exportStressTests, StressTestData } from '../services/StressTestService';
+import { downloadBlob } from '../utils/downloadBlob';
 
 interface StressTest {
   ipn_stress_id: number;
@@ -84,6 +85,19 @@ export const useStressTest = () => {
     }
   }, [selectedTests, fetchTests]);
 
+  const handleExport = useCallback(async () => {
+    try {
+      setLoading(true);
+      const blob = await exportStressTests();
+      downloadBlob(blob, "壓力測試.xlsx");
+    } catch (error) {
+      console.error('Error exporting stress tests:', error);
+      alert('匯出報表失敗！');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   return {
     tests,
     selectedTests,
@@ -91,7 +105,8 @@ export const useStressTest = () => {
     fetchTests,
     handleSearch,
     handleCheckboxChange,
-    handleDelete
+    handleDelete,
+    handleExport
   };
 };
 

--- a/client/src/pages/finance/SalesOrderList.tsx
+++ b/client/src/pages/finance/SalesOrderList.tsx
@@ -5,8 +5,9 @@ import { useNavigate } from 'react-router-dom';
 import Header from '../../components/Header';
 import DynamicContainer from '../../components/DynamicContainer';
 import ScrollableTable from '../../components/ScrollableTable';
-import { SalesOrderListRow, getSalesOrders, deleteSalesOrders } from '../../services/SalesOrderService';
+import { SalesOrderListRow, getSalesOrders, deleteSalesOrders, exportSalesOrders } from '../../services/SalesOrderService';
 import { formatCurrency } from '../../utils/productSellUtils'; // 借用金額格式化工具
+import { downloadBlob } from '../../utils/downloadBlob';
 
 const SalesOrderList: React.FC = () => {
     const navigate = useNavigate();
@@ -34,6 +35,18 @@ const SalesOrderList: React.FC = () => {
     }, [fetchData]);
 
     const handleSearch = () => fetchData(keyword);
+    const handleExport = async () => {
+        try {
+            setLoading(true);
+            const blob = await exportSalesOrders();
+            downloadBlob(blob, `銷售單列表_${new Date().toISOString().split('T')[0]}.xlsx`);
+        } catch (err: any) {
+            console.error('匯出銷售單失敗：', err);
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
     const handleDelete = async () => {
         if (selectedIds.length === 0) return;
         if (window.confirm(`確定要刪除選中的 ${selectedIds.length} 筆銷售單嗎？`)) {
@@ -103,7 +116,7 @@ const SalesOrderList: React.FC = () => {
 
             <Container className="my-4">
                 <Row className="justify-content-end g-2">
-                    <Col xs="auto"><Button variant="info" className="text-white" disabled={true}>報表匯出</Button></Col>
+                    <Col xs="auto"><Button variant="info" className="text-white" onClick={handleExport} disabled={loading}>報表匯出</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={handleDelete} disabled={loading || selectedIds.length === 0}>刪除</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={() => navigate(`/finance/sales/add?order_id=${selectedIds[0]}`)} disabled={loading || selectedIds.length !== 1}>修改</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={() => navigate("/finance")}>確認</Button></Col>

--- a/client/src/pages/health/stress_test/StressTest.tsx
+++ b/client/src/pages/health/stress_test/StressTest.tsx
@@ -32,7 +32,8 @@ const StressTest: React.FC = () => {
     loading,
     handleSearch,
     handleCheckboxChange,
-    handleDelete
+    handleDelete,
+    handleExport
   } = useStressTest();
 
   // 智慧搜尋邏輯
@@ -187,7 +188,7 @@ const StressTest: React.FC = () => {
       <div className="button-area">
         <Row className="justify-content-end g-3">
           <Col xs="auto">
-            <Button variant="info" className="text-white px-4" disabled={loading || selectedTests.length === 0}>
+            <Button variant="info" className="text-white px-4" onClick={handleExport} disabled={loading}>
               報表匯出
             </Button>
           </Col>

--- a/client/src/services/SalesOrderService.ts
+++ b/client/src/services/SalesOrderService.ts
@@ -96,6 +96,11 @@ export const deleteSalesOrders = async (ids: number[]): Promise<{success: boolea
         throw new Error(error.response?.data?.error || "刪除銷售單時發生錯誤");
     }
 };
+
+export const exportSalesOrders = async (): Promise<Blob> => {
+    const response = await axios.get(`${API_URL}/export`, { responseType: 'blob' });
+    return response.data;
+};
 export interface SalesOrderDetail {
     order_id: number;
     order_number: string;

--- a/client/src/services/StressTestService.ts
+++ b/client/src/services/StressTestService.ts
@@ -75,6 +75,17 @@ export const deleteStressTest = async (stressId: number) => {
     return axios.delete(`${API_URL}/${stressId}`);
 };
 
+export const exportStressTests = async (filters?: StressTestSearchFilters) => {
+    const filtered = Object.fromEntries(
+        Object.entries(filters || {}).filter(([k, v]) => v !== undefined && v !== null && v !== "")
+    );
+    const response = await axios.get(`${API_URL}/export`, {
+        params: filtered,
+        responseType: 'blob'
+    });
+    return response.data;
+};
+
 // 取得單筆（含所有答案）
 export const getStressTestByIdWithAnswers = async (id: string | number) => {
     // 後端已經改好 /api/stress-test/<id> 會帶 answers

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -168,7 +168,7 @@ def export_members():
         df = pd.DataFrame(members)
         
         column_mapping = {
-            'member_id': '會員編號', 'member_code': '會員編號', 'name': '姓名',
+            'member_id': '會員ID', 'member_code': '會員編號', 'name': '姓名',
             'birthday': '生日', 'address': '地址', 'phone': '電話', 'gender': '性別',
             'blood_type': '血型', 'line_id': 'Line ID', 'inferrer_id': '推薦人編號',
             'occupation': '職業', 'note': '備註', 'store_id': '所屬分店ID'

--- a/server/tests/test_export_routes.py
+++ b/server/tests/test_export_routes.py
@@ -1,0 +1,91 @@
+import io
+import os
+import sys
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app import create_app
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def auth_headers():
+    return {
+        'X-Store-ID': '1',
+        'X-Store-Level': 'admin'
+    }
+
+def test_member_export(client, monkeypatch):
+    sample = [{
+        'member_id': 1,
+        'member_code': 'M001',
+        'name': 'Alice',
+        'birthday': '1990-01-01',
+        'address': 'addr',
+        'phone': '123',
+        'gender': '女',
+        'blood_type': 'A',
+        'line_id': 'line',
+        'inferrer_id': None,
+        'occupation': 'engineer',
+        'note': '',
+        'store_id': 1
+    }]
+    monkeypatch.setattr('app.routes.member.get_all_members', lambda store_level, store_id: sample)
+    rv = client.get('/api/member/export', headers=auth_headers())
+    assert rv.status_code == 200
+    assert rv.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+def test_stress_test_export(client, monkeypatch):
+    sample = [{
+        'ipn_stress_id': 1,
+        'member_code': 'M001',
+        'Name': 'Alice',
+        'position': '職員',
+        'a_score': 1,
+        'b_score': 2,
+        'c_score': 3,
+        'd_score': 4,
+        'total_score': 10,
+        'test_date': '2024-01-01'
+    }]
+    monkeypatch.setattr('app.routes.stress_test.get_all_stress_tests', lambda level, store_id, filters: sample)
+    rv = client.get('/api/stress-test/export', headers=auth_headers())
+    assert rv.status_code == 200
+    assert rv.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+def test_therapy_record_export(client, monkeypatch):
+    sample = [{
+        'therapy_record_id': 1,
+        'member_code': 'M001',
+        'member_name': 'Alice',
+        'store_name': 'Store',
+        'staff_name': 'Bob',
+        'date': '2024-01-01',
+        'note': ''
+    }]
+    monkeypatch.setattr('app.routes.therapy.export_therapy_records', lambda store_id: sample)
+    rv = client.get('/api/therapy/record/export', headers=auth_headers())
+    assert rv.status_code == 200
+    assert rv.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+def test_sales_order_export(client, monkeypatch):
+    sample = [{
+        'order_id': 1,
+        'order_number': 'SO1',
+        'order_date': '2024-01-01',
+        'grand_total': 100,
+        'sale_category': 'P',
+        'note': '',
+        'member_name': 'Alice',
+        'staff_name': 'Bob'
+    }]
+    monkeypatch.setattr('app.routes.sales_order_routes.get_all_sales_orders', lambda keyword=None: {'success': True, 'data': sample})
+    rv = client.get('/api/sales-orders/export', headers=auth_headers())
+    assert rv.status_code == 200
+    assert rv.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'


### PR DESCRIPTION
## Summary
- implement Excel export for stress test records and sales orders
- fix member export column names to avoid duplicates
- add tests covering member, stress test, therapy record, and sales order exports
- wire front-end buttons to export stress tests and sales orders without requiring selections

## Testing
- `pytest server/tests/test_export_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b054014d2c8329a6832c7f75bb6506