### PR TITLE
Fix member code visibility and date formats

### DIFF
--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -413,7 +413,7 @@ const AddProductSell: React.FC = () => {
           <Col md={6}>
             <Form.Group className="mb-3">
               <Form.Label>購買日期</Form.Label>
-              <Form.Control type="date" value={purchaseDate} max={new Date().toISOString().split("T")[0]} onChange={(e) => setPurchaseDate(e.target.value)} required />
+              <Form.Control type="date" lang="en-CA" value={purchaseDate} max={new Date().toISOString().split("T")[0]} onChange={(e) => setPurchaseDate(e.target.value)} required />
               <Form.Text muted>選擇購買日期。會跳出日曆，無法選取未來日期。</Form.Text>
             </Form.Group>
 

--- a/client/src/pages/product/EditProductSell.tsx
+++ b/client/src/pages/product/EditProductSell.tsx
@@ -13,7 +13,6 @@ import {
 } from "../../services/ProductSellService";
 import { getStoreId } from "../../services/LoginService";
 import { getStaffMembers, StaffMember } from "../../services/TherapyDropdownService";
-import { formatDateToChinese } from "../../utils/memberUtils"; // 用於顯示日期 (如果需要)
 
 // SelectedProduct interface 與 AddProductSell.tsx 保持一致
 interface SelectedProduct {
@@ -395,12 +394,13 @@ const EditProductSell: React.FC = () => {
 
             <Form.Group className="mb-3">
               <Form.Label>購買日期</Form.Label>
-              <Form.Control 
-                type="date" 
-                value={purchaseDate} 
+              <Form.Control
+                type="date"
+                lang="en-CA"
+                value={purchaseDate}
                 max={new Date().toISOString().split("T")[0]}
-                onChange={(e) => setPurchaseDate(e.target.value)} 
-                required 
+                onChange={(e) => setPurchaseDate(e.target.value)}
+                required
               />
               <Form.Text muted>選擇購買日期。會跳出日曆，無法選取未來日期。</Form.Text>
             </Form.Group>

--- a/client/src/pages/product/ProductSell.tsx
+++ b/client/src/pages/product/ProductSell.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import ScrollableTable from "../../components/ScrollableTable";
-import { formatDateToChinese } from "../../utils/memberUtils"; // 假設日期格式化函數適用
+import { formatDateToYYYYMMDD } from "../../utils/dateUtils";
 import { formatCurrency } from "../../utils/productSellUtils"; // formatDiscount 可能不再需要
 import { useProductSell } from "../../hooks/useProductSell";
 import { ProductSell as ProductSellType } from "../../services/ProductSellService"; // 匯入更新後的型別
@@ -141,7 +141,7 @@ const ProductSell: React.FC = () => {
                 </td>
                 <td className="align-middle">{sale.member_code || "-"}</td>
                 <td className="align-middle">{sale.member_name || "-"}</td>
-                <td className="align-middle">{formatDateToChinese(sale.date) || "-"}</td>
+                <td className="align-middle">{formatDateToYYYYMMDD(sale.date) || "-"}</td>
                 <td className="align-middle">{getDisplayName(sale)}</td>
                 <td className="text-center align-middle">{sale.quantity || "-"}</td>
                 <td className="text-end align-middle">

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -119,7 +119,7 @@ const AddTherapySell: React.FC = () => {
         setFormData(prev => ({
           ...prev,
           memberId: editSale.Member_ID?.toString() || "",
-          memberCode: editSale.member_code || "",
+          memberCode: editSale.MemberCode || "",
           staffId: editSale.Staff_ID?.toString() || "",
           date: editSale.PurchaseDate?.split("T")[0] || prev.date,
           paymentMethod: editSale.PaymentMethod || prev.paymentMethod,
@@ -450,7 +450,7 @@ const AddTherapySell: React.FC = () => {
 
                 <Form.Group className="mb-3" controlId="date">
                   <Form.Label>購買日期</Form.Label>
-                  <Form.Control type="date" name="date" value={formData.date} onChange={handleChange} required />
+                  <Form.Control type="date" lang="en-CA" name="date" value={formData.date} onChange={handleChange} required />
                 </Form.Group>
 
                 <Form.Group className="mb-3" controlId="note">

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -11,7 +11,7 @@ import {
     deleteTherapySell,
     // exportTherapySells // Figma 中沒有匯出按鈕，暫時移除或按需保留
 } from "../../services/TherapySellService"; // 假設路徑正確
-import { formatDateToChinese } from "../../utils/memberUtils"; // 假設日期格式化
+import { formatDateToYYYYMMDD } from "../../utils/dateUtils";
 import { formatCurrency } from "../../utils/productSellUtils"; // 借用金額格式化
 import { fetchAllBundles, Bundle } from "../../services/ProductBundleService";
 
@@ -251,7 +251,7 @@ const TherapySell: React.FC = () => {
                 </td>
                 <td className="align-middle">{sale.MemberCode || "-"}</td>
                 <td className="align-middle">{sale.MemberName || "-"}</td>
-                <td className="align-middle">{formatDateToChinese(sale.PurchaseDate) || "-"}</td>
+                <td className="align-middle">{formatDateToYYYYMMDD(sale.PurchaseDate) || "-"}</td>
                 <td className="align-middle">{getDisplayName(sale)}</td>
                 <td className="text-center align-middle">{sale.Sessions || "-"}</td>
                 <td className="text-end align-middle">{formatCurrency(sale.Price) || "-"}</td>


### PR DESCRIPTION
## Summary
- show member code when editing therapy sales
- format therapy/product sale dates as YYYY/MM/DD
- use consistent locale for purchase date inputs

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Irregular whitespace, unused vars)


------
https://chatgpt.com/codex/tasks/task_e_68b853a65a50832987e4d45d767e6313