### PR TITLE
chore: rename member code labels

### DIFF
--- a/client/src/pages/member/MemberInfo.tsx
+++ b/client/src/pages/member/MemberInfo.tsx
@@ -30,7 +30,7 @@ const MemberInfo: React.FC = () => {
         <tr>
             <th style={{ width: '50px' }}>勾選</th>
             <th>姓名</th>
-            <th>編號</th>
+            <th>會員編號</th>
             <th>生日</th>
             <th>年齡</th>
             <th>住址</th>
@@ -98,7 +98,7 @@ const MemberInfo: React.FC = () => {
                     <Col xs={12} md={6} className="mb-3 mb-md-0">
                         <Form.Control
                             type="text"
-                            placeholder="姓名/電話/編號"
+                            placeholder="姓名/電話/會員編號"
                             value={keyword}
                             onChange={(e) => setKeyword(e.target.value)}
                             onKeyPress={(e) => e.key === 'Enter' && handleSearch()}


### PR DESCRIPTION
## Summary
- rename search placeholder and table header from `編號` to `會員編號` on the member info page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 547 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f994fe3c832996b365683b5c270a