### PR TITLE
fix: improve therapy remaining sessions parsing

### DIFF
--- a/client/src/pages/therapy/AddTherapyRecord.tsx
+++ b/client/src/pages/therapy/AddTherapyRecord.tsx
@@ -116,7 +116,19 @@ const AddTherapyRecord: React.FC = () => {
 
             try {
                 const res = await fetchRemainingSessionsBulk(formData.member_id);
-                const remainingMap = (res && res.data ? res.data : res) || {};
+                const raw = (res && (res as any).data ? (res as any).data : res) || {};
+                let remainingMap: Record<number, number> = {};
+                if (Array.isArray(raw)) {
+                    remainingMap = raw.reduce((acc: Record<number, number>, cur: any) => {
+                        const tid = Number(cur.therapy_id ?? cur.id);
+                        const remain = Number(cur.remaining_sessions ?? cur.remaining);
+                        if (!isNaN(tid) && !isNaN(remain)) acc[tid] = remain;
+                        return acc;
+                    }, {});
+                } else if (raw && typeof raw === 'object') {
+                    remainingMap = raw as Record<number, number>;
+                }
+
                 const filtered = allTherapyList.filter((t) => {
                     const tid = Number(t.therapy_id);
                     return !isNaN(tid) && (remainingMap[tid] || 0) > 0;

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -1,6 +1,7 @@
 // client\src\services\TherapySellService.ts
 import axios from "axios";
 import { base_url } from "./BASE_URL";
+import { getAuthHeaders } from "./AuthUtils";
 
 // API 端點基礎路徑
 const API_URL = `${base_url}/therapy-sell`; // 所有此服務的 API 都基於此路徑


### PR DESCRIPTION
## Summary
- normalize remaining session responses for therapy plan dropdown
- import authentication headers for remaining session lookups

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npm run lint` *(fails: 564 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b7216312408329a5c6edb50321632e