### PR TITLE
feat: add export for account management

### DIFF
--- a/client/src/pages/backend/UserAccountManagement.tsx
+++ b/client/src/pages/backend/UserAccountManagement.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Container, Row, Col, Form, Button, Table, Spinner, Alert } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
-import { getStaffAccounts, deleteMultipleStaff, StaffAccount } from '../../services/StaffService';
+import { getStaffAccounts, deleteMultipleStaff, StaffAccount, exportStaffAccounts, exportSelectedStaffAccounts } from '../../services/StaffService';
 import Header from '../../components/Header'; // 1. 引入 Header
 import DynamicContainer from '../../components/DynamicContainer'; // 2. 引入 DynamicContainer
 
@@ -79,6 +79,43 @@ const UserAccountManagement: React.FC = () => {
         navigate(`/backend/user-accounts/edit/${selectedIds[0]}`);
     };
 
+    const handleExport = async () => {
+        try {
+            setLoading(true);
+            const blob = await exportStaffAccounts(keyword);
+            const url = window.URL.createObjectURL(new Blob([blob]));
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = '員工帳號資料.xlsx';
+            a.click();
+            window.URL.revokeObjectURL(url);
+        } catch (err) {
+            console.error('匯出帳號資料失敗：', err);
+            alert('匯出帳號資料失敗');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleExportSelected = async () => {
+        if (selectedIds.length === 0) return;
+        try {
+            setLoading(true);
+            const blob = await exportSelectedStaffAccounts(selectedIds);
+            const url = window.URL.createObjectURL(new Blob([blob]));
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = '員工帳號資料.xlsx';
+            a.click();
+            window.URL.revokeObjectURL(url);
+        } catch (err) {
+            console.error('匯出勾選帳號資料失敗：', err);
+            alert('匯出帳號資料失敗');
+        } finally {
+            setLoading(false);
+        }
+    };
+
     // 3. 將所有頁面內容都放進一個名為 `content` 的變數中
     const content = (
         <Container fluid className="p-4">
@@ -135,6 +172,8 @@ const UserAccountManagement: React.FC = () => {
                 </tbody>
             </Table>
             <div className="d-flex justify-content-end gap-2 mt-4">
+                <Button variant="info" className="text-white" onClick={handleExport} disabled={loading}>報表匯出</Button>
+                <Button variant="info" className="text-white" onClick={handleExportSelected} disabled={loading || selectedIds.length === 0}>勾選匯出</Button>
                 <Button variant="info" className="text-white" onClick={handleDelete} disabled={selectedIds.length === 0}>刪除</Button>
                 <Button variant="info" className="text-white" onClick={handleEdit} disabled={selectedIds.length !== 1}>修改</Button>
                 <Button variant="info" className="text-white" onClick={() => navigate('/backend')}>確認</Button>

--- a/client/src/services/StaffService.ts
+++ b/client/src/services/StaffService.ts
@@ -347,7 +347,36 @@ export const createStaffAccount = async (data: Partial<StaffAccount>) => {
     }
 };
 
-// 6. 沿用您原有的 getAllStores 函式
+// 6. 新增：匯出員工帳號資料（全部）
+export const exportStaffAccounts = async (keyword?: string) => {
+    try {
+        const response = await axios.get(`${API_URL}/accounts/export`, {
+            responseType: "blob",
+            headers: getAuthHeaders(),
+            params: { keyword: keyword || undefined }
+        });
+        return response.data;
+    } catch (error) {
+        console.error("匯出員工帳號資料失敗:", error);
+        throw error;
+    }
+};
+
+// 7. 新增：匯出勾選的員工帳號資料
+export const exportSelectedStaffAccounts = async (ids: number[]) => {
+    try {
+        const response = await axios.post(`${API_URL}/accounts/export-selected`, { ids }, {
+            responseType: "blob",
+            headers: getAuthHeaders()
+        });
+        return response.data;
+    } catch (error) {
+        console.error("匯出選定員工帳號資料失敗:", error);
+        throw error;
+    }
+};
+
+// 8. 沿用您原有的 getAllStores 函式
 // 為了讓 AddEditUserAccount.tsx 能直接使用，我們做一個簡單的包裝
 export const fetchStoresForDropdown = async (): Promise<Store[]> => {
     try {


### PR DESCRIPTION
## Summary
- add admin export endpoints for account records
- expose account export helpers in StaffService
- allow user account management page to export all or selected rows

## Testing
- `npm run lint` *(fails: Irregular whitespace not allowed)*
- `pytest` *(fails: KeyError: 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b6a521cecc8329a332f64081a90a55