### PR TITLE
Fix store-specific filtering for bundles

### DIFF
--- a/server/app/models/product_bundle_model.py
+++ b/server/app/models/product_bundle_model.py
@@ -18,6 +18,7 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
     以利前端直接顯示。
     會依據傳入的 store_id 過濾僅限於該分店可見的組合。
     """
+    print(f"[DEBUG] get_all_product_bundles called with status={status}, store_id={store_id}")
     conn = connect_to_db()
     try:
         with conn.cursor() as cursor:
@@ -60,22 +61,34 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
             cursor.execute(query, tuple(params))
             result = cursor.fetchall()
 
-            # 將可見分店欄位從 JSON 轉換為整數列表，以便後續比對
+            # 將可見分店欄位統一轉換為整數列表，以便後續比對
             for row in result:
-                if row.get('visible_store_ids'):
-                    try:
-                        store_ids = json.loads(row['visible_store_ids'])
-                        if isinstance(store_ids, int):
-                            store_ids = [store_ids]
-                        elif isinstance(store_ids, str):
-                            store_ids = [int(store_ids)]
-                        else:
-                            store_ids = [int(s) for s in store_ids]
-                        row['visible_store_ids'] = store_ids
-                    except Exception:
-                        row['visible_store_ids'] = []
-                else:
+                raw_ids = row.get('visible_store_ids')
+                print(f"[DEBUG] Bundle {row.get('bundle_id')} raw visible_store_ids={raw_ids}")
+                if raw_ids in (None, ''):
                     row['visible_store_ids'] = []
+                    print(f"[DEBUG] -> normalized visible_store_ids={row['visible_store_ids']}")
+                    continue
+                try:
+                    # 若資料庫 driver 已自動解析為 list，直接使用
+                    if isinstance(raw_ids, list):
+                        parsed = raw_ids
+                    # 若為單一整數或字串，轉為列表
+                    elif isinstance(raw_ids, (int, str)):
+                        parsed = json.loads(str(raw_ids))
+                    else:
+                        parsed = json.loads(raw_ids)
+
+                    if isinstance(parsed, list):
+                        row['visible_store_ids'] = [int(s) for s in parsed]
+                    elif isinstance(parsed, (int, str)):
+                        row['visible_store_ids'] = [int(parsed)]
+                    else:
+                        row['visible_store_ids'] = []
+                    print(f"[DEBUG] -> normalized visible_store_ids={row['visible_store_ids']}")
+                except Exception as e:
+                    row['visible_store_ids'] = []
+                    print(f"[DEBUG] Failed to parse visible_store_ids for bundle {row.get('bundle_id')}: {e}")
 
             if store_id is not None:
                 result = [
@@ -84,6 +97,9 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
                     if not row['visible_store_ids']
                     or store_id in row['visible_store_ids']
                 ]
+                print(f"[DEBUG] Filtered bundle_ids for store_id={store_id}: {[row.get('bundle_id') for row in result]}")
+            else:
+                print(f"[DEBUG] Returning all bundles without store filter; count={len(result)}")
             return result
     finally:
         conn.close()

--- a/server/app/routes/product_bundle.py
+++ b/server/app/routes/product_bundle.py
@@ -29,7 +29,7 @@ def get_bundles():
                 store_id = int(store_id_header)
             except (TypeError, ValueError):
                 store_id = None
-
+        print(f"[DEBUG] get_product_bundles status={status}, store_level={store_level}, store_id={store_id}")
         bundles = get_all_product_bundles(status, store_id)
         return jsonify(bundles)
     except Exception as e:
@@ -43,7 +43,17 @@ def get_available_bundles():
     """根據店家權限取得可用的產品組合列表"""
     try:
         user = get_user_from_token(request)
-        store_id = user.get('store_id') if user and user.get('permission') != 'admin' else None
+        store_id = None
+
+        if user and user.get('permission') == 'admin':
+            store_id = None
+        else:
+            store_id = user.get('store_id') if user else getattr(request, 'store_id', None)
+            try:
+                store_id = int(store_id) if store_id is not None else None
+            except (TypeError, ValueError):
+                store_id = None
+        print(f"[DEBUG] get_available_product_bundles user={user}, store_id={store_id}")
         bundles = get_all_product_bundles(status="PUBLISHED", store_id=store_id)
         return jsonify(bundles)
     except Exception as e:

--- a/server/app/routes/therapy_bundle.py
+++ b/server/app/routes/therapy_bundle.py
@@ -27,7 +27,7 @@ def get_bundles():
                 store_id = int(store_id_header)
             except (TypeError, ValueError):
                 store_id = None
-
+        print(f"[DEBUG] get_therapy_bundles status={status}, store_level={store_level}, store_id={store_id}")
         bundles = get_all_therapy_bundles(status, store_id)
         return jsonify(bundles)
     except Exception as e:
@@ -105,7 +105,17 @@ def get_available_therapy_bundles():
     """根據店家權限取得可用的療程組合列表"""
     try:
         user = get_user_from_token(request)
-        store_id = user.get('store_id') if user and user.get('permission') != 'admin' else None
+        store_id = None
+
+        if user and user.get('permission') == 'admin':
+            store_id = None
+        else:
+            store_id = user.get('store_id') if user else getattr(request, 'store_id', None)
+            try:
+                store_id = int(store_id) if store_id is not None else None
+            except (TypeError, ValueError):
+                store_id = None
+        print(f"[DEBUG] get_available_therapy_bundles user={user}, store_id={store_id}")
         bundles = get_all_therapy_bundles(status="PUBLISHED", store_id=store_id)
         return jsonify(bundles)
     except Exception as e:


### PR DESCRIPTION
## Summary
- ensure bundle availability endpoints respect store-specific visibility even without JWT token
- handle already-parsed JSON lists for visible store IDs when filtering bundles
- add debug logs to trace store visibility parsing and filtering

## Testing
- `python -m py_compile server/app/routes/product_bundle.py server/app/routes/therapy_bundle.py server/app/models/product_bundle_model.py server/app/models/therapy_bundle_model.py`
- `python3 -m pytest` *(fails: ModuleNotFoundError: No module named 'jwt')*


------
https://chatgpt.com/codex/tasks/task_e_68ba995129b08329aad7e726e33b5482