### PR TITLE
Fix store-specific filtering for bundles

### DIFF
--- a/server/app/routes/product_bundle.py
+++ b/server/app/routes/product_bundle.py
@@ -43,7 +43,17 @@ def get_available_bundles():
     """根據店家權限取得可用的產品組合列表"""
     try:
         user = get_user_from_token(request)
-        store_id = user.get('store_id') if user and user.get('permission') != 'admin' else None
+        store_id = None
+
+        if user and user.get('permission') == 'admin':
+            store_id = None
+        else:
+            store_id = user.get('store_id') if user else getattr(request, 'store_id', None)
+            try:
+                store_id = int(store_id) if store_id is not None else None
+            except (TypeError, ValueError):
+                store_id = None
+
         bundles = get_all_product_bundles(status="PUBLISHED", store_id=store_id)
         return jsonify(bundles)
     except Exception as e:

--- a/server/app/routes/therapy_bundle.py
+++ b/server/app/routes/therapy_bundle.py
@@ -105,7 +105,17 @@ def get_available_therapy_bundles():
     """根據店家權限取得可用的療程組合列表"""
     try:
         user = get_user_from_token(request)
-        store_id = user.get('store_id') if user and user.get('permission') != 'admin' else None
+        store_id = None
+
+        if user and user.get('permission') == 'admin':
+            store_id = None
+        else:
+            store_id = user.get('store_id') if user else getattr(request, 'store_id', None)
+            try:
+                store_id = int(store_id) if store_id is not None else None
+            except (TypeError, ValueError):
+                store_id = None
+
         bundles = get_all_therapy_bundles(status="PUBLISHED", store_id=store_id)
         return jsonify(bundles)
     except Exception as e:


### PR DESCRIPTION
## Summary
- ensure bundle availability endpoints respect store-specific visibility even without JWT token

## Testing
- `python -m py_compile server/app/routes/product_bundle.py server/app/routes/therapy_bundle.py`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ba995129b08329aad7e726e33b5482