### PR TITLE
feat: confirm before printing therapy sale

### DIFF
--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -296,6 +296,7 @@ const AddTherapySell: React.FC = () => {
   const handlePrint = async () => {
     const success = await processSale();
     if (success) {
+      alert('銷售資料已儲存，跳轉至列印頁面。');
       const itemsForOrder: SalesOrderItemData[] = therapyPackages.map(pkg => ({
         therapy_id: pkg.type === 'bundle' ? undefined : pkg.therapy_id,
         item_code: pkg.TherapyCode || '',


### PR DESCRIPTION
## Summary
- show alert before navigating to print page after saving therapy sale data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html" at repository root)*
- `cd client && npm test` *(fails: Missing script: "test")*
- `cd client && npm run build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b962c9a5dc8329996b1cce790a0351