### PR TITLE
Ensure therapy selection uses numeric IDs

### DIFF
--- a/client/src/pages/therapy/AddTherapyRecord.tsx
+++ b/client/src/pages/therapy/AddTherapyRecord.tsx
@@ -65,7 +65,13 @@ const AddTherapyRecord: React.FC = () => {
                 ]);
 
                 setStaffList(Array.isArray(staffData) ? staffData : []);
-                setAllTherapyList(Array.isArray(therapyData) ? therapyData : []);
+                const normalizedTherapies = Array.isArray(therapyData)
+                    ? therapyData.map((t: any) => ({
+                        ...t,
+                        therapy_id: Number(t.therapy_id),
+                    }))
+                    : [];
+                setAllTherapyList(normalizedTherapies);
 
                 if (recordId) {
                     const record = await getTherapyRecordById(recordId);
@@ -109,8 +115,8 @@ const AddTherapyRecord: React.FC = () => {
             }
 
             const therapyIds = allTherapyList
-                .map((t) => t.therapy_id)
-                .filter((id): id is number => typeof id === 'number');
+                .map((t) => Number(t.therapy_id))
+                .filter((id) => !isNaN(id));
             if (therapyIds.length === 0) {
                 setTherapyList([]);
                 return;
@@ -119,9 +125,10 @@ const AddTherapyRecord: React.FC = () => {
             try {
                 const res = await fetchRemainingSessionsBulk(formData.member_id, therapyIds);
                 const remainingMap = res.data || {};
-                const filtered = allTherapyList.filter(
-                    (t) => (remainingMap[t.therapy_id ?? 0] || 0) > 0
-                );
+                const filtered = allTherapyList.filter((t) => {
+                    const tid = Number(t.therapy_id);
+                    return !isNaN(tid) && (remainingMap[tid] || 0) > 0;
+                });
                 setTherapyList(filtered);
                 if (
                     formData.therapy_id &&
@@ -246,7 +253,7 @@ const AddTherapyRecord: React.FC = () => {
                         <Form.Select name="therapy_id" value={formData.therapy_id} onChange={handleChange} required disabled={loading}>
                             <option value="" disabled>{loading ? '載入中...' : '請選擇療程方案'}</option>
                             {therapyList.map((therapy) => (
-                                <option key={therapy.therapy_id} value={therapy.therapy_id}>{therapy.name}</option>
+                                <option key={therapy.therapy_id} value={therapy.therapy_id?.toString()}>{therapy.name}</option>
                             ))}
                         </Form.Select>
                     </Form.Group>

--- a/client/src/pages/therapy/TherapyPackageSelection.tsx
+++ b/client/src/pages/therapy/TherapyPackageSelection.tsx
@@ -88,7 +88,11 @@ const TherapyPackageSelection: React.FC = () => {
 
             let packages: TherapyPackageBaseType[] = [];
             if (therapyRes.success && therapyRes.data) {
-                packages = therapyRes.data.map(p => ({ ...p, type: 'therapy' }));
+                packages = therapyRes.data.map(p => ({
+                    ...p,
+                    type: 'therapy',
+                    therapy_id: Number(p.therapy_id),
+                }));
             }
 
             const bundlePackages: TherapyPackageBaseType[] = bundleData.map((b: Bundle) => ({
@@ -118,14 +122,17 @@ const TherapyPackageSelection: React.FC = () => {
                 return;
             }
             try {
-                const therapyIds = allPackages.filter(p => p.type !== 'bundle' && p.therapy_id)
-                    .map(p => p.therapy_id as number);
+                const therapyIds = allPackages
+                    .filter(p => p.type !== 'bundle' && p.therapy_id !== undefined)
+                    .map(p => Number(p.therapy_id))
+                    .filter(id => !isNaN(id));
                 const res = await fetchRemainingSessionsBulk(memberId, therapyIds);
                 const map = new Map<string, number>();
                 if (res && res.data) {
                     Object.entries(res.data).forEach(([id, remaining]) => {
-                        if (remaining !== undefined) {
-                            map.set(`t-${id}`, Number(remaining as any));
+                        const numericId = Number(id);
+                        if (!isNaN(numericId) && remaining !== undefined) {
+                            map.set(`t-${numericId}`, Number(remaining as any));
                         }
                     });
                 }


### PR DESCRIPTION
## Summary
- Normalize therapy IDs to numbers before fetching remaining sessions
- Filter therapy options using numeric IDs to avoid empty dropdowns

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 561 problems)
- `pytest` (fails: pyenv: version `3.11.3` is not installed)


------
https://chatgpt.com/codex/tasks/task_e_68b71369740483298ba8280a1d14041c