### PR TITLE
Fix product bundle visibility filtering

### DIFF
--- a/client/src/pages/product/ProductSelection.tsx
+++ b/client/src/pages/product/ProductSelection.tsx
@@ -54,7 +54,11 @@ const ProductSelection: React.FC = () => {
 
         const storeId = Number(getStoreId());
         const filteredBundles = storeId
-          ? bundleData.filter(b => !b.visible_store_ids || b.visible_store_ids.includes(storeId))
+          ? bundleData.filter(b =>
+              !b.visible_store_ids ||
+              b.visible_store_ids.length === 0 ||
+              b.visible_store_ids.includes(storeId)
+            )
           : bundleData;
         const bundles: ItemBase[] = filteredBundles.map((b: Bundle) => ({
           type: 'bundle',


### PR DESCRIPTION
## Summary
- ensure product bundles with no store restriction are visible to all stores

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68ba8b05dad48329accf8f76a60d5199