### PR TITLE
Allow admins to view all bundles

### DIFF
--- a/server/app/routes/product_bundle.py
+++ b/server/app/routes/product_bundle.py
@@ -19,8 +19,18 @@ def get_bundles():
     """獲取產品組合列表"""
     try:
         status = request.args.get("status")
-        store_id = request.headers.get('X-Store-ID')
-        bundles = get_all_product_bundles(status, int(store_id) if store_id else None)
+        # 總店或具備 admin 權限的使用者應能查看所有組合，不受門市限制
+        store_level = request.headers.get('X-Store-Level')
+        store_id_header = request.headers.get('X-Store-ID')
+
+        store_id = None
+        if store_level not in ["總店", "admin"] and store_id_header:
+            try:
+                store_id = int(store_id_header)
+            except (TypeError, ValueError):
+                store_id = None
+
+        bundles = get_all_product_bundles(status, store_id)
         return jsonify(bundles)
     except Exception as e:
         print(f"Error fetching product bundles: {e}")

--- a/server/app/routes/therapy_bundle.py
+++ b/server/app/routes/therapy_bundle.py
@@ -17,8 +17,18 @@ def get_bundles():
     """獲取療程組合列表"""
     try:
         status = request.args.get("status")
-        store_id = request.headers.get('X-Store-ID')
-        bundles = get_all_therapy_bundles(status, int(store_id) if store_id else None)
+        # 總店或 admin 權限可以取得所有療程組合，不限制分店
+        store_level = request.headers.get('X-Store-Level')
+        store_id_header = request.headers.get('X-Store-ID')
+
+        store_id = None
+        if store_level not in ["總店", "admin"] and store_id_header:
+            try:
+                store_id = int(store_id_header)
+            except (TypeError, ValueError):
+                store_id = None
+
+        bundles = get_all_therapy_bundles(status, store_id)
         return jsonify(bundles)
     except Exception as e:
         print(f"Error fetching therapy bundles: {e}")


### PR DESCRIPTION
## Summary
- allow product bundle listing to ignore store restriction for HQ and admin users
- apply same logic to therapy bundle listing

## Testing
- `PYENV_VERSION=3.11.12 pytest --ignore=app/routes/stress_test.py` *(fails: HTTPConnectionPool host='localhost', port=5000: Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a99aa6208329a01d263fc3bc29a1