### PR TITLE
Fix missing member code in medical record edit form

### DIFF
--- a/client/src/pages/medical_record/AddMedicalRecord.tsx
+++ b/client/src/pages/medical_record/AddMedicalRecord.tsx
@@ -47,6 +47,7 @@ const AddMedicalRecord = () => {
                         <MemberColumn
                             memberCode={form.memberCode}
                             name={form.name}
+                            isEditMode={isEditMode}
                             onMemberChange={handleMemberChange}
                             onError={setError}
                         />

--- a/server/app/models/medical_record_model.py
+++ b/server/app/models/medical_record_model.py
@@ -121,6 +121,8 @@ def format_record_for_edit(record: dict):
         record['bloodPressure'] = record.pop('blood_preasure', None)
         record['cosmeticSurgery'] = record.pop('cosmetic_surgery', 'No')
         record['cosmeticDesc'] = record.pop('micro_surgery_description', None)
+        # 將 member_code 轉換為前端使用的 camelCase
+        record['memberCode'] = record.pop('member_code', None)
         
         # 將產生的新欄位加入 record 中
         record['symptom'] = symptom


### PR DESCRIPTION
## Summary
- Ensure editing a medical record pre-fills member code by returning `memberCode` from API
- Pass edit mode flag to member input to keep field locked during updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `npm run lint` *(fails: Irregular whitespace not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6acfbe34c8329b3ba492570062f11