### PR TITLE
feat: add store visibility for products and therapies

### DIFF
--- a/client/src/pages/backend/product_bundle/AddProductModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddProductModal.tsx
@@ -2,37 +2,47 @@ import React, { useState, useEffect } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
 import { addProduct, updateProduct } from '../../../services/ProductService';
 import { Product as ProductItem } from '../../../services/ProductBundleService';
+import { Store } from '../../../services/StoreService';
 
 interface AddProductModalProps {
     show: boolean;
     onHide: () => void;
     editingProduct?: ProductItem | null;
+    stores: Store[];
 }
 
-const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editingProduct }) => {
+const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editingProduct, stores }) => {
     const [code, setCode] = useState('');
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
+    const [selectedStoreIds, setSelectedStoreIds] = useState<number[]>([]);
 
     useEffect(() => {
         if (editingProduct) {
             setCode(editingProduct.product_code);
             setName(editingProduct.product_name);
             setPrice(String(editingProduct.product_price));
+            setSelectedStoreIds(editingProduct.visible_store_ids || []);
         } else {
             setCode('');
             setName('');
             setPrice('');
+            setSelectedStoreIds([]);
         }
     }, [editingProduct]);
+
+    const handleStoreCheckChange = (id: number, checked: boolean) => {
+        setSelectedStoreIds(prev => checked ? [...prev, id] : prev.filter(sid => sid !== id));
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
+            const payload = { code, name, price: Number(price), visible_store_ids: selectedStoreIds.length > 0 ? selectedStoreIds : null };
             if (editingProduct) {
-                await updateProduct(editingProduct.product_id, { code, name, price: Number(price) });
+                await updateProduct(editingProduct.product_id, payload);
             } else {
-                await addProduct({ code, name, price: Number(price) });
+                await addProduct(payload);
             }
             onHide();
         } catch (err) {
@@ -58,6 +68,21 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editing
                     <Form.Group className="mb-3">
                         <Form.Label>設定售價</Form.Label>
                         <Form.Control type="number" min={0} value={price} onChange={e => setPrice(e.target.value)} />
+                    </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Label>限定分店 (可複選)</Form.Label>
+                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
+                            {stores.map(s => (
+                                <Form.Check
+                                    key={`store-${s.store_id}`}
+                                    type="checkbox"
+                                    id={`store-check-${s.store_id}`}
+                                    label={s.store_name}
+                                    checked={selectedStoreIds.includes(s.store_id)}
+                                    onChange={e => handleStoreCheckChange(s.store_id, e.target.checked)}
+                                />
+                            ))}
+                        </div>
                     </Form.Group>
                 </Modal.Body>
                 <Modal.Footer>

--- a/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
@@ -2,37 +2,47 @@ import React, { useState, useEffect } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
 import { addTherapy, updateTherapy } from '../../../services/TherapyService';
 import { Therapy } from '../../../services/ProductBundleService';
+import { Store } from '../../../services/StoreService';
 
 interface AddTherapyModalProps {
     show: boolean;
     onHide: () => void;
     editingTherapy?: Therapy | null;
+    stores: Store[];
 }
 
-const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editingTherapy }) => {
+const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editingTherapy, stores }) => {
     const [code, setCode] = useState('');
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
+    const [selectedStoreIds, setSelectedStoreIds] = useState<number[]>([]);
 
     useEffect(() => {
         if (editingTherapy) {
             setCode(editingTherapy.code);
             setName(editingTherapy.name);
             setPrice(String(editingTherapy.price));
+            setSelectedStoreIds(editingTherapy.visible_store_ids || []);
         } else {
             setCode('');
             setName('');
             setPrice('');
+            setSelectedStoreIds([]);
         }
     }, [editingTherapy]);
+
+    const handleStoreCheckChange = (id: number, checked: boolean) => {
+        setSelectedStoreIds(prev => checked ? [...prev, id] : prev.filter(sid => sid !== id));
+    };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
+            const payload = { code, name, price: Number(price), visible_store_ids: selectedStoreIds.length > 0 ? selectedStoreIds : null };
             if (editingTherapy) {
-                await updateTherapy(editingTherapy.therapy_id, { code, name, price: Number(price) });
+                await updateTherapy(editingTherapy.therapy_id, payload);
             } else {
-                await addTherapy({ code, name, price: Number(price) });
+                await addTherapy(payload);
             }
             onHide();
         } catch (err) {
@@ -58,6 +68,21 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
                     <Form.Group className="mb-3">
                         <Form.Label>設定售價</Form.Label>
                         <Form.Control type="number" min={0} value={price} onChange={e => setPrice(e.target.value)} />
+                    </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Label>限定分店 (可複選)</Form.Label>
+                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
+                            {stores.map(s => (
+                                <Form.Check
+                                    key={`store-${s.store_id}`}
+                                    type="checkbox"
+                                    id={`store-check-${s.store_id}`}
+                                    label={s.store_name}
+                                    checked={selectedStoreIds.includes(s.store_id)}
+                                    onChange={e => handleStoreCheckChange(s.store_id, e.target.checked)}
+                                />
+                            ))}
+                        </div>
                     </Form.Group>
                 </Modal.Body>
                 <Modal.Footer>

--- a/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
+++ b/client/src/pages/backend/product_bundle/ProductBundleManagement.tsx
@@ -620,18 +620,26 @@ const ProductBundleManagement: React.FC = () => {
                                 <tr>
                                     <th>產品編號</th>
                                     <th>項目名稱</th>
+                                    <th>限定分店</th>
                                     <th>售價</th>
                                     <th>操作</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {productLoading ? (
-                                    <tr><td colSpan={4} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                                    <tr><td colSpan={5} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
                                 ) : filteredProducts.length > 0 ? (
                                     filteredProducts.map(product => (
                                         <tr key={product.product_id}>
                                             <td className="align-middle">{product.product_code}</td>
                                             <td className="align-middle">{product.product_name}</td>
+                                            <td className="align-middle">
+                                                {product.visible_store_ids && product.visible_store_ids.length > 0
+                                                    ? product.visible_store_ids
+                                                        .map(id => stores.find(s => s.store_id === id)?.store_name || id)
+                                                        .join(', ')
+                                                    : '---'}
+                                            </td>
                                             <td className="align-middle">{`$${Number(product.product_price).toLocaleString()}`}</td>
                                             <td className="align-middle">
                                                 <Button variant="link" onClick={() => handleShowEditProductModal(product)}>修改</Button>
@@ -675,7 +683,7 @@ const ProductBundleManagement: React.FC = () => {
                                         </tr>
                                     ))
                                 ) : (
-                                    <tr><td colSpan={4} className="text-center text-muted py-5">尚無資料</td></tr>
+                                    <tr><td colSpan={5} className="text-center text-muted py-5">尚無資料</td></tr>
                                 )}
                             </tbody>
                         </Table>
@@ -705,18 +713,26 @@ const ProductBundleManagement: React.FC = () => {
                                 <tr>
                                     <th>療程編號</th>
                                     <th>項目名稱</th>
+                                    <th>限定分店</th>
                                     <th>售價</th>
                                     <th>操作</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {therapyLoading ? (
-                                    <tr><td colSpan={4} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
+                                    <tr><td colSpan={5} className="text-center py-5"><Spinner animation="border" variant="info"/></td></tr>
                                 ) : filteredTherapies.length > 0 ? (
                                     filteredTherapies.map(therapy => (
                                         <tr key={therapy.therapy_id}>
                                             <td className="align-middle">{therapy.code}</td>
                                             <td className="align-middle">{therapy.name}</td>
+                                            <td className="align-middle">
+                                                {therapy.visible_store_ids && therapy.visible_store_ids.length > 0
+                                                    ? therapy.visible_store_ids
+                                                        .map(id => stores.find(s => s.store_id === id)?.store_name || id)
+                                                        .join(', ')
+                                                    : '---'}
+                                            </td>
                                             <td className="align-middle">{`$${Number(therapy.price).toLocaleString()}`}</td>
                                             <td className="align-middle">
                                                 <Button variant="link" onClick={() => handleShowEditTherapyModal(therapy)}>修改</Button>
@@ -760,7 +776,7 @@ const ProductBundleManagement: React.FC = () => {
                                         </tr>
                                     ))
                                 ) : (
-                                    <tr><td colSpan={4} className="text-center text-muted py-5">尚無資料</td></tr>
+                                    <tr><td colSpan={5} className="text-center text-muted py-5">尚無資料</td></tr>
                                 )}
                             </tbody>
                         </Table>
@@ -790,11 +806,13 @@ const ProductBundleManagement: React.FC = () => {
                 show={showTherapyModal}
                 onHide={handleCloseTherapyModal}
                 editingTherapy={editingTherapy}
+                stores={stores}
             />
             <AddProductModal
                 show={showProductModal}
                 onHide={handleCloseProductModal}
                 editingProduct={editingProduct}
+                stores={stores}
             />
         </>
     );

--- a/client/src/services/ProductBundleService.ts
+++ b/client/src/services/ProductBundleService.ts
@@ -41,6 +41,7 @@ export interface Product {
     product_name: string;
     product_price: number;
     product_code: string;
+    visible_store_ids?: number[];
 }
 
 export interface Therapy {
@@ -49,6 +50,7 @@ export interface Therapy {
     price: number;
     code: string;
     content?: string;
+     visible_store_ids?: number[];
 }
 
 

--- a/client/src/services/ProductService.ts
+++ b/client/src/services/ProductService.ts
@@ -11,6 +11,7 @@ export interface Product {
   content?: string;
   price: number;
   inventory_count?: number;
+  visible_store_ids?: number[];
 }
 
 // 獲取所有產品
@@ -49,7 +50,7 @@ export const getProductById = async (productId: number): Promise<Product> => {
   }
 };
 
-export const addProduct = async (data: { code: string; name: string; price: number }) => {
+export const addProduct = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null }) => {
   try {
     const token = localStorage.getItem("token");
     const response = await axios.post(`${API_URL}/`, data, {
@@ -68,7 +69,7 @@ export const addProduct = async (data: { code: string; name: string; price: numb
 
 export const updateProduct = async (
   productId: number,
-  data: { code: string; name: string; price: number }
+  data: { code: string; name: string; price: number; visible_store_ids?: number[] | null }
 ) => {
   try {
     const token = localStorage.getItem("token");

--- a/client/src/services/TherapyService.ts
+++ b/client/src/services/TherapyService.ts
@@ -164,7 +164,7 @@ export const getAllTherapiesForDropdown = async () => {
     return response.data;
 };
 
-export const addTherapy = async (data: { code: string; name: string; price: number }) => {
+export const addTherapy = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null }) => {
     try {
         const token = localStorage.getItem("token");
         const response = await axios.post(`${API_URL}/package`, data, {
@@ -183,7 +183,7 @@ export const addTherapy = async (data: { code: string; name: string; price: numb
 
 export const updateTherapy = async (
     therapyId: number,
-    data: { code: string; name: string; price: number; content?: string }
+    data: { code: string; name: string; price: number; content?: string; visible_store_ids?: number[] | null }
 ) => {
     try {
         const token = localStorage.getItem("token");

--- a/server/app/models/product_model.py
+++ b/server/app/models/product_model.py
@@ -1,4 +1,5 @@
 import pymysql
+import json
 from app.config import DB_CONFIG
 from pymysql.cursors import DictCursor
 
@@ -14,13 +15,14 @@ def create_product(data: dict):
     try:
         with conn.cursor() as cursor:
             query = (
-                "INSERT INTO product (code, name, price, status) "
-                "VALUES (%s, %s, %s, 'PUBLISHED')"
+                "INSERT INTO product (code, name, price, visible_store_ids, status) "
+                "VALUES (%s, %s, %s, %s, 'PUBLISHED')"
             )
             cursor.execute(query, (
                 data.get("code"),
                 data.get("name"),
                 data.get("price"),
+                json.dumps(data.get("visible_store_ids")) if data.get("visible_store_ids") is not None else None,
             ))
             product_id = conn.insert_id()
         conn.commit()
@@ -38,12 +40,13 @@ def update_product(product_id: int, data: dict):
     try:
         with conn.cursor() as cursor:
             query = (
-                "UPDATE product SET code=%s, name=%s, price=%s WHERE product_id=%s"
+                "UPDATE product SET code=%s, name=%s, price=%s, visible_store_ids=%s WHERE product_id=%s"
             )
             cursor.execute(query, (
                 data.get("code"),
                 data.get("name"),
                 data.get("price"),
+                json.dumps(data.get("visible_store_ids")) if data.get("visible_store_ids") is not None else None,
                 product_id,
             ))
         conn.commit()

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -1,5 +1,6 @@
 # \app\models\product_sell_model.py
 import pymysql
+import json
 from decimal import Decimal
 from app.config import DB_CONFIG
 
@@ -473,6 +474,7 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                 p.code AS product_code,
                 p.name AS product_name,
                 p.price AS product_price,
+                p.visible_store_ids,
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id
             FROM product p
@@ -490,11 +492,23 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
         if status:
             query += " WHERE p.status = %s"
             params.append(status)
-        query += " GROUP BY p.product_id, p.code, p.name, p.price ORDER BY p.name"
+        query += " GROUP BY p.product_id, p.code, p.name, p.price, p.visible_store_ids ORDER BY p.name"
         cursor.execute(query, tuple(params))
         result = cursor.fetchall()
     conn.close()
-    return result
+    filtered = []
+    for row in result:
+        store_ids = None
+        if row.get('visible_store_ids'):
+            try:
+                store_ids = json.loads(row['visible_store_ids'])
+            except Exception:
+                store_ids = None
+        if store_id is None or not store_ids or int(store_id) in store_ids:
+            if store_ids is not None:
+                row['visible_store_ids'] = store_ids
+            filtered.append(row)
+    return filtered
 
 def search_products_with_inventory(keyword, store_id=None, status: str | None = 'PUBLISHED'):
     """
@@ -511,6 +525,7 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                 p.code AS product_code,
                 p.name AS product_name,
                 p.price AS product_price,
+                p.visible_store_ids,
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id
             FROM product p
@@ -537,12 +552,24 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
-        query += " GROUP BY p.product_id, p.code, p.name, p.price ORDER BY p.name"
+        query += " GROUP BY p.product_id, p.code, p.name, p.price, p.visible_store_ids ORDER BY p.name"
 
         cursor.execute(query, tuple(params))
         result = cursor.fetchall()
     conn.close()
-    return result
+    filtered = []
+    for row in result:
+        store_ids = None
+        if row.get('visible_store_ids'):
+            try:
+                store_ids = json.loads(row['visible_store_ids'])
+            except Exception:
+                store_ids = None
+        if store_id is None or not store_ids or int(store_id) in store_ids:
+            if store_ids is not None:
+                row['visible_store_ids'] = store_ids
+            filtered.append(row)
+    return filtered
 
 def export_product_sells(store_id=None):
     """匯出產品銷售記錄，可選用 store_id 過濾"""

--- a/server/app/routes/therapy.py
+++ b/server/app/routes/therapy.py
@@ -325,7 +325,9 @@ def get_therapy_list():
     """提供給前端下拉選單使用的療程列表"""
     try:
         status = request.args.get("status", 'PUBLISHED')
-        therapy_list = get_all_therapies_for_dropdown(status)
+        user = get_user_from_token(request)
+        store_id = user.get('store_id') if user and user.get('permission') != 'admin' else None
+        therapy_list = get_all_therapies_for_dropdown(status, store_id)
         return jsonify(therapy_list)
     except Exception as e:
         return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- support `visible_store_ids` for products and therapies
- filter product and therapy listings by allowed stores
- allow configuring store restrictions in product and therapy management tabs

## Testing
- `npm test` (fails: Missing script: "test")
- `cd server && pytest` (fails: pyenv: version `3.11.3` is not installed)


------
https://chatgpt.com/codex/tasks/task_e_68b982588d588329a22a06030751e20c