### PR TITLE
Ensure therapy dropdown populates when remaining sessions API returns raw map

### DIFF
--- a/client/src/pages/therapy/AddTherapyRecord.tsx
+++ b/client/src/pages/therapy/AddTherapyRecord.tsx
@@ -124,7 +124,7 @@ const AddTherapyRecord: React.FC = () => {
 
             try {
                 const res = await fetchRemainingSessionsBulk(formData.member_id, therapyIds);
-                const remainingMap = res.data || {};
+                const remainingMap = (res && res.data ? res.data : res) || {};
                 const filtered = allTherapyList.filter((t) => {
                     const tid = Number(t.therapy_id);
                     return !isNaN(tid) && (remainingMap[tid] || 0) > 0;

--- a/client/src/pages/therapy/TherapyPackageSelection.tsx
+++ b/client/src/pages/therapy/TherapyPackageSelection.tsx
@@ -127,15 +127,14 @@ const TherapyPackageSelection: React.FC = () => {
                     .map(p => Number(p.therapy_id))
                     .filter(id => !isNaN(id));
                 const res = await fetchRemainingSessionsBulk(memberId, therapyIds);
+                const dataMap = (res && res.data ? res.data : res) || {};
                 const map = new Map<string, number>();
-                if (res && res.data) {
-                    Object.entries(res.data).forEach(([id, remaining]) => {
-                        const numericId = Number(id);
-                        if (!isNaN(numericId) && remaining !== undefined) {
-                            map.set(`t-${numericId}`, Number(remaining as any));
-                        }
-                    });
-                }
+                Object.entries(dataMap).forEach(([id, remaining]) => {
+                    const numericId = Number(id);
+                    if (!isNaN(numericId) && remaining !== undefined) {
+                        map.set(`t-${numericId}`, Number(remaining as any));
+                    }
+                });
                 setRemainingMap(map);
             } catch (e) {
                 console.error('獲取剩餘堂數失敗', e);


### PR DESCRIPTION
## Summary
- Handle API responses that return remaining sessions directly instead of under a `data` key in AddTherapyRecord and TherapyPackageSelection

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `./venv/bin/python -m pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b717dc59c4832991bc59b45c8c2985