### PR TITLE
fix: avoid duplicate bundle tabs in selection pages

### DIFF
--- a/client/src/pages/product/ProductSelection.tsx
+++ b/client/src/pages/product/ProductSelection.tsx
@@ -217,7 +217,7 @@ const ProductSelection: React.FC = () => {
     if (displayedItems.length === 0 && !pageError) {
       return (
         <Alert variant="secondary">
-          目前沒有符合條件的{topTab === 'product' ? '產品' : '產品組合'}。
+          目前沒有符合條件的{activeTab === 'product' ? '產品' : '產品組合'}。
         </Alert>
       );
     }
@@ -328,15 +328,6 @@ const ProductSelection: React.FC = () => {
               </Tabs>
             </Tab>
           </Tabs>
-
-          {activeTab === 'bundle' && (
-            <Tabs activeKey={activeBundleTab} onSelect={(k) => setActiveBundleTab(k || 'all')} className="mb-3">
-              <Tab eventKey="all" title="全部" />
-              {bundleCategories.map(cat => (
-                <Tab key={cat.category_id} eventKey={cat.name} title={cat.name} />
-              ))}
-            </Tabs>
-          )}
 
           {renderItemList()}
         </Card.Body>

--- a/client/src/pages/therapy/TherapyPackageSelection.tsx
+++ b/client/src/pages/therapy/TherapyPackageSelection.tsx
@@ -261,15 +261,6 @@ const TherapyPackageSelection: React.FC = () => {
                         </Tab>
                     </Tabs>
 
-                    {activeTab === 'bundle' && (
-                        <Tabs activeKey={activeBundleTab} onSelect={(k) => setActiveBundleTab(k || 'all')} className="mb-3">
-                            <Tab eventKey="all" title="全部" />
-                            {bundleCategories.map(cat => (
-                                <Tab key={cat.category_id} eventKey={cat.name} title={cat.name} />
-                            ))}
-                        </Tabs>
-                    )}
-
                     {loading && (
                         <div className="text-center p-5"><Spinner animation="border" variant="info" /> <p className="mt-2">載入中...</p></div>
                     )}


### PR DESCRIPTION
## Summary
- prevent double-rendering of bundle subcategory tabs in product selection
- prevent duplicate bundle subcategory tabs in therapy package selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Irregular whitespace and unused vars)*
- `npm run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c822e7054083299bbf7ebf24176b16