### PR TITLE
Handle empty bundle sales

### DIFF
--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -341,7 +341,7 @@ CREATE TABLE `product_sell` (
   `member_id` int NOT NULL,
   `staff_id` int DEFAULT NULL,
   `store_id` int NOT NULL,
-  `product_id` int NOT NULL,
+  `product_id` int DEFAULT NULL,
   `date` date NOT NULL,
   `quantity` int NOT NULL,
   `unit_price` decimal(10,2) NOT NULL,


### PR DESCRIPTION
## Summary
- record sales for bundles even when no product items are present
- allow product_sell.product_id to be NULL in schema

## Testing
- `python -m pytest` *(fails: requests.exceptions.ConnectionError, KeyError: 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b70b103cf08329844fcb967228aac3