### PR TITLE
feat: display codes for item selections

### DIFF
--- a/client/src/pages/finance/ItemSelection.tsx
+++ b/client/src/pages/finance/ItemSelection.tsx
@@ -33,11 +33,21 @@ const ItemSelection: React.FC = () => {
                 console.log("從 API 獲取的產品資料 (productRes):", productRes);
 
                 if (Array.isArray(productRes)) {
-                    setProducts(productRes);
+                    const sortedProducts = [...productRes].sort((a, b) => {
+                        const codeA = a.product_code ? parseInt(a.product_code, 10) : 0;
+                        const codeB = b.product_code ? parseInt(b.product_code, 10) : 0;
+                        return codeB - codeA;
+                    });
+                    setProducts(sortedProducts);
                 }
 
                 if (therapyRes.success && Array.isArray(therapyRes.data)) {
-                    setTherapies(therapyRes.data);
+                    const sortedTherapies = [...therapyRes.data].sort((a, b) => {
+                        const codeA = a.TherapyCode ? parseInt(a.TherapyCode, 10) : 0;
+                        const codeB = b.TherapyCode ? parseInt(b.TherapyCode, 10) : 0;
+                        return codeB - codeA;
+                    });
+                    setTherapies(sortedTherapies);
                 }
             } catch (err) {
                 setError("載入品項資料時發生錯誤。");
@@ -116,7 +126,7 @@ const ItemSelection: React.FC = () => {
                             <ListGroup className="mt-2" style={{ maxHeight: '60vh', overflowY: 'auto' }}>
                                 {loading ? <Spinner animation="border" /> : products.map(p => (
                                     <ListGroup.Item key={`prod-${p.product_id}`} action onClick={() => handleSelectItem(p, 'Product')}>
-                                        {p.product_name} - {formatCurrency(p.product_price)}
+                                        [{p.product_code ?? ''}] {p.product_name} - {formatCurrency(p.product_price)}
                                     </ListGroup.Item>
                                 ))}
                             </ListGroup>
@@ -125,7 +135,7 @@ const ItemSelection: React.FC = () => {
                              <ListGroup className="mt-2" style={{ maxHeight: '60vh', overflowY: 'auto' }}>
                                 {loading ? <Spinner animation="border" /> : therapies.map(t => (
                                     <ListGroup.Item key={`thr-${t.therapy_id}`} action onClick={() => handleSelectItem(t, 'Therapy')}>
-                                        {t.TherapyContent || t.TherapyName} - NT$ {t.TherapyPrice}
+                                        [{t.TherapyCode}] {t.TherapyContent || t.TherapyName} - NT$ {t.TherapyPrice}
                                     </ListGroup.Item>
                                 ))}
                             </ListGroup>

--- a/client/src/pages/inventory/InventoryInsert.tsx
+++ b/client/src/pages/inventory/InventoryInsert.tsx
@@ -1,18 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { Container, Row, Col, Form, Button } from "react-bootstrap";
-import { getAllProducts } from "../../services/ProductSellService";
+import { getAllProducts, Product } from "../../services/ProductSellService";
 import { useNavigate } from "react-router-dom";
 import Header from "../../components/Header";
 import { addInventoryItem } from "../../services/InventoryService";
-
-interface Product {
-  product_id: number;
-  product_name: string;
-  product_price: number;
-  inventory_id: number;
-  quantity: number;
-  sale_category?: string;
-}
 
 const InventoryInsert = () => {
   const navigate = useNavigate();
@@ -26,8 +17,12 @@ const InventoryInsert = () => {
 
   useEffect(() => {
     getAllProducts().then((res) => {
-      console.log("產品資料:", res);
-      setProducts(res);
+      const sorted = [...res].sort((a, b) => {
+        const codeA = a.product_code ? parseInt(a.product_code, 10) : 0;
+        const codeB = b.product_code ? parseInt(b.product_code, 10) : 0;
+        return codeB - codeA;
+      });
+      setProducts(sorted);
     });
   }, []);
 
@@ -78,7 +73,7 @@ const InventoryInsert = () => {
                           <option value="">-- 選擇品項 --</option>
                           {products.map((p) => (
                             <option key={p.product_id} value={p.product_id}>
-                              [{p.product_id}] {p.product_name}
+                              [{p.product_code ?? ""}] {p.product_name}
                             </option>
                           ))}
                         </Form.Select>

--- a/client/src/pages/inventory/InventoryUpdate.tsx
+++ b/client/src/pages/inventory/InventoryUpdate.tsx
@@ -29,7 +29,14 @@ const InventoryEntryForm = () => {
   });
 
   useEffect(() => {
-    getAllProducts().then((res) => setProducts(res));
+    getAllProducts().then((res) => {
+      const sorted = [...res].sort((a, b) => {
+        const codeA = a.product_code ? parseInt(a.product_code, 10) : 0;
+        const codeB = b.product_code ? parseInt(b.product_code, 10) : 0;
+        return codeB - codeA;
+      });
+      setProducts(sorted);
+    });
     getAllStaffs().then((res) => setStaffs(res));
 
     if (editingId) {
@@ -129,10 +136,10 @@ const InventoryEntryForm = () => {
                   onChange={handleChange}
                 >
                   <option value="">-- 選擇品項 --</option>
-                  {products.map((p, index) => {
+                  {products.map((p) => {
                     const key = p.product_id;
                     const value = p.product_id;
-                    const label = `[${p.product_id}] ${p.product_name}`;
+                    const label = `[${p.product_code ?? ""}] ${p.product_name}`;
                     return (
                       <option key={key} value={value}>
                         {label}


### PR DESCRIPTION
## Summary
- show product codes instead of ids for inventory entries and sort by code descending
- list product and therapy codes in item selection and sort by code descending

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8779e4e7c83299367f869364aaf6a