### PR TITLE
Remove confirm button and show store name in member export

### DIFF
--- a/client/src/pages/member/MemberInfo.tsx
+++ b/client/src/pages/member/MemberInfo.tsx
@@ -164,11 +164,6 @@ const MemberInfo: React.FC = () => {
                         </Button>
                         {/* ***** 結束修改 ***** */}
                     </Col>
-                    <Col xs="auto">
-                        <Button variant="info" className="text-white" onClick={() => navigate(-1)}>
-                            確認
-                        </Button>
-                    </Col>
                 </Row>
             </Container>
         </div>

--- a/server/tests/test_export_routes.py
+++ b/server/tests/test_export_routes.py
@@ -38,6 +38,7 @@ def test_member_export(client, monkeypatch):
         'store_id': 1
     }]
     monkeypatch.setattr('app.routes.member.get_all_members', lambda store_level, store_id: sample)
+    monkeypatch.setattr('app.routes.member.get_all_stores', lambda: [{'store_id': 1, 'store_name': '總部'}])
     rv = client.get('/api/member/export', headers=auth_headers())
     assert rv.status_code == 200
     assert rv.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'


### PR DESCRIPTION
## Summary
- remove unused confirm button from member info page
- show store names instead of IDs in member export
- update export tests to mock store lookup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `pytest` *(fails: KeyError: 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b6a5536a6083299521653283c2f8b4