### PR TITLE
Fix therapy export date formatting and store name query

### DIFF
--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -1,4 +1,5 @@
 import pymysql
+from datetime import date, datetime
 from app.config import DB_CONFIG
 from app.utils import get_store_based_where_condition
 
@@ -316,7 +317,7 @@ def export_therapy_records(store_id=None):
                            m.member_id,
                            m.member_code,
                            m.name as member_name,
-                           s.name as store_name,
+                           s.store_name as store_name,
                            st.name as staff_name,
                            tr.date,
                            tr.note
@@ -334,7 +335,7 @@ def export_therapy_records(store_id=None):
                            m.member_id,
                            m.member_code,
                            m.name as member_name,
-                           s.name as store_name,
+                           s.store_name as store_name,
                            st.name as staff_name,
                            tr.date,
                            tr.note
@@ -347,11 +348,11 @@ def export_therapy_records(store_id=None):
                 cursor.execute(query)
                 
             result = cursor.fetchall()
-            
-            # 處理日期格式
+
+            # 處理日期格式，將 datetime 物件轉為字串
             for record in result:
-                if record.get('日期'):
-                    record['日期'] = record['日期'].strftime('%Y-%m-%d')
+                if record.get('date') and isinstance(record['date'], (date, datetime)):
+                    record['date'] = record['date'].strftime('%Y-%m-%d')
                     
         return result
     except Exception as e:

--- a/server/tests/test_export_routes.py
+++ b/server/tests/test_export_routes.py
@@ -1,8 +1,8 @@
 import io
 import os
 import sys
-import pandas as pd
 import pytest
+from datetime import date
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import create_app
@@ -66,7 +66,7 @@ def test_therapy_record_export(client, monkeypatch):
         'member_name': 'Alice',
         'store_name': 'Store',
         'staff_name': 'Bob',
-        'date': '2024-01-01',
+        'date': date(2024, 1, 1),
         'note': ''
     }]
     monkeypatch.setattr('app.routes.therapy.export_therapy_records', lambda store_id: sample)

--- a/server/tests/test_therapy_model.py
+++ b/server/tests/test_therapy_model.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app.models import therapy_model
+
+
+def test_export_therapy_records_queries_use_store_name(monkeypatch):
+    queries = []
+
+    class DummyCursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, query, params=None):
+            queries.append(query)
+
+        def fetchall(self):
+            return []
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+        def close(self):
+            pass
+
+    # Without store filter
+    monkeypatch.setattr(therapy_model, 'connect_to_db', lambda: DummyConn())
+    therapy_model.export_therapy_records()
+
+    # With store filter
+    monkeypatch.setattr(therapy_model, 'connect_to_db', lambda: DummyConn())
+    therapy_model.export_therapy_records(store_id=1)
+
+    assert 's.store_name as store_name' in queries[0].lower()
+    assert 's.store_name as store_name' in queries[1].lower()


### PR DESCRIPTION
## Summary
- normalize therapy record export dates to string format
- test therapy export using actual date objects
- ensure therapy export query selects `store_name`
- add regression test verifying query uses store_name column

## Testing
- `pytest server/tests/test_export_routes.py server/tests/test_therapy_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b076a9e57483298e19414824381210