### PR TITLE
Allow therapists to load categories without admin rights

### DIFF
--- a/server/app/routes/category.py
+++ b/server/app/routes/category.py
@@ -1,12 +1,12 @@
 from flask import Blueprint, request, jsonify
 from app.models.category_model import create_category, get_categories, delete_category
-from app.middleware import admin_required
+from app.middleware import admin_required, auth_required
 
 category_bp = Blueprint("category", __name__)
 
 
 @category_bp.route("/", methods=["GET"])
-@admin_required
+@auth_required
 def list_categories():
     target_type = request.args.get("target_type")
     try:


### PR DESCRIPTION
## Summary
- Allow authenticated users to retrieve category lists
- Ensure auth middleware populates permission and store context for header-based clients so non-admin staff can load sale catalogs

## Testing
- `pytest` *(fails: missing pandas/requests/openpyxl/jwt dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c822a982248329876616ba2b21bd3c