### PR TITLE
fix: guard therapy price display

### DIFF
--- a/client/src/pages/therapy/TherapyPackageSelection.tsx
+++ b/client/src/pages/therapy/TherapyPackageSelection.tsx
@@ -248,7 +248,7 @@ const TherapyPackageSelection: React.FC = () => {
                                                     label={
                                                         <div style={{fontSize:'0.9rem'}}>
                                                             <strong>{pkg.TherapyContent || pkg.TherapyName}</strong>
-                                                            <div><small className="text-muted">產品編號: {pkg.TherapyCode} / 單價: NT$ {pkg.TherapyPrice.toLocaleString()}</small></div>
+                                                            <div><small className="text-muted">產品編號: {pkg.TherapyCode} / 單價: NT$ {Number(pkg.TherapyPrice ?? 0).toLocaleString()}</small></div>
                                                             {memberId && remainingMap.has(pkgKey) && (
                                                                 <div><small className="text-success">剩餘 {remainingMap.get(pkgKey)} 堂</small></div>
                                                             )}


### PR DESCRIPTION
## Summary
- default missing therapy price to zero when displaying selection items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 556 problems (540 errors, 16 warnings))*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b87ae7cb6c8329a4c13a2cea0d864c