### PR TITLE
Fix cascade deletion for members and stress tests

### DIFF
--- a/server/app/models/member_model.py
+++ b/server/app/models/member_model.py
@@ -136,7 +136,7 @@ def delete_member_and_related_data(member_id: int):
             # 關聯表列表 (直接以 member_id 關聯)
             related_tables = [
                 "product_sell", "therapy_sell", "therapy_record", "ipn_pure",
-                "ipn_stress", "medical_record", "usual_sympton_and_family_history"
+                "ipn_stress", "medical_record", "health_status", "usual_sympton_and_family_history"
             ]
             for table in related_tables:
                 cursor.execute(f"DELETE FROM `{table}` WHERE member_id = %s", (member_id,))

--- a/server/app/models/stress_test_model.py
+++ b/server/app/models/stress_test_model.py
@@ -229,6 +229,7 @@ def delete_stress_test(stress_id):
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
+            cursor.execute("DELETE FROM ipn_stress_answer WHERE ipn_stress_id = %s", (stress_id,))
             cursor.execute("DELETE FROM ipn_stress WHERE ipn_stress_id = %s", (stress_id,))
         conn.commit()
         return True

--- a/server/tests/test_deletion_integrity.py
+++ b/server/tests/test_deletion_integrity.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import pytest
+import importlib.util
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str):
+    """Load a module from a relative file path without importing the package"""
+    module_path = BASE_DIR / relative_path
+    spec = importlib.util.spec_from_file_location(relative_path, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def stub_app_module(monkeypatch):
+    import types
+
+    app_module = types.ModuleType("app")
+    config_module = types.ModuleType("app.config")
+    config_module.DB_CONFIG = {}
+
+    sys.modules["app"] = app_module
+    sys.modules["app.config"] = config_module
+    yield
+    sys.modules.pop("app.config", None)
+    sys.modules.pop("app", None)
+
+
+class FakeCursor:
+    def __init__(self):
+        self.queries = []
+
+    def execute(self, sql, params=None):
+        self.queries.append(sql.strip())
+        # 模擬刪除成功
+        return 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeConnection:
+    def __init__(self):
+        self.cursor_obj = FakeCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+    def begin(self):
+        pass
+
+
+def test_delete_member_removes_health_status(monkeypatch):
+    member_model = load_module("app/models/member_model.py")
+
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(member_model, "connect_to_db", lambda: fake_conn)
+
+    member_model.delete_member_and_related_data(1)
+
+    queries = fake_conn.cursor_obj.queries
+    assert any("FROM `health_status`" in q for q in queries), "health_status table not cleared"
+
+
+def test_delete_stress_test_cascades_answers(monkeypatch):
+    stress_test_model = load_module("app/models/stress_test_model.py")
+
+    fake_conn = FakeConnection()
+    monkeypatch.setattr(stress_test_model, "connect_to_db", lambda: fake_conn)
+
+    stress_test_model.delete_stress_test(1)
+
+    queries = fake_conn.cursor_obj.queries
+    assert queries[0].startswith("DELETE FROM ipn_stress_answer"), "answers not removed first"
+    assert queries[1].startswith("DELETE FROM ipn_stress"), "stress record not deleted"
+


### PR DESCRIPTION
## Summary
- ensure member deletion removes health_status records
- cascade delete stress test answers before removing stress test
- add unit tests for deletion logic

## Testing
- `pytest tests/test_deletion_integrity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b076cf9a7883299b0418d2770480ae