### PR TITLE
Fix therapy export date formatting to avoid report failure

### DIFF
--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -1,4 +1,5 @@
 import pymysql
+from datetime import date, datetime
 from app.config import DB_CONFIG
 from app.utils import get_store_based_where_condition
 
@@ -347,11 +348,11 @@ def export_therapy_records(store_id=None):
                 cursor.execute(query)
                 
             result = cursor.fetchall()
-            
-            # 處理日期格式
+
+            # 處理日期格式，將 datetime 物件轉為字串
             for record in result:
-                if record.get('日期'):
-                    record['日期'] = record['日期'].strftime('%Y-%m-%d')
+                if record.get('date') and isinstance(record['date'], (date, datetime)):
+                    record['date'] = record['date'].strftime('%Y-%m-%d')
                     
         return result
     except Exception as e:

--- a/server/tests/test_export_routes.py
+++ b/server/tests/test_export_routes.py
@@ -3,6 +3,7 @@ import os
 import sys
 import pandas as pd
 import pytest
+from datetime import date
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import create_app
@@ -66,7 +67,7 @@ def test_therapy_record_export(client, monkeypatch):
         'member_name': 'Alice',
         'store_name': 'Store',
         'staff_name': 'Bob',
-        'date': '2024-01-01',
+        'date': date(2024, 1, 1),
         'note': ''
     }]
     monkeypatch.setattr('app.routes.therapy.export_therapy_records', lambda store_id: sample)


### PR DESCRIPTION
## Summary
- normalize therapy record export dates to string format
- test therapy export using actual date objects

## Testing
- `python -m pytest tests/test_export_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b076a9e57483298e19414824381210