### PR TITLE
Use therapy bundles for therapy purchase flows

### DIFF
--- a/client/src/pages/therapy/TherapyPackageSelection.tsx
+++ b/client/src/pages/therapy/TherapyPackageSelection.tsx
@@ -9,7 +9,7 @@ import {
     TherapyPackage as TherapyPackageBaseType,
     fetchRemainingSessionsBulk
 } from '../../services/TherapySellService';
-import { fetchAllBundles, Bundle } from '../../services/ProductBundleService';
+import { fetchAllTherapyBundles, TherapyBundle } from '../../services/TherapyBundleService';
 
 // 與 AddTherapySell.tsx 中 SelectedTherapyPackageUIData 結構對應，但此頁面只關心基礎資訊和 userSessions
 export interface PackageInSelection extends TherapyPackageBaseType {
@@ -82,7 +82,7 @@ const TherapyPackageSelection: React.FC = () => {
         try {
             const [therapyRes, bundleData] = await Promise.all([
                 fetchAllTherapyPackagesService(),
-                fetchAllBundles()
+                fetchAllTherapyBundles()
             ]);
 
             let packages: TherapyPackageBaseType[] = [];
@@ -94,7 +94,7 @@ const TherapyPackageSelection: React.FC = () => {
                 }));
             }
 
-            const bundlePackages: TherapyPackageBaseType[] = bundleData.map((b: Bundle) => ({
+            const bundlePackages: TherapyPackageBaseType[] = bundleData.map((b: TherapyBundle) => ({
                 bundle_id: b.bundle_id,
                 type: 'bundle',
                 TherapyCode: b.bundle_code,

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../services/TherapySellService"; // 假設路徑正確
 import { formatDateToYYYYMMDD } from "../../utils/dateUtils";
 import { formatCurrency } from "../../utils/productSellUtils"; // 借用金額格式化
-import { fetchAllBundles, Bundle } from "../../services/ProductBundleService";
+import { fetchAllTherapyBundles, TherapyBundle } from "../../services/TherapyBundleService";
 
 // 更新 interface 以符合 Figma 需求
 export interface TherapySellRow { // 更改 interface 名稱以避免與組件名衝突
@@ -94,14 +94,14 @@ const TherapySell: React.FC = () => {
     useEffect(() => {
         const loadBundles = async () => {
             try {
-                const bundles = await fetchAllBundles();
+                const bundles = await fetchAllTherapyBundles();
                 const map: Record<number, { name: string; contents: string }> = {};
-                bundles.forEach((b: Bundle) => {
+                bundles.forEach((b: TherapyBundle) => {
                     map[b.bundle_id] = { name: b.name || b.bundle_contents, contents: b.bundle_contents };
                 });
                 setBundleMap(map);
             } catch (err) {
-                console.error("載入產品組合失敗", err);
+                console.error("載入療程組合失敗", err);
             }
         };
         loadBundles();


### PR DESCRIPTION
## Summary
- Load therapy bundle data in therapy package selection and therapy sell pages
- Replace product bundle service usage with therapy bundle service

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run build` (client) *(fails: tsc errors in project)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ed4016c8329823bf9446b3da112