### PR TITLE
Fix therapy record UI and search issues

### DIFF
--- a/client/src/pages/therapy/AddTherapyRecord.tsx
+++ b/client/src/pages/therapy/AddTherapyRecord.tsx
@@ -303,7 +303,7 @@ const AddTherapyRecord: React.FC = () => {
                     <Button
                         variant="info"
                         className="text-white"
-                        onClick={() => {}}
+                        onClick={() => window.print()}
                         disabled={loading || isFetchingSessions}
                     >
                         列印

--- a/client/src/pages/therapy/TherapyRecord.tsx
+++ b/client/src/pages/therapy/TherapyRecord.tsx
@@ -110,11 +110,11 @@ const TherapyRecord: React.FC = () => {
                             >
                                 <option value="">請選擇方案</option>
                                 {therapyPackages.map((pkg) => (
-                                    <option 
-                                        key={pkg.therapy_id} 
-                                        value={pkg.TherapyCode}
+                                    <option
+                                        key={pkg.therapy_id}
+                                        value={pkg.therapy_id.toString()}
                                     >
-                                        {pkg.TherapyContent}
+                                        {pkg.TherapyName || pkg.TherapyContent}
                                     </option>
                                 ))}
                             </Form.Select>
@@ -295,15 +295,6 @@ const TherapyRecord: React.FC = () => {
                             disabled={loading || selectedIds.length !== 1}
                         >
                             修改
-                        </Button>
-                    </Col>
-                    <Col xs="auto">
-                        <Button
-                            variant="info"
-                            className="text-white px-4"
-                            onClick={() => navigate(-1)}
-                        >
-                            確認
                         </Button>
                     </Col>
                 </Row>

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -426,7 +426,8 @@ export const searchMemberById = async (memberId: string): Promise<Member[]> => {
 // vvvv 新增這個函式 vvvv
 export const fetchRemainingSessions = async (memberId: string, therapyId: string) => {
     const response = await axios.get(`${API_URL}/remaining-sessions`, {
-        params: { member_id: memberId, therapy_id: therapyId }
+        params: { member_id: memberId, therapy_id: therapyId },
+        headers: getAuthHeaders()
     });
     return response.data;
 };
@@ -435,9 +436,13 @@ export const fetchRemainingSessionsBulk = async (
     memberId: string,
     therapyIds: number[]
 ) => {
-    const response = await axios.post(`${API_URL}/remaining-sessions/bulk`, {
-        member_id: memberId,
-        therapy_ids: therapyIds,
-    });
+    const response = await axios.post(
+        `${API_URL}/remaining-sessions/bulk`,
+        {
+            member_id: memberId,
+            therapy_ids: therapyIds,
+        },
+        { headers: getAuthHeaders() }
+    );
     return response.data;
 };

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -137,7 +137,7 @@ def search_therapy_records(filters):
 
             if filters.get('endDate'):
                 sql += " AND tr.date <= %s"
-                sql_params.append(params['endDate'])
+                sql_params.append(filters['endDate'])
 
             if filters.get('therapist'):
                 sql += " AND tr.staff_id = %s"


### PR DESCRIPTION
## Summary
- populate therapy options after authentication
- allow date-range searches for therapy records
- remove outdated confirm button and enable printing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors)*
- `pytest server/tests/test_therapy_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a598fad48329903c69b2b69bf99f