### PR TITLE
feat: add bundle name search

### DIFF
--- a/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
+++ b/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Table, Button, Container, Alert, Spinner, Row, Col, Tabs, Tab } from 'react-bootstrap';
+import { Table, Button, Container, Alert, Spinner, Row, Col, Tabs, Tab, Form } from 'react-bootstrap';
 import Header from '../../../components/Header';
 import DynamicContainer from '../../../components/DynamicContainer';
 import BundleCreateModal from './BundleCreateModal';
@@ -27,6 +27,7 @@ const ProductBundleManagement: React.FC = () => {
     const [editingTherapy, setEditingTherapy] = useState<TherapyItem | null>(null);
     const [stores, setStores] = useState<Store[]>([]);
     const [activeTab, setActiveTab] = useState<'bundle' | 'product' | 'therapy'>('bundle');
+    const [bundleSearch, setBundleSearch] = useState('');
 
     const fetchBundles = useCallback(async () => {
         setBundleLoading(true);
@@ -162,6 +163,10 @@ const ProductBundleManagement: React.FC = () => {
         setTimeout(() => setSuccessMessage(null), 3000);
     };
 
+    const filteredBundles = bundles.filter(bundle =>
+        bundle.name.toLowerCase().includes(bundleSearch.toLowerCase())
+    );
+
     const content = (
         <>
             <Container className="my-4">
@@ -206,55 +211,67 @@ const ProductBundleManagement: React.FC = () => {
                 </Tabs>
 
                 {activeTab === 'bundle' && (
-                    <Table striped bordered hover responsive>
-                        <thead>
-                            <tr>
-                                <th>編號</th>
-                                <th>項目 (組合名稱)</th>
-                                <th>組合內容</th>
-                                <th>限定分店</th>
-                                <th>售價</th>
-                                <th>操作</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {bundleLoading ? (
-                                <tr><td colSpan={6} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
-                            ) : bundles.length > 0 ? (
-                                bundles.map(bundle => (
-                                    <tr key={bundle.bundle_id}>
-                                        <td className="align-middle">{bundle.bundle_code}</td>
-                                        <td className="align-middle">{bundle.name}</td>
-                                        <td className="align-middle">{bundle.bundle_contents || '---'}</td>
-                                        <td className="align-middle">{
-                                            bundle.visible_store_ids && bundle.visible_store_ids.length > 0
-                                                ? bundle.visible_store_ids
-                                                    .map(id => stores.find(s => s.store_id === id)?.store_name || id)
-                                                    .join(', ')
-                                                : '---'
-                                        }</td>
-                                        <td className="align-middle">{`$${Number(bundle.selling_price).toLocaleString()}`}</td>
-                                        <td className="align-middle">
-                                            <Button variant="link" onClick={() => handleShowEditModal(bundle)}>修改</Button>
-                                            <Button
-                                                variant="link"
-                                                className="text-danger"
-                                                onClick={() => {
-                                                    if (window.confirm(`確定要刪除「${bundle.name}」嗎？`)) {
-                                                        handleDelete(bundle.bundle_id);
-                                                    }
-                                                }}
-                                            >
-                                                刪除
-                                            </Button>
-                                        </td>
-                                    </tr>
-                                ))
-                            ) : (
-                                <tr><td colSpan={6} className="text-center text-muted py-5">尚無資料</td></tr>
-                            )}
-                        </tbody>
-                    </Table>
+                    <>
+                        <Row className="mb-3">
+                            <Col xs={12} md={4}>
+                                <Form.Control
+                                    type="text"
+                                    placeholder="輸入組合名稱搜尋"
+                                    value={bundleSearch}
+                                    onChange={(e) => setBundleSearch(e.target.value)}
+                                />
+                            </Col>
+                        </Row>
+                        <Table striped bordered hover responsive>
+                            <thead>
+                                <tr>
+                                    <th>編號</th>
+                                    <th>項目 (組合名稱)</th>
+                                    <th>組合內容</th>
+                                    <th>限定分店</th>
+                                    <th>售價</th>
+                                    <th>操作</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {bundleLoading ? (
+                                    <tr><td colSpan={6} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                                ) : filteredBundles.length > 0 ? (
+                                    filteredBundles.map(bundle => (
+                                        <tr key={bundle.bundle_id}>
+                                            <td className="align-middle">{bundle.bundle_code}</td>
+                                            <td className="align-middle">{bundle.name}</td>
+                                            <td className="align-middle">{bundle.bundle_contents || '---'}</td>
+                                            <td className="align-middle">
+                                                {bundle.visible_store_ids && bundle.visible_store_ids.length > 0
+                                                    ? bundle.visible_store_ids
+                                                        .map(id => stores.find(s => s.store_id === id)?.store_name || id)
+                                                        .join(', ')
+                                                    : '---'}
+                                            </td>
+                                            <td className="align-middle">{`$${Number(bundle.selling_price).toLocaleString()}`}</td>
+                                            <td className="align-middle">
+                                                <Button variant="link" onClick={() => handleShowEditModal(bundle)}>修改</Button>
+                                                <Button
+                                                    variant="link"
+                                                    className="text-danger"
+                                                    onClick={() => {
+                                                        if (window.confirm(`確定要刪除「${bundle.name}」嗎？`)) {
+                                                            handleDelete(bundle.bundle_id);
+                                                        }
+                                                    }}
+                                                >
+                                                    刪除
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))
+                                ) : (
+                                    <tr><td colSpan={6} className="text-center text-muted py-5">尚無資料</td></tr>
+                                )}
+                            </tbody>
+                        </Table>
+                    </>
                 )}
 
                 {activeTab === 'product' && (


### PR DESCRIPTION
## Summary
- add search field for bundle name filter on product bundle management page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b926577c44832993107122b52c13b0