### PR TITLE
Deduplicate store list in fetchAllStores

### DIFF
--- a/client/src/services/StoreService.ts
+++ b/client/src/services/StoreService.ts
@@ -26,7 +26,12 @@ export const fetchAllStores = async (): Promise<Store[]> => {
         const response = await axios.get(`${API_URL}/list`, {
             headers: getAuthHeaders()
         });
-        return response.data;
+        // 去除重複分店（依據 store_id）
+        const stores: Store[] = response.data;
+        const uniqueStores = Array.from(
+            new Map(stores.map(s => [s.store_id, s])).values()
+        );
+        return uniqueStores;
     } catch (error: any) {
         console.error("獲取分店列表失敗:", error);
         throw error;


### PR DESCRIPTION
## Summary
- remove duplicate stores from `fetchAllStores` so each branch appears once in dropdowns

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: multiple lint errors)
- `pytest` (fails: ModuleNotFoundError: No module named 'app')

------
https://chatgpt.com/codex/tasks/task_e_68b6bca85d4c8329bec3ee80577b02a7