### PR TITLE
Preserve sales history when deleting products or therapies

### DIFF
--- a/server/app/models/product_model.py
+++ b/server/app/models/product_model.py
@@ -55,10 +55,16 @@ def update_product(product_id: int, data: dict):
 
 
 def delete_product(product_id: int):
-    """刪除產品資料"""
+    """刪除產品資料並保留相關的銷售紀錄"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
+            # 將 product_sell 中引用此產品的紀錄設為 NULL，以保留銷售歷史
+            cursor.execute(
+                "UPDATE product_sell SET product_id = NULL WHERE product_id=%s",
+                (product_id,),
+            )
+            # 再刪除產品本身
             cursor.execute("DELETE FROM product WHERE product_id=%s", (product_id,))
         conn.commit()
     except Exception as e:

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -544,10 +544,16 @@ def update_therapy(therapy_id: int, data: dict):
 
 
 def delete_therapy(therapy_id: int):
-    """刪除療程套餐"""
+    """刪除療程套餐並保留相關的銷售紀錄"""
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
+            # 先將 therapy_sell 中引用此療程的紀錄設為 NULL，避免銷售紀錄被刪除
+            cursor.execute(
+                "UPDATE therapy_sell SET therapy_id = NULL WHERE therapy_id=%s",
+                (therapy_id,),
+            )
+            # 再刪除療程本身
             cursor.execute("DELETE FROM therapy WHERE therapy_id=%s", (therapy_id,))
         conn.commit()
     except Exception as e:


### PR DESCRIPTION
## Summary
- Keep `product_sell` records by nulling `product_id` before deleting a product
- Keep `therapy_sell` records by nulling `therapy_id` before deleting a therapy
- Extend deletion integrity tests to ensure sales history is preserved

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_deletion_integrity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b94ca3d1788329b832a89c321c06b5