### PR TITLE
Fix therapy bundle store ID parsing for filtering

### DIFF
--- a/server/app/models/therapy_bundle_model.py
+++ b/server/app/models/therapy_bundle_model.py
@@ -45,22 +45,25 @@ def get_all_therapy_bundles(status: str | None = None, store_id: int | None = No
             query += " GROUP BY tb.bundle_id ORDER BY tb.bundle_id DESC"
             cursor.execute(query, tuple(params))
             result = cursor.fetchall()
-            filtered = []
+            # 解析每筆資料中的可見門市 ID，使其成為整數列表以便後續篩選
             for row in result:
-                store_ids = None
-                if row.get('visible_store_ids'):
+                if row.get("visible_store_ids"):
                     try:
-                        store_ids = json.loads(row['visible_store_ids'])
+                        store_ids = json.loads(row["visible_store_ids"])
                         if isinstance(store_ids, (int, str)):
                             store_ids = [int(store_ids)]
+                        row["visible_store_ids"] = store_ids
                     except Exception:
-                        pass
+                        row["visible_store_ids"] = None
+                else:
+                    row["visible_store_ids"] = None
+
             if store_id is not None:
                 result = [
                     row
                     for row in result
-                    if not row.get('visible_store_ids')
-                    or store_id in row['visible_store_ids']
+                    if not row.get("visible_store_ids")
+                    or store_id in row["visible_store_ids"]
                 ]
             return result
     finally:


### PR DESCRIPTION
## Summary
- Parse therapy bundle `visible_store_ids` into integer lists for accurate filtering
- Prevent type errors when checking store visibility

## Testing
- `pip install -r requirements.txt`
- `pip install requests openpyxl bcrypt`
- `PYENV_VERSION=3.11.12 pytest tests/test_therapy_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b98636683483299a070477d48dc7ad