### PR TITLE
Fix therapy bundle sales missing item names

### DIFF
--- a/server/app/models/therapy_sell_model.py
+++ b/server/app/models/therapy_sell_model.py
@@ -242,14 +242,20 @@ def insert_many_therapy_sells(sales_data_list: list[dict]):
                 if bundle_id:
                     bundle_qty = int(data_item.get("amount", 1))
                     cursor.execute(
-                        "SELECT item_id, quantity FROM product_bundle_items WHERE bundle_id = %s AND item_type = 'Therapy'",
+                        "SELECT item_id, quantity FROM therapy_bundle_items WHERE bundle_id = %s",
                         (bundle_id,)
                     )
                     bundle_items = cursor.fetchall()
                     if not bundle_items:
+                        cursor.execute(
+                            "SELECT name FROM therapy_bundles WHERE bundle_id = %s",
+                            (bundle_id,),
+                        )
+                        bundle_row = cursor.fetchone()
+                        bundle_name = bundle_row.get("name") if bundle_row else None
                         empty_bundle_values = {
                             "therapy_id": None,
-                            "therapy_name": data_item.get("therapy_name") or data_item.get("therapyName"),
+                            "therapy_name": bundle_name or data_item.get("therapy_name") or data_item.get("therapyName"),
                             "member_id": data_item.get("memberId"),
                             "store_id": data_item.get("storeId"),
                             "staff_id": data_item.get("staffId"),


### PR DESCRIPTION
## Summary
- Use therapy_bundle_items table when inserting bundle sales
- Store bundle name when bundle items unavailable to ensure item names display

## Testing
- `PYENV_VERSION=3.11.12 pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b98fd799cc8329a26fa5686ca917cb