### PR TITLE
fix: improve staff account search and remove confirm

### DIFF
--- a/client/src/pages/backend/UserAccountManagement.tsx
+++ b/client/src/pages/backend/UserAccountManagement.tsx
@@ -176,7 +176,6 @@ const UserAccountManagement: React.FC = () => {
                 <Button variant="info" className="text-white" onClick={handleExportSelected} disabled={loading || selectedIds.length === 0}>勾選匯出</Button>
                 <Button variant="info" className="text-white" onClick={handleDelete} disabled={selectedIds.length === 0}>刪除</Button>
                 <Button variant="info" className="text-white" onClick={handleEdit} disabled={selectedIds.length !== 1}>修改</Button>
-                <Button variant="info" className="text-white" onClick={() => navigate('/backend')}>確認</Button>
             </div>
         </Container>
     );

--- a/server/app/models/staff_model.py
+++ b/server/app/models/staff_model.py
@@ -823,10 +823,10 @@ def search_staff_with_accounts(keyword):
             SELECT s.staff_id, s.name, s.phone, s.account, s.password, s.permission, s.reset_requested, st.store_name
             FROM staff s
             LEFT JOIN store st ON s.store_id = st.store_id
-            WHERE s.name LIKE %s OR s.phone LIKE %s OR s.account LIKE %s
+            WHERE s.name LIKE %s OR s.phone LIKE %s OR s.account LIKE %s OR CAST(s.staff_id AS CHAR) LIKE %s
             ORDER BY s.staff_id DESC
             """
-            cursor.execute(query, (like_keyword, like_keyword, like_keyword))
+            cursor.execute(query, (like_keyword, like_keyword, like_keyword, like_keyword))
             return cursor.fetchall()
     finally:
         if conn:


### PR DESCRIPTION
## Summary
- show store info next to staff ID in user account list
- search staff accounts by ID
- remove unnecessary confirm button

## Testing
- `PYENV_VERSION=3.11.12 pytest` *(fails: KeyError 'app')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6aacf8da48329aefc5dafb599b889