### PR TITLE
Restrict bundle visibility and fix print data after edits

### DIFF
--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -126,6 +126,7 @@ const AddProductSell: React.FC = () => {
             type: saleData.bundle_id ? 'bundle' : 'product',
             product_id: saleData.product_id || undefined,
             bundle_id: saleData.bundle_id || undefined,
+            code: saleData.product_code || '',
             name: saleData.product_name || "",
             price: saleData.unit_price || 0,
             quantity: saleData.quantity || 0,

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -131,6 +131,7 @@ const AddTherapySell: React.FC = () => {
           {
             therapy_id: editSale.therapy_id,
             type: 'therapy',
+            TherapyCode: editSale.TherapyCode,
             TherapyName: editSale.PackageName,
             TherapyContent: editSale.PackageName,
             TherapyPrice: editSale.UnitPrice ||

--- a/client/src/services/ProductSellService.ts
+++ b/client/src/services/ProductSellService.ts
@@ -91,6 +91,7 @@ export interface ProductSell extends ProductSellData {
   member_name?: string;
   store_name?: string;
   product_name?: string;
+  product_code?: string;
   staff_name?: string;
 }
 

--- a/server/app/models/product_bundle_model.py
+++ b/server/app/models/product_bundle_model.py
@@ -9,11 +9,11 @@ def connect_to_db():
     """建立資料庫連線"""
     return pymysql.connect(**DB_CONFIG, cursorclass=DictCursor)
 
-def get_all_product_bundles(status: str | None = None):
+def get_all_product_bundles(status: str | None = None, store_id: int | None = None):
     """
     獲取所有產品組合列表。
-    使用 GROUP_CONCAT 將每個組合的內容物（產品和療程名稱）合併成一個字串，
-    以利前端直接顯示。
+    若提供 store_id，僅返回 visible_store_ids 為空或包含該 store_id 的組合。
+    使用 GROUP_CONCAT 將每個組合的內容物（產品和療程名稱）合併成一個字串，以利前端直接顯示。
     """
     conn = connect_to_db()
     try:
@@ -56,13 +56,19 @@ def get_all_product_bundles(status: str | None = None):
             query += " GROUP BY pb.bundle_id ORDER BY pb.bundle_id DESC"
             cursor.execute(query, tuple(params))
             result = cursor.fetchall()
+            filtered = []
             for row in result:
+                store_ids = None
                 if row.get('visible_store_ids'):
                     try:
-                        row['visible_store_ids'] = json.loads(row['visible_store_ids'])
+                        store_ids = json.loads(row['visible_store_ids'])
                     except Exception:
-                        pass
-            return result
+                        store_ids = None
+                if store_id is None or not store_ids or int(store_id) in store_ids:
+                    if store_ids is not None:
+                        row['visible_store_ids'] = store_ids
+                    filtered.append(row)
+            return filtered
     finally:
         conn.close()
 

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -45,7 +45,8 @@ def get_product_sell_by_id(sell_id: int):
         query = """
             SELECT
                 ps.*, m.member_code AS member_code, m.name AS member_name,
-                st.store_name, COALESCE(p.name, ps.product_name) AS product_name, sf.name AS staff_name
+                st.store_name, p.code AS product_code,
+                COALESCE(p.name, ps.product_name) AS product_name, sf.name AS staff_name
             FROM product_sell ps
             LEFT JOIN member m ON ps.member_id = m.member_id
             LEFT JOIN store st ON ps.store_id = st.store_id

--- a/server/app/routes/product_bundle.py
+++ b/server/app/routes/product_bundle.py
@@ -19,7 +19,8 @@ def get_bundles():
     """獲取產品組合列表"""
     try:
         status = request.args.get("status")
-        bundles = get_all_product_bundles(status)
+        store_id = request.headers.get('X-Store-ID')
+        bundles = get_all_product_bundles(status, int(store_id) if store_id else None)
         return jsonify(bundles)
     except Exception as e:
         print(f"Error fetching product bundles: {e}")

--- a/server/app/routes/therapy_bundle.py
+++ b/server/app/routes/therapy_bundle.py
@@ -17,7 +17,8 @@ def get_bundles():
     """獲取療程組合列表"""
     try:
         status = request.args.get("status")
-        bundles = get_all_therapy_bundles(status)
+        store_id = request.headers.get('X-Store-ID')
+        bundles = get_all_therapy_bundles(status, int(store_id) if store_id else None)
         return jsonify(bundles)
     except Exception as e:
         print(f"Error fetching therapy bundles: {e}")


### PR DESCRIPTION
## Summary
- hide therapy/product bundles from stores not in `visible_store_ids`
- ensure product and therapy sale edits retain codes for printing

## Testing
- `python -m py_compile server/app/models/therapy_bundle_model.py server/app/models/product_bundle_model.py server/app/routes/therapy_bundle.py server/app/routes/product_bundle.py server/app/models/product_sell_model.py`
- `cd server && pytest` *(fails: pyenv version `3.11.3` is not installed)*
- `cd client && npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b97ffb74e08329be907e2b19ea6c22