### PR TITLE
feat: add tabs to product bundle management

### DIFF
--- a/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
+++ b/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
@@ -1,17 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Table, Button, Container, Alert, Spinner, Row, Col } from 'react-bootstrap';
-import { useNavigate } from 'react-router-dom';
+import { Table, Button, Container, Alert, Spinner, Row, Col, Tabs, Tab } from 'react-bootstrap';
 import Header from '../../../components/Header';
 import DynamicContainer from '../../../components/DynamicContainer';
 import BundleCreateModal from './BundleCreateModal';
 import AddTherapyModal from './AddTherapyModal';
 import AddProductModal from './AddProductModal';
-import { fetchAllBundles, deleteBundle, Bundle } from '../../../services/ProductBundleService';
+import { fetchAllBundles, deleteBundle, fetchProductsForDropdown, fetchTherapiesForDropdown, Bundle, Product as ProductItem, Therapy as TherapyItem } from '../../../services/ProductBundleService';
 import { fetchAllStores, Store } from '../../../services/StoreService';
 
 const ProductBundleManagement: React.FC = () => {
     const [bundles, setBundles] = useState<Bundle[]>([]);
-    const [loading, setLoading] = useState(true);
+    const [products, setProducts] = useState<ProductItem[]>([]);
+    const [therapies, setTherapies] = useState<TherapyItem[]>([]);
+    const [bundleLoading, setBundleLoading] = useState(true);
+    const [productLoading, setProductLoading] = useState(true);
+    const [therapyLoading, setTherapyLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
     const [showModal, setShowModal] = useState(false);
@@ -19,24 +22,53 @@ const ProductBundleManagement: React.FC = () => {
     const [showTherapyModal, setShowTherapyModal] = useState(false);
     const [showProductModal, setShowProductModal] = useState(false);
     const [stores, setStores] = useState<Store[]>([]);
-    const navigate = useNavigate();
+    const [activeTab, setActiveTab] = useState<'bundle' | 'product' | 'therapy'>('bundle');
 
     const fetchBundles = useCallback(async () => {
-        setLoading(true);
+        setBundleLoading(true);
         setError(null);
         try {
             const data = await fetchAllBundles();
             setBundles(data);
-        } catch (err: any) {
-            setError(err.response?.data?.error || '無法獲取組合列表');
+        } catch (err: unknown) {
+            const error = err as { response?: { data?: { error?: string } } };
+            setError(error.response?.data?.error || '無法獲取組合列表');
         } finally {
-            setLoading(false);
+            setBundleLoading(false);
+        }
+    }, []);
+
+    const fetchProducts = useCallback(async () => {
+        setProductLoading(true);
+        try {
+            const data = await fetchProductsForDropdown();
+            setProducts(data);
+        } catch (err: unknown) {
+            const error = err as { response?: { data?: { error?: string } } };
+            setError(error.response?.data?.error || '無法獲取產品列表');
+        } finally {
+            setProductLoading(false);
+        }
+    }, []);
+
+    const fetchTherapies = useCallback(async () => {
+        setTherapyLoading(true);
+        try {
+            const data = await fetchTherapiesForDropdown();
+            setTherapies(data);
+        } catch (err: unknown) {
+            const error = err as { response?: { data?: { error?: string } } };
+            setError(error.response?.data?.error || '無法獲取療程列表');
+        } finally {
+            setTherapyLoading(false);
         }
     }, []);
 
     useEffect(() => {
         fetchBundles();
-    }, [fetchBundles]);
+        fetchProducts();
+        fetchTherapies();
+    }, [fetchBundles, fetchProducts, fetchTherapies]);
 
     useEffect(() => {
         fetchAllStores().then(setStores).catch(() => {});
@@ -65,13 +97,23 @@ const ProductBundleManagement: React.FC = () => {
         setShowProductModal(true);
     };
 
+    const handleCloseTherapyModal = () => {
+        setShowTherapyModal(false);
+        fetchTherapies();
+    };
+
+    const handleCloseProductModal = () => {
+        setShowProductModal(false);
+        fetchProducts();
+    };
+
     const handleDelete = async (bundleId: number) => {
         setSuccessMessage(null); // 清除舊的成功訊息
         try {
             await deleteBundle(bundleId);
             setSuccessMessage('刪除成功！');
             fetchBundles(); // 重新載入列表
-        } catch (err) {
+        } catch {
             setError('刪除失敗，請稍後再試。');
         }
         // 讓成功訊息顯示幾秒後自動消失
@@ -115,55 +157,117 @@ const ProductBundleManagement: React.FC = () => {
             {successMessage && <Container><Alert variant="success">{successMessage}</Alert></Container>}
 
             <Container>
-                <Table striped bordered hover responsive>
-                    <thead>
-                        <tr>
-                            <th>編號</th>
-                            <th>項目 (組合名稱)</th>
-                            <th>組合內容</th>
-                            <th>限定分店</th>
-                            <th>售價</th>
-                            <th>操作</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {loading ? (
-                            <tr><td colSpan={5} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
-                        ) : bundles.length > 0 ? (
-                            bundles.map(bundle => (
-                                <tr key={bundle.bundle_id}>
-                                    <td className="align-middle">{bundle.bundle_code}</td>
-                                    <td className="align-middle">{bundle.name}</td>
-                                    <td className="align-middle">{bundle.bundle_contents || '---'}</td>
-                                    <td className="align-middle">{
-                                        bundle.visible_store_ids && bundle.visible_store_ids.length > 0
-                                            ? bundle.visible_store_ids
-                                                .map(id => stores.find(s => s.store_id === id)?.store_name || id)
-                                                .join(', ')
-                                            : '---'
-                                    }</td>
-                                    <td className="align-middle">{`$${Number(bundle.selling_price).toLocaleString()}`}</td>
-                                    <td className="align-middle">
-                                        <Button variant="link" onClick={() => handleShowEditModal(bundle)}>修改</Button>
-                                        <Button 
-                                            variant="link" 
-                                            className="text-danger" 
-                                            onClick={() => {
-                                                if (window.confirm(`確定要刪除「${bundle.name}」嗎？`)) {
-                                                    handleDelete(bundle.bundle_id);
-                                                }
-                                            }}
-                                        >
-                                            刪除
-                                        </Button>
-                                    </td>
-                                </tr>
-                            ))
-                        ) : (
-                            <tr><td colSpan={5} className="text-center text-muted py-5">尚無資料</td></tr>
-                        )}
-                    </tbody>
-                </Table>
+                <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab((k as 'bundle' | 'product' | 'therapy') || 'bundle')} className="mb-3">
+                    <Tab eventKey="bundle" title="組合" />
+                    <Tab eventKey="product" title="產品" />
+                    <Tab eventKey="therapy" title="療程" />
+                </Tabs>
+
+                {activeTab === 'bundle' && (
+                    <Table striped bordered hover responsive>
+                        <thead>
+                            <tr>
+                                <th>編號</th>
+                                <th>項目 (組合名稱)</th>
+                                <th>組合內容</th>
+                                <th>限定分店</th>
+                                <th>售價</th>
+                                <th>操作</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {bundleLoading ? (
+                                <tr><td colSpan={6} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                            ) : bundles.length > 0 ? (
+                                bundles.map(bundle => (
+                                    <tr key={bundle.bundle_id}>
+                                        <td className="align-middle">{bundle.bundle_code}</td>
+                                        <td className="align-middle">{bundle.name}</td>
+                                        <td className="align-middle">{bundle.bundle_contents || '---'}</td>
+                                        <td className="align-middle">{
+                                            bundle.visible_store_ids && bundle.visible_store_ids.length > 0
+                                                ? bundle.visible_store_ids
+                                                    .map(id => stores.find(s => s.store_id === id)?.store_name || id)
+                                                    .join(', ')
+                                                : '---'
+                                        }</td>
+                                        <td className="align-middle">{`$${Number(bundle.selling_price).toLocaleString()}`}</td>
+                                        <td className="align-middle">
+                                            <Button variant="link" onClick={() => handleShowEditModal(bundle)}>修改</Button>
+                                            <Button
+                                                variant="link"
+                                                className="text-danger"
+                                                onClick={() => {
+                                                    if (window.confirm(`確定要刪除「${bundle.name}」嗎？`)) {
+                                                        handleDelete(bundle.bundle_id);
+                                                    }
+                                                }}
+                                            >
+                                                刪除
+                                            </Button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr><td colSpan={6} className="text-center text-muted py-5">尚無資料</td></tr>
+                            )}
+                        </tbody>
+                    </Table>
+                )}
+
+                {activeTab === 'product' && (
+                    <Table striped bordered hover responsive>
+                        <thead>
+                            <tr>
+                                <th>編號</th>
+                                <th>項目名稱</th>
+                                <th>售價</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {productLoading ? (
+                                <tr><td colSpan={3} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                            ) : products.length > 0 ? (
+                                products.map(product => (
+                                    <tr key={product.product_id}>
+                                        <td className="align-middle">{product.product_id}</td>
+                                        <td className="align-middle">{product.product_name}</td>
+                                        <td className="align-middle">{`$${Number(product.product_price).toLocaleString()}`}</td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr><td colSpan={3} className="text-center text-muted py-5">尚無資料</td></tr>
+                            )}
+                        </tbody>
+                    </Table>
+                )}
+
+                {activeTab === 'therapy' && (
+                    <Table striped bordered hover responsive>
+                        <thead>
+                            <tr>
+                                <th>編號</th>
+                                <th>項目名稱</th>
+                                <th>售價</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {therapyLoading ? (
+                                <tr><td colSpan={3} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                            ) : therapies.length > 0 ? (
+                                therapies.map(therapy => (
+                                    <tr key={therapy.therapy_id}>
+                                        <td className="align-middle">{therapy.therapy_id}</td>
+                                        <td className="align-middle">{therapy.name}</td>
+                                        <td className="align-middle">{`$${Number(therapy.price).toLocaleString()}`}</td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr><td colSpan={3} className="text-center text-muted py-5">尚無資料</td></tr>
+                            )}
+                        </tbody>
+                    </Table>
+                )}
             </Container>
         </>
     );
@@ -180,11 +284,11 @@ const ProductBundleManagement: React.FC = () => {
             />
             <AddTherapyModal
                 show={showTherapyModal}
-                onHide={() => setShowTherapyModal(false)}
+                onHide={handleCloseTherapyModal}
             />
             <AddProductModal
                 show={showProductModal}
-                onHide={() => setShowProductModal(false)}
+                onHide={handleCloseProductModal}
             />
         </>
     );


### PR DESCRIPTION
## Summary
- add tabs for bundles, products, and therapies in backend product bundle page
- fetch and display products and therapies lists

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Irregular whitespace in existing files)
- `npx eslint src/pages/backend/product_bundle/ProductBundleManagement.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b859c477a48329aac5f627b5e51278