### PR TITLE
Add therapy bundle management tab and API support

### DIFF
--- a/client/src/services/TherapyBundleService.ts
+++ b/client/src/services/TherapyBundleService.ts
@@ -1,0 +1,101 @@
+import axios from "axios";
+import { base_url } from "./BASE_URL";
+
+const API_URL = `${base_url}/therapy-bundles`;
+const API_URL_THERAPIES = `${base_url}/therapy`;
+
+const getAuthHeaders = () => {
+    const token = localStorage.getItem("token");
+    return {
+        headers: {
+            Authorization: `Bearer ${token}`,
+            "X-Store-ID": "1",
+            "X-Store-Level": "admin"
+        }
+    };
+};
+
+export interface TherapyBundle {
+    bundle_id: number;
+    bundle_code: string;
+    name: string;
+    selling_price: number;
+    bundle_contents: string;
+    created_at: string;
+    visible_store_ids?: number[];
+}
+
+export interface TherapyBundleDetails extends TherapyBundle {
+    items: {
+        item_id: number;
+        quantity: number;
+    }[];
+}
+
+export interface Therapy {
+    therapy_id: number;
+    name: string;
+    price: number;
+    code: string;
+    content?: string;
+}
+
+export const fetchAllTherapyBundles = async (): Promise<TherapyBundle[]> => {
+    try {
+        const response = await axios.get(`${API_URL}/`, getAuthHeaders());
+        return response.data;
+    } catch (error) {
+        console.error("獲取療程組合列表失敗:", error);
+        throw error;
+    }
+};
+
+export const createTherapyBundle = async (payload: unknown) => {
+    try {
+        const response = await axios.post(`${API_URL}/`, payload, getAuthHeaders());
+        return response.data;
+    } catch (error) {
+        console.error("新增療程組合失敗:", error);
+        throw error;
+    }
+};
+
+export const getTherapyBundleDetails = async (bundleId: number): Promise<TherapyBundleDetails> => {
+    try {
+        const response = await axios.get(`${API_URL}/${bundleId}`, getAuthHeaders());
+        return response.data;
+    } catch (error) {
+        console.error("獲取療程組合詳情失敗:", error);
+        throw error;
+    }
+};
+
+export const updateTherapyBundle = async (bundleId: number, payload: unknown) => {
+    try {
+        const response = await axios.put(`${API_URL}/${bundleId}`, payload, getAuthHeaders());
+        return response.data;
+    } catch (error) {
+        console.error("更新療程組合失敗:", error);
+        throw error;
+    }
+};
+
+export const deleteTherapyBundle = async (bundleId: number) => {
+    try {
+        const response = await axios.delete(`${API_URL}/${bundleId}`, getAuthHeaders());
+        return response.data;
+    } catch (error) {
+        console.error("刪除療程組合失敗:", error);
+        throw error;
+    }
+};
+
+export const fetchTherapiesForDropdown = async (): Promise<Therapy[]> => {
+    try {
+        const response = await axios.get(`${API_URL_THERAPIES}/for-dropdown`, getAuthHeaders());
+        return response.data;
+    } catch (error) {
+        console.error("Service: 獲取療程下拉選單失敗:", error);
+        throw error;
+    }
+};

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -11,6 +11,7 @@ from app.routes.health_check import health_check_bp
 from app.routes.staff import staff_bp
 from app.routes.pure_medical_record import pure_medical_bp
 from app.routes.product_bundle import product_bundle_bp
+from app.routes.therapy_bundle import therapy_bundle_bp
 from app.routes.product import product_bp
 from .routes.sales_order_routes import sales_order_bp
 from app.routes.store import store_bp
@@ -68,6 +69,7 @@ def create_app():
     app.register_blueprint(stress_test, url_prefix='/api/stress-test')
     app.register_blueprint(staff_bp, url_prefix='/api/staff')
     app.register_blueprint(product_bundle_bp, url_prefix='/api/product-bundles')
+    app.register_blueprint(therapy_bundle_bp, url_prefix='/api/therapy-bundles')
     app.register_blueprint(product_bp, url_prefix='/api/product')
     app.register_blueprint(store_bp, url_prefix='/api/stores')
 

--- a/server/app/models/therapy_bundle_model.py
+++ b/server/app/models/therapy_bundle_model.py
@@ -1,0 +1,180 @@
+import pymysql
+import json
+from app.config import DB_CONFIG
+from pymysql.cursors import DictCursor
+
+
+def connect_to_db():
+    """建立資料庫連線"""
+    return pymysql.connect(**DB_CONFIG, cursorclass=DictCursor)
+
+
+def get_all_therapy_bundles():
+    """獲取所有療程組合列表"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            query = """
+                SELECT
+                    tb.bundle_id,
+                    tb.bundle_code,
+                    tb.name,
+                    tb.selling_price,
+                    tb.calculated_price,
+                    tb.visible_store_ids,
+                    tb.created_at,
+                    IFNULL(
+                        GROUP_CONCAT(
+                            CONCAT(t.name, ' x', tbi.quantity)
+                            SEPARATOR ', '
+                        ),
+                        ''
+                    ) AS bundle_contents
+                FROM
+                    therapy_bundles tb
+                LEFT JOIN
+                    therapy_bundle_items tbi ON tb.bundle_id = tbi.bundle_id
+                LEFT JOIN
+                    therapy t ON tbi.item_id = t.therapy_id
+                GROUP BY
+                    tb.bundle_id
+                ORDER BY
+                    tb.bundle_id DESC;
+            """
+            cursor.execute(query)
+            result = cursor.fetchall()
+            for row in result:
+                if row.get('visible_store_ids'):
+                    try:
+                        row['visible_store_ids'] = json.loads(row['visible_store_ids'])
+                    except Exception:
+                        pass
+            return result
+    finally:
+        conn.close()
+
+
+def create_therapy_bundle(data: dict):
+    """新增一筆療程組合紀錄"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            bundle_query = """
+                INSERT INTO therapy_bundles (bundle_code, name, calculated_price, selling_price, visible_store_ids)
+                VALUES (%s, %s, %s, %s, %s)
+            """
+            bundle_values = (
+                data['bundle_code'],
+                data['name'],
+                data.get('calculated_price'),
+                data['selling_price'],
+                json.dumps(data.get('visible_store_ids')) if data.get('visible_store_ids') is not None else None
+            )
+            cursor.execute(bundle_query, bundle_values)
+            bundle_id = conn.insert_id()
+
+            items = data.get('items', [])
+            if items:
+                item_query = """
+                    INSERT INTO therapy_bundle_items (bundle_id, item_id, quantity)
+                    VALUES (%s, %s, %s)
+                """
+                item_values = [
+                    (bundle_id, item['item_id'], item.get('quantity', 1))
+                    for item in items
+                ]
+                cursor.executemany(item_query, item_values)
+
+        conn.commit()
+        return bundle_id
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()
+
+
+def get_bundle_details_by_id(bundle_id: int):
+    """獲取單一療程組合詳細資料"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT * FROM therapy_bundles WHERE bundle_id = %s", (bundle_id,))
+            bundle_details = cursor.fetchone()
+            if not bundle_details:
+                return None
+            if bundle_details.get('visible_store_ids'):
+                try:
+                    bundle_details['visible_store_ids'] = json.loads(bundle_details['visible_store_ids'])
+                except Exception:
+                    pass
+
+            cursor.execute(
+                "SELECT item_id, quantity FROM therapy_bundle_items WHERE bundle_id = %s",
+                (bundle_id,)
+            )
+            items = cursor.fetchall()
+            bundle_details['items'] = items
+            return bundle_details
+    finally:
+        conn.close()
+
+
+def update_therapy_bundle(bundle_id: int, data: dict):
+    """更新一個療程組合"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            update_query = """
+                UPDATE therapy_bundles SET
+                    bundle_code = %s,
+                    name = %s,
+                    calculated_price = %s,
+                    selling_price = %s,
+                    visible_store_ids = %s
+                WHERE bundle_id = %s
+            """
+            update_values = (
+                data['bundle_code'], data['name'],
+                data.get('calculated_price'), data['selling_price'],
+                json.dumps(data.get('visible_store_ids')) if data.get('visible_store_ids') is not None else None,
+                bundle_id
+            )
+            cursor.execute(update_query, update_values)
+
+            cursor.execute("DELETE FROM therapy_bundle_items WHERE bundle_id = %s", (bundle_id,))
+
+            items = data.get('items', [])
+            if items:
+                item_query = """
+                    INSERT INTO therapy_bundle_items (bundle_id, item_id, quantity)
+                    VALUES (%s, %s, %s)
+                """
+                item_values = [
+                    (bundle_id, item['item_id'], item.get('quantity', 1))
+                    for item in items
+                ]
+                cursor.executemany(item_query, item_values)
+
+        conn.commit()
+        return True
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()
+
+
+def delete_therapy_bundle(bundle_id: int):
+    """刪除一個療程組合"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("DELETE FROM therapy_bundles WHERE bundle_id = %s", (bundle_id,))
+        conn.commit()
+        return True
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()

--- a/server/app/routes/therapy_bundle.py
+++ b/server/app/routes/therapy_bundle.py
@@ -1,0 +1,87 @@
+from flask import Blueprint, request, jsonify
+from app.models.therapy_bundle_model import (
+    get_all_therapy_bundles, create_therapy_bundle,
+    get_bundle_details_by_id, update_therapy_bundle, delete_therapy_bundle
+)
+from app.middleware import admin_required
+
+therapy_bundle_bp = Blueprint(
+    "therapy_bundle",
+    __name__
+)
+
+
+@therapy_bundle_bp.route("/", methods=["GET"])
+@admin_required
+def get_bundles():
+    """獲取療程組合列表"""
+    try:
+        bundles = get_all_therapy_bundles()
+        return jsonify(bundles)
+    except Exception as e:
+        print(f"Error fetching therapy bundles: {e}")
+        return jsonify({"error": "無法獲取療程組合列表"}), 500
+
+
+@therapy_bundle_bp.route("/", methods=["POST"])
+@admin_required
+def add_bundle():
+    """新增一個療程組合"""
+    data = request.json
+
+    if not all(k in data for k in ['bundle_code', 'name', 'selling_price']):
+        return jsonify({"error": "缺少必要欄位：編號、名稱、售價"}), 400
+
+    try:
+        bundle_id = create_therapy_bundle(data)
+        return jsonify({
+            "message": "療程組合新增成功",
+            "bundle_id": bundle_id
+        }), 201
+    except Exception as e:
+        print(f"Error creating therapy bundle: {e}")
+        if "Duplicate entry" in str(e):
+            return jsonify({"error": f"組合編號 '{data['bundle_code']}' 已存在，請使用不同的編號"}), 409
+        return jsonify({"error": "伺服器內部錯誤，無法新增組合"}), 500
+
+
+@therapy_bundle_bp.route("/<int:bundle_id>", methods=["GET"])
+@admin_required
+def get_single_bundle(bundle_id):
+    """獲取單一療程組合的詳細資料"""
+    try:
+        bundle = get_bundle_details_by_id(bundle_id)
+        if bundle is None:
+            return jsonify({"error": "找不到指定的療程組合"}), 404
+        return jsonify(bundle)
+    except Exception as e:
+        return jsonify({"error": "伺服器錯誤"}), 500
+
+
+@therapy_bundle_bp.route("/<int:bundle_id>", methods=["PUT"])
+@admin_required
+def update_single_bundle(bundle_id):
+    """更新一個療程組合"""
+    data = request.json
+    try:
+        success = update_therapy_bundle(bundle_id, data)
+        if success:
+            return jsonify({"message": "療程組合更新成功"})
+        else:
+            return jsonify({"error": "更新失敗"}), 400
+    except Exception as e:
+        return jsonify({"error": f"伺服器錯誤: {e}"}), 500
+
+
+@therapy_bundle_bp.route("/<int:bundle_id>", methods=["DELETE"])
+@admin_required
+def delete_single_bundle(bundle_id):
+    """刪除一個療程組合"""
+    try:
+        success = delete_therapy_bundle(bundle_id)
+        if success:
+            return jsonify({"message": "療程組合刪除成功"})
+        else:
+            return jsonify({"error": "刪除失敗"}), 400
+    except Exception as e:
+        return jsonify({"error": f"伺服器錯誤: {e}"}), 500


### PR DESCRIPTION
## Summary
- rename "組合" tab and button to "產品組合"
- add "療程組合" tab and therapy bundle service
- expose therapy bundle backend endpoints and register blueprint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b932a865f083299b3bc51db22c6382