### PR TITLE
feat: expand category management

### DIFF
--- a/client/src/pages/backend/product_bundle/AddCategoryModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddCategoryModal.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+import { addCategory } from '../../../services/CategoryService';
+
+interface Props {
+  show: boolean;
+  onHide: () => void;
+}
+
+const AddCategoryModal: React.FC<Props> = ({ show, onHide }) => {
+  const [name, setName] = useState('');
+  const [targetType, setTargetType] = useState<'product' | 'therapy' | 'product_bundle' | 'therapy_bundle'>('product');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await addCategory({ name, target_type: targetType });
+      setName('');
+      onHide();
+    } catch (err) {
+      alert('新增分類失敗');
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Form onSubmit={handleSubmit}>
+        <Modal.Header closeButton>
+          <Modal.Title>新增分類</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Group className="mb-3">
+            <Form.Label>分類名稱</Form.Label>
+            <Form.Control value={name} onChange={e => setName(e.target.value)} />
+          </Form.Group>
+          <Form.Group className="mb-3">
+            <Form.Label>分類類型</Form.Label>
+            <Form.Select value={targetType} onChange={e => setTargetType(e.target.value as any)}>
+              <option value="product">商品</option>
+              <option value="therapy">療程</option>
+              <option value="product_bundle">產品組合</option>
+              <option value="therapy_bundle">療程組合</option>
+            </Form.Select>
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="info" className="text-white" onClick={onHide}>取消</Button>
+          <Button variant="info" className="text-white" type="submit">新增</Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+};
+
+export default AddCategoryModal;

--- a/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Modal, Form, Button } from 'react-bootstrap';
 import { addTherapy, updateTherapy } from '../../../services/TherapyService';
 import { Therapy } from '../../../services/ProductBundleService';
+import { getCategories, Category } from '../../../services/CategoryService';
 import { Store } from '../../../services/StoreService';
 
 interface AddTherapyModalProps {
@@ -16,6 +17,8 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
     const [selectedStoreIds, setSelectedStoreIds] = useState<number[]>([]);
+    const [categories, setCategories] = useState<Category[]>([]);
+    const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
 
     useEffect(() => {
         if (editingTherapy) {
@@ -23,13 +26,19 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
             setName(editingTherapy.name);
             setPrice(String(editingTherapy.price));
             setSelectedStoreIds(editingTherapy.visible_store_ids || []);
+            setSelectedCategoryIds([]);
         } else {
             setCode('');
             setName('');
             setPrice('');
             setSelectedStoreIds([]);
+            setSelectedCategoryIds([]);
         }
     }, [editingTherapy]);
+
+    useEffect(() => {
+        getCategories('therapy').then(setCategories).catch(() => {});
+    }, []);
 
     const handleStoreCheckChange = (id: number, checked: boolean) => {
         setSelectedStoreIds(prev => checked ? [...prev, id] : prev.filter(sid => sid !== id));
@@ -38,7 +47,13 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            const payload = { code, name, price: Number(price), visible_store_ids: selectedStoreIds.length > 0 ? selectedStoreIds : null };
+            const payload = {
+                code,
+                name,
+                price: Number(price),
+                visible_store_ids: selectedStoreIds.length > 0 ? selectedStoreIds : null,
+                category_ids: selectedCategoryIds,
+            };
             if (editingTherapy) {
                 await updateTherapy(editingTherapy.therapy_id, payload);
             } else {
@@ -48,6 +63,10 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
         } catch (err) {
             alert(editingTherapy ? '更新療程失敗' : '新增療程失敗');
         }
+    };
+
+    const handleCategoryChange = (id: number, checked: boolean) => {
+        setSelectedCategoryIds(prev => checked ? [...prev, id] : prev.filter(cid => cid !== id));
     };
 
     return (
@@ -80,6 +99,21 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
                                     label={s.store_name}
                                     checked={selectedStoreIds.includes(s.store_id)}
                                     onChange={e => handleStoreCheckChange(s.store_id, e.target.checked)}
+                                />
+                            ))}
+                        </div>
+                    </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Label>分類 (可複選)</Form.Label>
+                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
+                            {categories.map(c => (
+                                <Form.Check
+                                    key={`cat-${c.category_id}`}
+                                    type="checkbox"
+                                    id={`cat-check-${c.category_id}`}
+                                    label={c.name}
+                                    checked={selectedCategoryIds.includes(c.category_id)}
+                                    onChange={e => handleCategoryChange(c.category_id, e.target.checked)}
                                 />
                             ))}
                         </div>

--- a/client/src/pages/backend/product_bundle/DeleteCategoryModal.tsx
+++ b/client/src/pages/backend/product_bundle/DeleteCategoryModal.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect } from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+import { getCategories, deleteCategory, Category } from '../../../services/CategoryService';
+
+interface Props {
+  show: boolean;
+  onHide: () => void;
+}
+
+const DeleteCategoryModal: React.FC<Props> = ({ show, onHide }) => {
+  const [targetType, setTargetType] = useState<'product' | 'therapy' | 'product_bundle' | 'therapy_bundle'>('product');
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selected, setSelected] = useState<number | ''>('');
+
+  useEffect(() => {
+    if (show) {
+      getCategories(targetType)
+        .then(data => {
+          setCategories(data);
+          setSelected('');
+        })
+        .catch(() => setCategories([]));
+    }
+  }, [show, targetType]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selected) return;
+    try {
+      await deleteCategory(Number(selected));
+      onHide();
+    } catch {
+      alert('刪除分類失敗');
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Form onSubmit={handleSubmit}>
+        <Modal.Header closeButton>
+          <Modal.Title>刪除分類</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form.Group className="mb-3">
+            <Form.Label>分類類型</Form.Label>
+            <Form.Select value={targetType} onChange={e => setTargetType(e.target.value as any)}>
+              <option value="product">商品</option>
+              <option value="therapy">療程</option>
+              <option value="product_bundle">產品組合</option>
+              <option value="therapy_bundle">療程組合</option>
+            </Form.Select>
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>選擇分類</Form.Label>
+            <Form.Select value={selected} onChange={e => setSelected(e.target.value ? Number(e.target.value) : '')}>
+              <option value="">請選擇</option>
+              {categories.filter(c => c.name !== '未歸類').map(c => (
+                <option key={c.category_id} value={c.category_id}>{c.name}</option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="info" className="text-white" onClick={onHide}>取消</Button>
+          <Button variant="danger" type="submit" disabled={!selected}>刪除</Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+};
+
+export default DeleteCategoryModal;

--- a/client/src/services/CategoryService.ts
+++ b/client/src/services/CategoryService.ts
@@ -1,0 +1,37 @@
+import axios from "axios";
+import { base_url } from "./BASE_URL";
+import { getAuthHeaders } from "./AuthUtils";
+
+export interface Category {
+  category_id: number;
+  name: string;
+  target_type: string;
+}
+
+const API_URL = `${base_url}/categories`;
+
+export const getCategories = async (targetType?: string): Promise<Category[]> => {
+  const response = await axios.get(`${API_URL}/`, {
+    params: { target_type: targetType },
+    headers: getAuthHeaders(),
+  });
+  const data: Category[] = response.data;
+  return [
+    ...data.filter(c => c.name !== '未歸類'),
+    ...data.filter(c => c.name === '未歸類')
+  ];
+};
+
+export const addCategory = async (data: { name: string; target_type: string }) => {
+  const response = await axios.post(`${API_URL}/`, data, {
+    headers: getAuthHeaders(),
+  });
+  return response.data;
+};
+
+export const deleteCategory = async (categoryId: number) => {
+  const response = await axios.delete(`${API_URL}/${categoryId}`, {
+    headers: getAuthHeaders(),
+  });
+  return response.data;
+};

--- a/client/src/services/ProductBundleService.ts
+++ b/client/src/services/ProductBundleService.ts
@@ -27,6 +27,7 @@ export interface Bundle {
     bundle_contents: string;
     created_at: string;
     visible_store_ids?: number[];
+    categories?: string[];
 }
 
 export interface BundleDetails extends Bundle {
@@ -35,6 +36,7 @@ export interface BundleDetails extends Bundle {
         item_type: 'Product' | 'Therapy';
         quantity: number;
     }[];
+    category_ids?: number[];
 }
 
 export interface Product {
@@ -43,6 +45,7 @@ export interface Product {
     product_price: number;
     product_code: string;
     visible_store_ids?: number[];
+    categories?: string[];
 }
 
 export interface Therapy {
@@ -52,6 +55,7 @@ export interface Therapy {
     code: string;
     content?: string;
      visible_store_ids?: number[];
+     categories?: string[];
 }
 
 

--- a/client/src/services/ProductSellService.ts
+++ b/client/src/services/ProductSellService.ts
@@ -24,6 +24,7 @@ export interface Product {
   product_price: number;
   inventory_id: number;
   inventory_quantity: number;
+  categories?: string[];
 }
 
 export interface ProductSellData {

--- a/client/src/services/ProductService.ts
+++ b/client/src/services/ProductService.ts
@@ -50,7 +50,7 @@ export const getProductById = async (productId: number): Promise<Product> => {
   }
 };
 
-export const addProduct = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null }) => {
+export const addProduct = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null; category_ids?: number[] }) => {
   try {
     const token = localStorage.getItem("token");
     const response = await axios.post(`${API_URL}/`, data, {
@@ -69,7 +69,7 @@ export const addProduct = async (data: { code: string; name: string; price: numb
 
 export const updateProduct = async (
   productId: number,
-  data: { code: string; name: string; price: number; visible_store_ids?: number[] | null }
+  data: { code: string; name: string; price: number; visible_store_ids?: number[] | null; category_ids?: number[] }
 ) => {
   try {
     const token = localStorage.getItem("token");

--- a/client/src/services/TherapyBundleService.ts
+++ b/client/src/services/TherapyBundleService.ts
@@ -24,6 +24,7 @@ export interface TherapyBundle {
     bundle_contents: string;
     created_at: string;
     visible_store_ids?: number[];
+    categories?: string[];
 }
 
 export interface TherapyBundleDetails extends TherapyBundle {
@@ -31,6 +32,7 @@ export interface TherapyBundleDetails extends TherapyBundle {
         item_id: number;
         quantity: number;
     }[];
+    category_ids?: number[];
 }
 
 export interface Therapy {

--- a/client/src/services/TherapySellService.ts
+++ b/client/src/services/TherapySellService.ts
@@ -29,6 +29,7 @@ export interface TherapyPackage { // 這是基礎的 TherapyPackage 型別
   name?: string;
   content?: string;
   price?: number;
+  categories?: string[];
 }
 
 export interface Store {
@@ -111,6 +112,7 @@ export const getAllTherapyPackages = async (): Promise<ApiResponse<TherapyPackag
                 TherapyPrice: item.TherapyPrice || item.price,
                 TherapyName: item.TherapyName || item.name,
                 TherapyContent: item.TherapyContent || item.content || item.TherapyName || item.name || '',
+                categories: item.categories || [],
             }));
             return { success: true, data: formattedData };
         } else if (response.data && typeof response.data === 'object' && response.data.hasOwnProperty('data') && Array.isArray(response.data.data)) {
@@ -121,6 +123,7 @@ export const getAllTherapyPackages = async (): Promise<ApiResponse<TherapyPackag
                 TherapyPrice: item.TherapyPrice || item.price,
                 TherapyName: item.TherapyName || item.name,
                 TherapyContent: item.TherapyContent || item.content || item.TherapyName || item.name || '',
+                categories: item.categories || [],
             }));
             return { success: response.data.success, data: formattedData, message: response.data.message };
         }

--- a/client/src/services/TherapyService.ts
+++ b/client/src/services/TherapyService.ts
@@ -164,7 +164,7 @@ export const getAllTherapiesForDropdown = async () => {
     return response.data;
 };
 
-export const addTherapy = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null }) => {
+export const addTherapy = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null; category_ids?: number[] }) => {
     try {
         const token = localStorage.getItem("token");
         const response = await axios.post(`${API_URL}/package`, data, {
@@ -183,7 +183,7 @@ export const addTherapy = async (data: { code: string; name: string; price: numb
 
 export const updateTherapy = async (
     therapyId: number,
-    data: { code: string; name: string; price: number; content?: string; visible_store_ids?: number[] | null }
+    data: { code: string; name: string; price: number; content?: string; visible_store_ids?: number[] | null; category_ids?: number[] }
 ) => {
     try {
         const token = localStorage.getItem("token");

--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -35,6 +35,89 @@ CREATE TABLE `emergency_contact` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `category`
+--
+
+DROP TABLE IF EXISTS `category`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `category` (
+  `category_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `target_type` enum('product','therapy','product_bundle','therapy_bundle') COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`category_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `product_category`
+--
+
+DROP TABLE IF EXISTS `product_category`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `product_category` (
+  `product_id` int NOT NULL,
+  `category_id` int NOT NULL,
+  PRIMARY KEY (`product_id`,`category_id`),
+  KEY `category_id` (`category_id`),
+  CONSTRAINT `product_category_ibfk_1` FOREIGN KEY (`product_id`) REFERENCES `product` (`product_id`) ON DELETE CASCADE,
+  CONSTRAINT `product_category_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `category` (`category_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `therapy_category`
+--
+
+DROP TABLE IF EXISTS `therapy_category`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `therapy_category` (
+  `therapy_id` int NOT NULL,
+  `category_id` int NOT NULL,
+  PRIMARY KEY (`therapy_id`,`category_id`),
+  KEY `category_id` (`category_id`),
+  CONSTRAINT `therapy_category_ibfk_1` FOREIGN KEY (`therapy_id`) REFERENCES `therapy` (`therapy_id`) ON DELETE CASCADE,
+  CONSTRAINT `therapy_category_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `category` (`category_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `product_bundle_category`
+--
+
+DROP TABLE IF EXISTS `product_bundle_category`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `product_bundle_category` (
+  `bundle_id` int NOT NULL,
+  `category_id` int NOT NULL,
+  PRIMARY KEY (`bundle_id`,`category_id`),
+  KEY `category_id` (`category_id`),
+  CONSTRAINT `product_bundle_category_ibfk_1` FOREIGN KEY (`bundle_id`) REFERENCES `product_bundles` (`bundle_id`) ON DELETE CASCADE,
+  CONSTRAINT `product_bundle_category_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `category` (`category_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `therapy_bundle_category`
+--
+
+DROP TABLE IF EXISTS `therapy_bundle_category`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `therapy_bundle_category` (
+  `bundle_id` int NOT NULL,
+  `category_id` int NOT NULL,
+  PRIMARY KEY (`bundle_id`,`category_id`),
+  KEY `category_id` (`category_id`),
+  CONSTRAINT `therapy_bundle_category_ibfk_1` FOREIGN KEY (`bundle_id`) REFERENCES `therapy_bundles` (`bundle_id`) ON DELETE CASCADE,
+  CONSTRAINT `therapy_bundle_category_ibfk_2` FOREIGN KEY (`category_id`) REFERENCES `category` (`category_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `family_information`
 --
 

--- a/mysql-init-scripts/02_data.sql
+++ b/mysql-init-scripts/02_data.sql
@@ -277,3 +277,167 @@ INSERT INTO `ipn_stress_answer` (`ipn_stress_id`, `question_no`, `answer`) VALUE
 (@stress_id2, 'b1', 'B'), (@stress_id2, 'b2', 'A'), (@stress_id2, 'b3', 'B'), (@stress_id2, 'b4', 'A'), (@stress_id2, 'b5', 'B'),
 (@stress_id2, 'c1', 'A'), (@stress_id2, 'c2', 'B'), (@stress_id2, 'c3', 'A'), (@stress_id2, 'c4', 'B'), (@stress_id2, 'c5', 'A'),
 (@stress_id2, 'd1', 'B'), (@stress_id2, 'd2', 'A'), (@stress_id2, 'd3', 'B'), (@stress_id2, 'd4', 'A'), (@stress_id2, 'd5', 'B');
+
+-- Seed product and therapy categories
+INSERT INTO `category` (`name`, `target_type`) VALUES
+('未歸類', 'product'),
+('明星商品', 'product'),
+('嚴選商品', 'product'),
+('MINI QP配件', 'product'),
+('MINI QP線材組', 'product'),
+('HPA量子儀配件', 'product'),
+('HPA 線材組', 'product'),
+('系統教育訓練', 'product'),
+('未歸類', 'therapy'),
+('IPN 身體課程', 'therapy'),
+('澎湖店限定', 'therapy'),
+('未歸類', 'product_bundle'),
+('嚴選商品', 'product_bundle'),
+('未歸類', 'therapy_bundle'),
+('IPN 身體課程', 'therapy_bundle'),
+('台北店/台中店/桃園店限定', 'therapy_bundle'),
+('桃園店限定', 'therapy_bundle'),
+('澎湖店限定', 'therapy_bundle'),
+('桃園店/澎湖店限定', 'therapy_bundle');
+
+-- Assign products to categories
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = '明星商品' AND c.target_type = 'product'
+WHERE p.code IN (
+  'PSA1001','PSA1002','PSA1003','PSA1004','PSA1005','PSA1006','PSA1007','PSA1008','PSA1009',
+  'PSA2001','PSA2002','PSA2003','PSA2004','PSA2005','PSA2006','PSA2007','PSA2008','PSA2009',
+  'PSB1001','PSB1002','PSB1003','PSB1004','PSB1005','PSB1006','PSB1007','PSB1008',
+  'PSO0101','PSO0102','PSO0103','PSO0104','PSO0105','PSO0106','PSO0107','PSO0108',
+  'PSS0101','PSS0102','PSS0103','PSS0104','PSS0105','PSS0106','PSS0107'
+);
+
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = '嚴選商品' AND c.target_type = 'product'
+WHERE p.code IN (
+  'PCP0101','PCP0102','PCP0103','PCP0104','PCP0105',
+  'PCP0201','PCP0202','PCP0203','PCP0204','PCP0205',
+  'PCP0301','PCP0302','PCP0303',
+  'PCP0401','PCP0402','PCP0403','PCP0404',
+  'PCP0501','PCP0502','PCP0503',
+  'PCC0001'
+);
+
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = 'MINI QP配件' AND c.target_type = 'product'
+WHERE p.code IN (
+  'SMA0101','SMA0102','SMA0103',
+  'SMA0201','SMA0202','SMA0203',
+  'SMA0301','SMA0302','SMA0303',
+  'SMA0401','SMA0402','SMA0403',
+  'SMA0501','SMA0502','SMA0503','SMA0504',
+  'SMA0601','SMA0602','SMA0603','SMA0604',
+  'SMA0701','SMA0702','SMA0703',
+  'SMA0801','SMA0802',
+  'SMA0901','SMA0902','SMA0903'
+);
+
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = 'MINI QP線材組' AND c.target_type = 'product'
+WHERE p.code IN ('SMW0101','SMW0102','SMW0103','SMW0104','SMW0105','SMW0106');
+
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = 'HPA量子儀配件' AND c.target_type = 'product'
+WHERE p.code IN (
+  'SHA0101','SHA0102','SHA0103','SHA0104',
+  'SHA0201','SHA0202','SHA0203','SHA0204',
+  'SHA0301','SHA0302','SHA0303','SHA0304',
+  'SHA0401','SHA0402','SHA0403','SHA0404',
+  'SHA0501','SHA0502','SHA0503','SHA0504',
+  'SHA0601','SHA0602','SHA0603','SHA0604',
+  'SHA0701','SHA0702','SHA0703','SHA0704',
+  'SHA0801','SHA0802','SHA0803','SHA0804',
+  'SHA0901','SHA0902','SHA0903','SHA0904',
+  'SHA1001','SHA1002','SHA1003','SHA1004','SHA1005',
+  'SHA1101',
+  'SHA1201','SHA1202','SHA1203'
+);
+
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = 'HPA 線材組' AND c.target_type = 'product'
+WHERE p.code IN ('SHW0101','SHW0102','SHW0103','SHW0104','SHW0201','SHW0202','SHW0203','SHW0204');
+
+INSERT INTO `product_category` (`product_id`, `category_id`)
+SELECT p.product_id, c.category_id
+FROM `product` p
+JOIN `category` c ON c.name = '系統教育訓練' AND c.target_type = 'product'
+WHERE p.code IN (
+  'SSO0101','SSO0102','SSO0103','SSO0104','SSO0105','SSO0106','SSO0107','SSO0108','SSO0109',
+  'SCP0101','SCP0102','SCP0103',
+  'SCP0201','SCP0202','SCP0203',
+  'SCP0301','SCP0302','SCP0303',
+  'SCP0401','SCP0402','SCP0403'
+);
+
+-- Assign therapies to categories
+INSERT INTO `therapy_category` (`therapy_id`, `category_id`)
+SELECT t.therapy_id, c.category_id
+FROM `therapy` t
+JOIN `category` c ON c.name = 'IPN 身體課程' AND c.target_type = 'therapy'
+WHERE t.code IN ('COF0101','COL0101','COM0101','COB0101','COH0101','COO0101','COS0101');
+
+INSERT INTO `therapy_category` (`therapy_id`, `category_id`)
+SELECT t.therapy_id, c.category_id
+FROM `therapy` t
+JOIN `category` c ON c.name = '未歸類' AND c.target_type = 'therapy'
+WHERE t.code IN ('COO0100','COZ0111','COZ0112');
+
+INSERT INTO `therapy_category` (`therapy_id`, `category_id`)
+SELECT t.therapy_id, c.category_id
+FROM `therapy` t
+JOIN `category` c ON c.name = '澎湖店限定' AND c.target_type = 'therapy'
+WHERE t.code IN ('CCP0001');
+
+-- Assign product bundles to categories
+INSERT INTO `product_bundle_category` (`bundle_id`, `category_id`)
+SELECT pb.bundle_id, c.category_id
+FROM `product_bundles` pb
+JOIN `category` c ON c.name = '嚴選商品' AND c.target_type = 'product_bundle'
+WHERE pb.bundle_code IN ('PCP0002','PCP0003','PCP0502','PCP0503');
+
+-- Assign therapy bundles to categories
+INSERT INTO `therapy_bundle_category` (`bundle_id`, `category_id`)
+SELECT tb.bundle_id, c.category_id
+FROM `therapy_bundles` tb
+JOIN `category` c ON c.name = 'IPN 身體課程' AND c.target_type = 'therapy_bundle'
+WHERE tb.bundle_code IN ('COF0102','COL0102','COB0102','COH0102','COO0102','COO0103','COO0104','COO0105');
+
+INSERT INTO `therapy_bundle_category` (`bundle_id`, `category_id`)
+SELECT tb.bundle_id, c.category_id
+FROM `therapy_bundles` tb
+JOIN `category` c ON c.name = '台北店/台中店/桃園店限定' AND c.target_type = 'therapy_bundle'
+WHERE tb.bundle_code IN ('CPP0001','CPP0002','CPP0003','CPP0004');
+
+INSERT INTO `therapy_bundle_category` (`bundle_id`, `category_id`)
+SELECT tb.bundle_id, c.category_id
+FROM `therapy_bundles` tb
+JOIN `category` c ON c.name = '桃園店限定' AND c.target_type = 'therapy_bundle'
+WHERE tb.bundle_code IN ('CDP0001','CDP0002','CDP0003');
+
+INSERT INTO `therapy_bundle_category` (`bundle_id`, `category_id`)
+SELECT tb.bundle_id, c.category_id
+FROM `therapy_bundles` tb
+JOIN `category` c ON c.name = '澎湖店限定' AND c.target_type = 'therapy_bundle'
+WHERE tb.bundle_code IN ('CCP0002','CCP0003','CCP0004','CCP0005');
+
+INSERT INTO `therapy_bundle_category` (`bundle_id`, `category_id`)
+SELECT tb.bundle_id, c.category_id
+FROM `therapy_bundles` tb
+JOIN `category` c ON c.name = '桃園店/澎湖店限定' AND c.target_type = 'therapy_bundle'
+WHERE tb.bundle_code IN ('CQP0001','CQP0002');

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -16,6 +16,7 @@ from app.routes.product import product_bp
 from app.routes.items import items_bp
 from .routes.sales_order_routes import sales_order_bp
 from app.routes.store import store_bp
+from app.routes.category import category_bp
 
 def create_app():
     app = Flask(__name__)
@@ -74,6 +75,7 @@ def create_app():
     app.register_blueprint(product_bp, url_prefix='/api/product')
     app.register_blueprint(store_bp, url_prefix='/api/stores')
     app.register_blueprint(items_bp, url_prefix='/api/items')
+    app.register_blueprint(category_bp, url_prefix='/api/categories')
 
     # 註冊產品銷售路由
     from app.routes.product_sell import product_sell_bp
@@ -102,3 +104,4 @@ def create_app():
         return jsonify({"message": "Welcome to IPN ERP System API"})
 
     return app
+

--- a/server/app/models/category_model.py
+++ b/server/app/models/category_model.py
@@ -1,0 +1,99 @@
+import pymysql
+from app.config import DB_CONFIG
+from pymysql.cursors import DictCursor
+
+
+def connect_to_db():
+    return pymysql.connect(**DB_CONFIG, cursorclass=DictCursor)
+
+
+def create_category(name: str, target_type: str):
+    """Create new category"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "INSERT INTO category (name, target_type) VALUES (%s, %s)",
+                (name, target_type),
+            )
+            category_id = conn.insert_id()
+        conn.commit()
+        return category_id
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()
+
+
+def get_categories(target_type: str | None = None):
+    """Fetch categories, optionally filtered by target_type"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            if target_type:
+                cursor.execute(
+                    "SELECT * FROM category WHERE target_type=%s ORDER BY (name='未歸類'), name",
+                    (target_type,),
+                )
+            else:
+                cursor.execute("SELECT * FROM category ORDER BY (name='未歸類'), name")
+            return cursor.fetchall()
+    finally:
+        conn.close()
+
+
+def delete_category(category_id: int):
+    """Delete category and move items to default '未歸類' category"""
+    conn = connect_to_db()
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT target_type FROM category WHERE category_id=%s", (category_id,))
+            row = cursor.fetchone()
+            if not row:
+                return
+            target_type = row["target_type"]
+
+            # ensure default category exists
+            cursor.execute(
+                "SELECT category_id FROM category WHERE name=%s AND target_type=%s",
+                ("未歸類", target_type),
+            )
+            default_row = cursor.fetchone()
+            if default_row:
+                default_id = default_row["category_id"]
+            else:
+                cursor.execute(
+                    "INSERT INTO category (name, target_type) VALUES (%s, %s)",
+                    ("未歸類", target_type),
+                )
+                default_id = conn.insert_id()
+
+            if target_type == "product":
+                cursor.execute(
+                    "UPDATE product_category SET category_id=%s WHERE category_id=%s",
+                    (default_id, category_id),
+                )
+            elif target_type == "therapy":
+                cursor.execute(
+                    "UPDATE therapy_category SET category_id=%s WHERE category_id=%s",
+                    (default_id, category_id),
+                )
+            elif target_type == "product_bundle":
+                cursor.execute(
+                    "UPDATE product_bundle_category SET category_id=%s WHERE category_id=%s",
+                    (default_id, category_id),
+                )
+            elif target_type == "therapy_bundle":
+                cursor.execute(
+                    "UPDATE therapy_bundle_category SET category_id=%s WHERE category_id=%s",
+                    (default_id, category_id),
+                )
+
+            cursor.execute("DELETE FROM category WHERE category_id=%s", (category_id,))
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        raise e
+    finally:
+        conn.close()

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -476,8 +476,11 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                 p.price AS product_price,
                 p.visible_store_ids,
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
-                0 AS inventory_id
+                0 AS inventory_id,
+                GROUP_CONCAT(c.name) AS categories
             FROM product p
+            LEFT JOIN product_category pc ON p.product_id = pc.product_id
+            LEFT JOIN category c ON pc.category_id = c.category_id
             LEFT JOIN inventory i ON p.product_id = i.product_id {store_join}
         """
 
@@ -509,6 +512,8 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
         if store_id is None or not store_ids or int(store_id) in store_ids:
             if store_ids is not None:
                 row['visible_store_ids'] = store_ids
+            if row.get('categories'):
+                row['categories'] = row['categories'].split(',')
             filtered.append(row)
     return filtered
 
@@ -529,8 +534,11 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                 p.price AS product_price,
                 p.visible_store_ids,
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
-                0 AS inventory_id
+                0 AS inventory_id,
+                GROUP_CONCAT(c.name) AS categories
             FROM product p
+            LEFT JOIN product_category pc ON p.product_id = pc.product_id
+            LEFT JOIN category c ON pc.category_id = c.category_id
             LEFT JOIN inventory i ON p.product_id = i.product_id {store_join}
         """
 
@@ -572,6 +580,8 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
         if store_id is None or not store_ids or int(store_id) in store_ids:
             if store_ids is not None:
                 row['visible_store_ids'] = store_ids
+            if row.get('categories'):
+                row['categories'] = row['categories'].split(',')
             filtered.append(row)
     return filtered
 

--- a/server/app/routes/category.py
+++ b/server/app/routes/category.py
@@ -1,0 +1,41 @@
+from flask import Blueprint, request, jsonify
+from app.models.category_model import create_category, get_categories, delete_category
+from app.middleware import admin_required
+
+category_bp = Blueprint("category", __name__)
+
+
+@category_bp.route("/", methods=["GET"])
+@admin_required
+def list_categories():
+    target_type = request.args.get("target_type")
+    try:
+        categories = get_categories(target_type)
+        return jsonify(categories)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@category_bp.route("/", methods=["POST"])
+@admin_required
+def add_category():
+    data = request.json or {}
+    name = data.get("name")
+    target_type = data.get("target_type")
+    if not name or not target_type:
+        return jsonify({"error": "缺少必要欄位"}), 400
+    try:
+        category_id = create_category(name, target_type)
+        return jsonify({"message": "分類新增成功", "category_id": category_id}), 201
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@category_bp.route("/<int:category_id>", methods=["DELETE"])
+@admin_required
+def remove_category(category_id: int):
+    try:
+        delete_category(category_id)
+        return jsonify({"message": "分類刪除成功"})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Summary
- support category assignment for product and therapy bundles with default "未歸類" groups
- allow deleting categories while reclassifying items to "未歸類"
- add category tabs for bundle selection and management plus deletion modal
- group product and therapy selection into top-level tabs separating items from bundles, each with its own category filters
- fix active tab handling in product and therapy selection pages
- place "未歸類" category last in all category listings

## Testing
- `cd server && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: pyenv: version `3.11.3` is not installed; pyenv: pytest: command not found)*
- `cd ../client && npm test >/tmp/npmtest.log && tail -n 20 /tmp/npmtest.log` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c80955f12083299e43fa444ad8456d