### PR TITLE
Fix sales order date formatting and editing

### DIFF
--- a/client/src/pages/finance/AddSalesOrder.tsx
+++ b/client/src/pages/finance/AddSalesOrder.tsx
@@ -8,6 +8,7 @@ import { SalesOrderItemData, SalesOrderPayload, addSalesOrder, getSalesOrderById
 import { getAllMembers, Member } from '../../services/MemberService';
 import { getStaffMembers, StaffMember } from '../../services/TherapyDropdownService';
 import { getStoreName } from '../../services/AuthUtils';
+import { formatDateForInput } from '../../utils/dateUtils';
 import './printStyles.css';
 // 假設您有獲取會員、員工、產品、療程的服務
 // import { searchMembers } from '../../services/MemberService';
@@ -148,7 +149,7 @@ const AddSalesOrder: React.FC = () => {
                 try {
                     const detail = await getSalesOrderById(idNum);
                     setOrderNumber(detail.order_number);
-                    setOrderDate(detail.order_date);
+                    setOrderDate(formatDateForInput(detail.order_date));
                     setMemberId(detail.member_id ? String(detail.member_id) : "");
                     setStaffId(detail.staff_id ? String(detail.staff_id) : "");
                     setStoreId(detail.store_id);
@@ -226,7 +227,7 @@ const AddSalesOrder: React.FC = () => {
             }));
             const orderPayload: SalesOrderPayload = {
                 order_number: orderNumber,
-                order_date: orderDate,
+                order_date: formatDateForInput(orderDate),
                 member_id: memberId ? parseInt(memberId) : null,
                 staff_id: staffId ? parseInt(staffId) : null,
                 store_id: storeId ?? 0,

--- a/client/src/pages/finance/SalesOrderList.tsx
+++ b/client/src/pages/finance/SalesOrderList.tsx
@@ -8,6 +8,7 @@ import ScrollableTable from '../../components/ScrollableTable';
 import { SalesOrderListRow, getSalesOrders, deleteSalesOrders, exportSalesOrders, exportSelectedSalesOrders } from '../../services/SalesOrderService';
 import { formatCurrency } from '../../utils/productSellUtils'; // 借用金額格式化工具
 import { downloadBlob } from '../../utils/downloadBlob';
+import { formatDateToYYYYMMDD } from '../../utils/dateUtils';
 
 const SalesOrderList: React.FC = () => {
     const navigate = useNavigate();
@@ -103,7 +104,7 @@ const SalesOrderList: React.FC = () => {
             <tr key={order.order_id}>
                 <td className="text-center"><Form.Check type="checkbox" checked={selectedIds.includes(order.order_id)} onChange={(e) => handleCheckboxChange(order.order_id, e.target.checked)} /></td>
                 <td>{order.order_number}</td>
-                <td>{order.order_date}</td>
+                <td>{formatDateToYYYYMMDD(order.order_date)}</td>
                 <td>{order.member_name || 'N/A'}</td>
                 <td>{order.staff_name || 'N/A'}</td>
                 <td className="text-end">{formatCurrency(order.grand_total)}</td>

--- a/client/src/utils/dateUtils.ts
+++ b/client/src/utils/dateUtils.ts
@@ -31,3 +31,20 @@ export const formatDateToYYYYMMDD = (dateInput: string | Date | null | undefined
     return '-';
   }
 };
+
+/**
+ * 將日期字串或 Date 物件格式化為 HTML `<input type="date">` 可使用的 `YYYY-MM-DD` 格式。
+ * @param dateInput - 可以被 `new Date()` 解析的日期
+ * @returns `YYYY-MM-DD` 格式字串，若輸入無效則回傳空字串
+ */
+export const formatDateForInput = (dateInput: string | Date | null | undefined): string => {
+  if (!dateInput) return '';
+  try {
+    const date = new Date(dateInput);
+    if (isNaN(date.getTime())) return '';
+    return date.toISOString().split('T')[0];
+  } catch (error) {
+    console.error('日期格式化失敗:', error);
+    return '';
+  }
+};


### PR DESCRIPTION
## Summary
- Format sales order list dates as YYYY/MM/DD without time suffix
- Ensure edit page keeps and submits dates in YYYY-MM-DD format to prevent empty date errors
- Add reusable date formatting helper for HTML date inputs

## Testing
- `npm run lint` *(fails: 564 problems across client modules)*
- `pytest` *(fails: missing pandas, requests, openpyxl, jwt dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b853e5195083298430736e77dac054