### PR TITLE
feat: add product and therapy CRUD in bundle management

### DIFF
--- a/client/src/pages/backend/product_bundle/AddProductModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddProductModal.tsx
@@ -1,31 +1,49 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
-import { addProduct } from '../../../services/ProductService';
+import { addProduct, updateProduct } from '../../../services/ProductService';
+import { Product as ProductItem } from '../../../services/ProductBundleService';
 
 interface AddProductModalProps {
     show: boolean;
     onHide: () => void;
+    editingProduct?: ProductItem | null;
 }
 
-const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide }) => {
+const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editingProduct }) => {
     const [code, setCode] = useState('');
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
 
+    useEffect(() => {
+        if (editingProduct) {
+            setCode(editingProduct.code);
+            setName(editingProduct.product_name);
+            setPrice(String(editingProduct.product_price));
+        } else {
+            setCode('');
+            setName('');
+            setPrice('');
+        }
+    }, [editingProduct]);
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            await addProduct({ code, name, price: Number(price) });
+            if (editingProduct) {
+                await updateProduct(editingProduct.product_id, { code, name, price: Number(price) });
+            } else {
+                await addProduct({ code, name, price: Number(price) });
+            }
             onHide();
         } catch (err) {
-            alert('新增產品失敗');
+            alert(editingProduct ? '更新產品失敗' : '新增產品失敗');
         }
     };
 
     return (
         <Modal show={show} onHide={onHide}>
             <Modal.Header closeButton>
-                <Modal.Title>建立產品 1.2.6.3.1.1.1</Modal.Title>
+                <Modal.Title>{editingProduct ? '修改產品 1.2.6.3.1.1.1' : '建立產品 1.2.6.3.1.1.1'}</Modal.Title>
             </Modal.Header>
             <Form onSubmit={handleSubmit}>
                 <Modal.Body>

--- a/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
@@ -1,31 +1,49 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
-import { addTherapy } from '../../../services/TherapyService';
+import { addTherapy, updateTherapy } from '../../../services/TherapyService';
+import { Therapy } from '../../../services/ProductBundleService';
 
 interface AddTherapyModalProps {
     show: boolean;
     onHide: () => void;
+    editingTherapy?: Therapy | null;
 }
 
-const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide }) => {
+const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editingTherapy }) => {
     const [code, setCode] = useState('');
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
 
+    useEffect(() => {
+        if (editingTherapy) {
+            setCode(editingTherapy.code);
+            setName(editingTherapy.name);
+            setPrice(String(editingTherapy.price));
+        } else {
+            setCode('');
+            setName('');
+            setPrice('');
+        }
+    }, [editingTherapy]);
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            await addTherapy({ code, name, price: Number(price) });
+            if (editingTherapy) {
+                await updateTherapy(editingTherapy.therapy_id, { code, name, price: Number(price) });
+            } else {
+                await addTherapy({ code, name, price: Number(price) });
+            }
             onHide();
         } catch (err) {
-            alert('新增療程失敗');
+            alert(editingTherapy ? '更新療程失敗' : '新增療程失敗');
         }
     };
 
     return (
         <Modal show={show} onHide={onHide}>
             <Modal.Header closeButton>
-                <Modal.Title>建立療程 1.2.6.3.1.1</Modal.Title>
+                <Modal.Title>{editingTherapy ? '修改療程 1.2.6.3.1.1' : '建立療程 1.2.6.3.1.1'}</Modal.Title>
             </Modal.Header>
             <Form onSubmit={handleSubmit}>
                 <Modal.Body>

--- a/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
+++ b/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
@@ -7,6 +7,8 @@ import AddTherapyModal from './AddTherapyModal';
 import AddProductModal from './AddProductModal';
 import { fetchAllBundles, deleteBundle, fetchProductsForDropdown, fetchTherapiesForDropdown, Bundle, Product as ProductItem, Therapy as TherapyItem } from '../../../services/ProductBundleService';
 import { fetchAllStores, Store } from '../../../services/StoreService';
+import { deleteProduct } from '../../../services/ProductService';
+import { deleteTherapy } from '../../../services/TherapyService';
 
 const ProductBundleManagement: React.FC = () => {
     const [bundles, setBundles] = useState<Bundle[]>([]);
@@ -21,6 +23,8 @@ const ProductBundleManagement: React.FC = () => {
     const [editingBundle, setEditingBundle] = useState<Bundle | null>(null);
     const [showTherapyModal, setShowTherapyModal] = useState(false);
     const [showProductModal, setShowProductModal] = useState(false);
+    const [editingProduct, setEditingProduct] = useState<ProductItem | null>(null);
+    const [editingTherapy, setEditingTherapy] = useState<TherapyItem | null>(null);
     const [stores, setStores] = useState<Store[]>([]);
     const [activeTab, setActiveTab] = useState<'bundle' | 'product' | 'therapy'>('bundle');
 
@@ -90,20 +94,34 @@ const ProductBundleManagement: React.FC = () => {
     };
 
     const handleShowTherapyModal = () => {
+        setEditingTherapy(null);
         setShowTherapyModal(true);
     };
 
     const handleShowProductModal = () => {
+        setEditingProduct(null);
         setShowProductModal(true);
+    };
+
+    const handleShowEditProductModal = (product: ProductItem) => {
+        setEditingProduct(product);
+        setShowProductModal(true);
+    };
+
+    const handleShowEditTherapyModal = (therapy: TherapyItem) => {
+        setEditingTherapy(therapy);
+        setShowTherapyModal(true);
     };
 
     const handleCloseTherapyModal = () => {
         setShowTherapyModal(false);
+        setEditingTherapy(null);
         fetchTherapies();
     };
 
     const handleCloseProductModal = () => {
         setShowProductModal(false);
+        setEditingProduct(null);
         fetchProducts();
     };
 
@@ -117,6 +135,30 @@ const ProductBundleManagement: React.FC = () => {
             setError('刪除失敗，請稍後再試。');
         }
         // 讓成功訊息顯示幾秒後自動消失
+        setTimeout(() => setSuccessMessage(null), 3000);
+    };
+
+    const handleDeleteProduct = async (productId: number) => {
+        setSuccessMessage(null);
+        try {
+            await deleteProduct(productId);
+            setSuccessMessage('刪除成功！');
+            fetchProducts();
+        } catch {
+            setError('刪除失敗，請稍後再試。');
+        }
+        setTimeout(() => setSuccessMessage(null), 3000);
+    };
+
+    const handleDeleteTherapy = async (therapyId: number) => {
+        setSuccessMessage(null);
+        try {
+            await deleteTherapy(therapyId);
+            setSuccessMessage('刪除成功！');
+            fetchTherapies();
+        } catch {
+            setError('刪除失敗，請稍後再試。');
+        }
         setTimeout(() => setSuccessMessage(null), 3000);
     };
 
@@ -222,21 +264,36 @@ const ProductBundleManagement: React.FC = () => {
                                 <th>產品編號</th>
                                 <th>項目名稱</th>
                                 <th>售價</th>
+                                <th>操作</th>
                             </tr>
                         </thead>
                         <tbody>
                             {productLoading ? (
-                                <tr><td colSpan={3} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                                <tr><td colSpan={4} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
                             ) : products.length > 0 ? (
                                 products.map(product => (
                                     <tr key={product.product_id}>
                                         <td className="align-middle">{product.code}</td>
                                         <td className="align-middle">{product.product_name}</td>
                                         <td className="align-middle">{`$${Number(product.product_price).toLocaleString()}`}</td>
+                                        <td className="align-middle">
+                                            <Button variant="link" onClick={() => handleShowEditProductModal(product)}>修改</Button>
+                                            <Button
+                                                variant="link"
+                                                className="text-danger"
+                                                onClick={() => {
+                                                    if (window.confirm(`確定要刪除「${product.product_name}」嗎？`)) {
+                                                        handleDeleteProduct(product.product_id);
+                                                    }
+                                                }}
+                                            >
+                                                刪除
+                                            </Button>
+                                        </td>
                                     </tr>
                                 ))
                             ) : (
-                                <tr><td colSpan={3} className="text-center text-muted py-5">尚無資料</td></tr>
+                                <tr><td colSpan={4} className="text-center text-muted py-5">尚無資料</td></tr>
                             )}
                         </tbody>
                     </Table>
@@ -249,21 +306,36 @@ const ProductBundleManagement: React.FC = () => {
                                 <th>療程編號</th>
                                 <th>項目名稱</th>
                                 <th>售價</th>
+                                <th>操作</th>
                             </tr>
                         </thead>
                         <tbody>
                             {therapyLoading ? (
-                                <tr><td colSpan={3} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                                <tr><td colSpan={4} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
                             ) : therapies.length > 0 ? (
                                 therapies.map(therapy => (
                                     <tr key={therapy.therapy_id}>
                                         <td className="align-middle">{therapy.code}</td>
                                         <td className="align-middle">{therapy.name}</td>
                                         <td className="align-middle">{`$${Number(therapy.price).toLocaleString()}`}</td>
+                                        <td className="align-middle">
+                                            <Button variant="link" onClick={() => handleShowEditTherapyModal(therapy)}>修改</Button>
+                                            <Button
+                                                variant="link"
+                                                className="text-danger"
+                                                onClick={() => {
+                                                    if (window.confirm(`確定要刪除「${therapy.name}」嗎？`)) {
+                                                        handleDeleteTherapy(therapy.therapy_id);
+                                                    }
+                                                }}
+                                            >
+                                                刪除
+                                            </Button>
+                                        </td>
                                     </tr>
                                 ))
                             ) : (
-                                <tr><td colSpan={3} className="text-center text-muted py-5">尚無資料</td></tr>
+                                <tr><td colSpan={4} className="text-center text-muted py-5">尚無資料</td></tr>
                             )}
                         </tbody>
                     </Table>
@@ -285,10 +357,12 @@ const ProductBundleManagement: React.FC = () => {
             <AddTherapyModal
                 show={showTherapyModal}
                 onHide={handleCloseTherapyModal}
+                editingTherapy={editingTherapy}
             />
             <AddProductModal
                 show={showProductModal}
                 onHide={handleCloseProductModal}
+                editingProduct={editingProduct}
             />
         </>
     );

--- a/client/src/services/ProductService.ts
+++ b/client/src/services/ProductService.ts
@@ -65,3 +65,40 @@ export const addProduct = async (data: { code: string; name: string; price: numb
     throw error;
   }
 };
+
+export const updateProduct = async (
+  productId: number,
+  data: { code: string; name: string; price: number }
+) => {
+  try {
+    const token = localStorage.getItem("token");
+    const response = await axios.put(`${API_URL}/${productId}`, data, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Store-ID": "1",
+        "X-Store-Level": "admin",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("更新產品失敗：", error);
+    throw error;
+  }
+};
+
+export const deleteProduct = async (productId: number) => {
+  try {
+    const token = localStorage.getItem("token");
+    const response = await axios.delete(`${API_URL}/${productId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Store-ID": "1",
+        "X-Store-Level": "admin",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error("刪除產品失敗：", error);
+    throw error;
+  }
+};

--- a/client/src/services/TherapyService.ts
+++ b/client/src/services/TherapyService.ts
@@ -180,3 +180,40 @@ export const addTherapy = async (data: { code: string; name: string; price: numb
         throw error;
     }
 };
+
+export const updateTherapy = async (
+    therapyId: number,
+    data: { code: string; name: string; price: number; content?: string }
+) => {
+    try {
+        const token = localStorage.getItem("token");
+        const response = await axios.put(`${API_URL}/package/${therapyId}`, data, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "X-Store-ID": "1",
+                "X-Store-Level": "admin",
+            },
+        });
+        return response.data;
+    } catch (error) {
+        console.error("更新療程失敗：", error);
+        throw error;
+    }
+};
+
+export const deleteTherapy = async (therapyId: number) => {
+    try {
+        const token = localStorage.getItem("token");
+        const response = await axios.delete(`${API_URL}/package/${therapyId}`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "X-Store-ID": "1",
+                "X-Store-Level": "admin",
+            },
+        });
+        return response.data;
+    } catch (error) {
+        console.error("刪除療程失敗：", error);
+        throw error;
+    }
+};

--- a/server/app/models/product_model.py
+++ b/server/app/models/product_model.py
@@ -30,3 +30,39 @@ def create_product(data: dict):
         raise e
     finally:
         conn.close()
+
+
+def update_product(product_id: int, data: dict):
+    """更新產品資料"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            query = (
+                "UPDATE product SET code=%s, name=%s, price=%s WHERE product_id=%s"
+            )
+            cursor.execute(query, (
+                data.get("code"),
+                data.get("name"),
+                data.get("price"),
+                product_id,
+            ))
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()
+
+
+def delete_product(product_id: int):
+    """刪除產品資料"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("DELETE FROM product WHERE product_id=%s", (product_id,))
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -517,3 +517,40 @@ def create_therapy(data: dict):
         raise e
     finally:
         conn.close()
+
+
+def update_therapy(therapy_id: int, data: dict):
+    """更新療程套餐資料"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            query = (
+                "UPDATE therapy SET code=%s, name=%s, price=%s, content=%s WHERE therapy_id=%s"
+            )
+            cursor.execute(query, (
+                data.get("code"),
+                data.get("name"),
+                data.get("price"),
+                data.get("content", None),
+                therapy_id,
+            ))
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()
+
+
+def delete_therapy(therapy_id: int):
+    """刪除療程套餐"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("DELETE FROM therapy WHERE therapy_id=%s", (therapy_id,))
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()

--- a/server/app/routes/product.py
+++ b/server/app/routes/product.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, jsonify
-from app.models.product_model import create_product
+from app.models.product_model import create_product, update_product, delete_product
 from app.middleware import admin_required
 
 product_bp = Blueprint("product", __name__)
@@ -16,4 +16,25 @@ def add_product():
     except Exception as e:
         if "Duplicate entry" in str(e):
             return jsonify({"error": "產品編號重複"}), 409
+        return jsonify({"error": str(e)}), 500
+
+
+@product_bp.route("/<int:product_id>", methods=["PUT"])
+@admin_required
+def update_product_route(product_id):
+    data = request.json
+    try:
+        update_product(product_id, data)
+        return jsonify({"message": "產品更新成功"})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@product_bp.route("/<int:product_id>", methods=["DELETE"])
+@admin_required
+def delete_product_route(product_id):
+    try:
+        delete_product(product_id)
+        return jsonify({"message": "產品刪除成功"})
+    except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/server/app/routes/therapy.py
+++ b/server/app/routes/therapy.py
@@ -17,7 +17,9 @@ from app.models.therapy_model import (
     update_therapy_sell,
     delete_therapy_sell,
     get_all_therapies_for_dropdown,
-    create_therapy
+    create_therapy,
+    update_therapy,
+    delete_therapy
 )
 from app.middleware import auth_required, admin_required, get_user_from_token
 
@@ -340,4 +342,27 @@ def add_therapy_package():
     except Exception as e:
         if "Duplicate entry" in str(e):
             return jsonify({"error": "療程編號重複"}), 409
+        return jsonify({"error": str(e)}), 500
+
+
+@therapy_bp.route("/package/<int:therapy_id>", methods=["PUT"])
+@admin_required
+def update_therapy_package(therapy_id):
+    """更新療程套餐"""
+    data = request.json
+    try:
+        update_therapy(therapy_id, data)
+        return jsonify({"message": "療程更新成功"})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@therapy_bp.route("/package/<int:therapy_id>", methods=["DELETE"])
+@admin_required
+def delete_therapy_package(therapy_id):
+    """刪除療程套餐"""
+    try:
+        delete_therapy(therapy_id)
+        return jsonify({"message": "療程刪除成功"})
+    except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- support editing and deleting products/therapies from product bundle management
- expose backend update/delete endpoints for products and therapy packages
- extend modals and services for product and therapy CRUD

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Irregular whitespace in existing files)
- `pytest` (fails: No module named 'jwt')

------
https://chatgpt.com/codex/tasks/task_e_68b876e1eb488329a20dd5a216994e27