### PR TITLE
Show bundle items in inventory details

### DIFF
--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -27,6 +27,7 @@ interface RecordRow {
   Buyer?: string;
   Voucher?: string;
   Price?: number;
+  Category?: string;
 }
 
 const InventoryDetail: React.FC = () => {
@@ -187,7 +188,7 @@ const InventoryDetail: React.FC = () => {
                 <td>{r.Price ?? ''}</td>
                 <td>{r.quantity}</td>
                 <td>{r.Price ? Math.abs(r.Price * r.quantity) : ''}</td>
-                <td></td>
+                <td>{r.Category || ''}</td>
                 <td></td>
                 <td>{formatDate(r.Date)}</td>
                 <td>{r.Supplier ?? ''}</td>

--- a/server/app/models/inventory_model.py
+++ b/server/app/models/inventory_model.py
@@ -306,7 +306,7 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None,
             prod_q = """
                 SELECT
                     ps.product_sell_id + 1000000 AS Inventory_ID,
-                    p.name AS Name,
+                    COALESCE(p.name, ps.product_name) AS Name,
                     NULL AS Unit,
                     ps.unit_price AS Price,
                     -ps.quantity AS quantity,
@@ -319,7 +319,8 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None,
                     st.store_name AS StoreName,
                     sf.name AS SaleStaff,
                     mb.name AS Buyer,
-                    '' AS Voucher
+                    '' AS Voucher,
+                    CASE WHEN ps.note LIKE '%[bundle:%' THEN '套組銷售' ELSE NULL END AS Category
                 FROM product_sell ps
                 LEFT JOIN product p ON ps.product_id = p.product_id
                 LEFT JOIN staff sf ON ps.staff_id = sf.staff_id
@@ -355,7 +356,7 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None,
             therapy_q = """
                 SELECT
                     ts.therapy_sell_id + 2000000 AS Inventory_ID,
-                    t.name AS Name,
+                    COALESCE(t.name, ts.therapy_name) AS Name,
                     NULL AS Unit,
                     t.price AS Price,
                     -ts.amount AS quantity,
@@ -368,7 +369,8 @@ def get_inventory_history(store_id=None, start_date=None, end_date=None,
                     st.store_name AS StoreName,
                     sf.name AS SaleStaff,
                     mb.name AS Buyer,
-                    '' AS Voucher
+                    '' AS Voucher,
+                    CASE WHEN ts.note LIKE '%[bundle:%' THEN '套組銷售' ELSE NULL END AS Category
                 FROM therapy_sell ts
                 LEFT JOIN therapy t ON ts.therapy_id = t.therapy_id
                 LEFT JOIN staff sf ON ts.staff_id = sf.staff_id


### PR DESCRIPTION
## Summary
- Display product and therapy bundle components in inventory history with proper names
- Tag bundled sales as `套組銷售` and surface category on inventory detail page

## Testing
- `pytest -q` *(fails: pyenv: version `3.11.3` is not installed)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b98726e8348329be6963f377652bcb