### PR TITLE
fix: remove head store option from account dropdown

### DIFF
--- a/client/src/pages/backend/AddEditUserAccount.tsx
+++ b/client/src/pages/backend/AddEditUserAccount.tsx
@@ -37,7 +37,7 @@ const AddEditUserAccount: React.FC = () => {
 
     useEffect(() => {
         fetchStoresForDropdown()
-            .then(setStores)
+            .then(data => setStores(data.filter(store => store.store_name !== '總店')))
             .catch(() => setError("無法載入分店列表"));
     }, []);
 


### PR DESCRIPTION
## Summary
- filter out the head store when loading branches for employee account creation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve entry module "index.html")
- `pytest` (fails: KeyError: 'app')

------
https://chatgpt.com/codex/tasks/task_e_68b9909f78dc8329b484087f1cd374a1