### PR TITLE
Add purchase price support and adjust inventory/bundle forms

### DIFF
--- a/client/src/pages/backend/product_bundle/AddProductModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddProductModal.tsx
@@ -16,6 +16,7 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editing
     const [code, setCode] = useState('');
     const [name, setName] = useState('');
     const [price, setPrice] = useState('');
+    const [purchasePrice, setPurchasePrice] = useState('');
     const [selectedStoreIds, setSelectedStoreIds] = useState<number[]>([]);
     const [categories, setCategories] = useState<Category[]>([]);
     const [selectedCategoryIds, setSelectedCategoryIds] = useState<number[]>([]);
@@ -25,12 +26,14 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editing
             setCode(editingProduct.product_code);
             setName(editingProduct.product_name);
             setPrice(String(editingProduct.product_price));
+            setPurchasePrice(editingProduct.purchase_price != null ? String(editingProduct.purchase_price) : '');
             setSelectedStoreIds(editingProduct.visible_store_ids || []);
             setSelectedCategoryIds([]);
         } else {
             setCode('');
             setName('');
             setPrice('');
+            setPurchasePrice('');
             setSelectedStoreIds([]);
             setSelectedCategoryIds([]);
         }
@@ -51,6 +54,7 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editing
                 code,
                 name,
                 price: Number(price),
+                purchase_price: purchasePrice === '' ? null : Number(purchasePrice),
                 visible_store_ids: selectedStoreIds.length > 0 ? selectedStoreIds : null,
                 category_ids: selectedCategoryIds,
             };
@@ -85,8 +89,23 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editing
                         <Form.Control value={name} onChange={e => setName(e.target.value)} />
                     </Form.Group>
                     <Form.Group className="mb-3">
-                        <Form.Label>設定售價</Form.Label>
-                        <Form.Control type="number" min={0} value={price} onChange={e => setPrice(e.target.value)} />
+                        <Form.Label>分類 (可複選)</Form.Label>
+                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
+                            {categories.map(c => (
+                                <Form.Check
+                                    key={`cat-${c.category_id}`}
+                                    type="checkbox"
+                                    id={`cat-check-${c.category_id}`}
+                                    label={c.name}
+                                    checked={selectedCategoryIds.includes(c.category_id)}
+                                    onChange={e => handleCategoryChange(c.category_id, e.target.checked)}
+                                />
+                            ))}
+                        </div>
+                    </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Label>設定進貨價</Form.Label>
+                        <Form.Control type="number" min={0} value={purchasePrice} onChange={e => setPurchasePrice(e.target.value)} />
                     </Form.Group>
                     <Form.Group className="mb-3">
                         <Form.Label>限定分店 (可複選)</Form.Label>
@@ -104,19 +123,8 @@ const AddProductModal: React.FC<AddProductModalProps> = ({ show, onHide, editing
                         </div>
                     </Form.Group>
                     <Form.Group className="mb-3">
-                        <Form.Label>分類 (可複選)</Form.Label>
-                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
-                            {categories.map(c => (
-                                <Form.Check
-                                    key={`cat-${c.category_id}`}
-                                    type="checkbox"
-                                    id={`cat-check-${c.category_id}`}
-                                    label={c.name}
-                                    checked={selectedCategoryIds.includes(c.category_id)}
-                                    onChange={e => handleCategoryChange(c.category_id, e.target.checked)}
-                                />
-                            ))}
-                        </div>
+                        <Form.Label>設定售價</Form.Label>
+                        <Form.Control type="number" min={0} value={price} onChange={e => setPrice(e.target.value)} />
                     </Form.Group>
                 </Modal.Body>
                 <Modal.Footer>

--- a/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
+++ b/client/src/pages/backend/product_bundle/AddTherapyModal.tsx
@@ -85,8 +85,19 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
                         <Form.Control value={name} onChange={e => setName(e.target.value)} />
                     </Form.Group>
                     <Form.Group className="mb-3">
-                        <Form.Label>設定售價</Form.Label>
-                        <Form.Control type="number" min={0} value={price} onChange={e => setPrice(e.target.value)} />
+                        <Form.Label>分類 (可複選)</Form.Label>
+                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
+                            {categories.map(c => (
+                                <Form.Check
+                                    key={`cat-${c.category_id}`}
+                                    type="checkbox"
+                                    id={`cat-check-${c.category_id}`}
+                                    label={c.name}
+                                    checked={selectedCategoryIds.includes(c.category_id)}
+                                    onChange={e => handleCategoryChange(c.category_id, e.target.checked)}
+                                />
+                            ))}
+                        </div>
                     </Form.Group>
                     <Form.Group className="mb-3">
                         <Form.Label>限定分店 (可複選)</Form.Label>
@@ -104,19 +115,8 @@ const AddTherapyModal: React.FC<AddTherapyModalProps> = ({ show, onHide, editing
                         </div>
                     </Form.Group>
                     <Form.Group className="mb-3">
-                        <Form.Label>分類 (可複選)</Form.Label>
-                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
-                            {categories.map(c => (
-                                <Form.Check
-                                    key={`cat-${c.category_id}`}
-                                    type="checkbox"
-                                    id={`cat-check-${c.category_id}`}
-                                    label={c.name}
-                                    checked={selectedCategoryIds.includes(c.category_id)}
-                                    onChange={e => handleCategoryChange(c.category_id, e.target.checked)}
-                                />
-                            ))}
-                        </div>
+                        <Form.Label>設定售價</Form.Label>
+                        <Form.Control type="number" min={0} value={price} onChange={e => setPrice(e.target.value)} />
                     </Form.Group>
                 </Modal.Body>
                 <Modal.Footer>

--- a/client/src/pages/backend/product_bundle/BundleCreateModal.tsx
+++ b/client/src/pages/backend/product_bundle/BundleCreateModal.tsx
@@ -184,8 +184,12 @@ const BundleCreateModal: React.FC<BundleCreateModalProps> = ({ show, onHide, onS
                     {error && <Alert variant="danger">{error}</Alert>}
                     
                     <Form.Group className="mb-3">
-                        <Form.Label>編號</Form.Label>
+                        <Form.Label>設定編號</Form.Label>
                         <Form.Control type="text" name="bundle_code" value={formData.bundle_code} onChange={handleInputChange} required />
+                    </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Label>設定產品組合名稱</Form.Label>
+                        <Form.Control type="text" name="name" value={formData.name} onChange={handleInputChange} required />
                     </Form.Group>
                     <Form.Group className="mb-3">
                         <Form.Label>分類 (可複選)</Form.Label>
@@ -205,10 +209,6 @@ const BundleCreateModal: React.FC<BundleCreateModalProps> = ({ show, onHide, onS
                                 />
                             ))}
                         </div>
-                    </Form.Group>
-                    <Form.Group className="mb-3">
-                        <Form.Label>項目 (組合名稱)</Form.Label>
-                        <Form.Control type="text" name="name" value={formData.name} onChange={handleInputChange} required />
                     </Form.Group>
                     
                     <Row>

--- a/client/src/pages/backend/product_bundle/TherapyBundleModal.tsx
+++ b/client/src/pages/backend/product_bundle/TherapyBundleModal.tsx
@@ -155,12 +155,31 @@ const TherapyBundleModal: React.FC<TherapyBundleModalProps> = ({ show, onHide, o
                     {error && <Alert variant="danger">{error}</Alert>}
 
                     <Form.Group className="mb-3">
-                        <Form.Label>編號</Form.Label>
+                        <Form.Label>設定編號</Form.Label>
                         <Form.Control type="text" name="bundle_code" value={formData.bundle_code} onChange={handleInputChange} required />
                     </Form.Group>
                     <Form.Group className="mb-3">
-                        <Form.Label>項目 (組合名稱)</Form.Label>
+                        <Form.Label>設定療程組合名稱</Form.Label>
                         <Form.Control type="text" name="name" value={formData.name} onChange={handleInputChange} required />
+                    </Form.Group>
+                    <Form.Group className="mb-3">
+                        <Form.Label>分類 (可複選)</Form.Label>
+                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
+                            {categories.map(cat => (
+                                <Form.Check
+                                    key={cat.category_id}
+                                    type="checkbox"
+                                    label={cat.name}
+                                    checked={selectedCategoryIds.includes(cat.category_id)}
+                                    onChange={e => {
+                                        const checked = e.target.checked;
+                                        setSelectedCategoryIds(prev =>
+                                            checked ? [...prev, cat.category_id] : prev.filter(id => id !== cat.category_id)
+                                        );
+                                    }}
+                                />
+                            ))}
+                        </div>
                     </Form.Group>
 
                     <Row>
@@ -212,31 +231,11 @@ const TherapyBundleModal: React.FC<TherapyBundleModalProps> = ({ show, onHide, o
                     </Row>
 
                     <Form.Group className="mb-3">
-                        <Form.Label>分類 (可複選)</Form.Label>
-                        <div style={{ maxHeight: '150px', overflowY: 'auto', border: '1px solid #dee2e6', padding: '0.5rem' }}>
-                            {categories.map(cat => (
-                                <Form.Check
-                                    key={cat.category_id}
-                                    type="checkbox"
-                                    label={cat.name}
-                                    checked={selectedCategoryIds.includes(cat.category_id)}
-                                    onChange={e => {
-                                        const checked = e.target.checked;
-                                        setSelectedCategoryIds(prev =>
-                                            checked ? [...prev, cat.category_id] : prev.filter(id => id !== cat.category_id)
-                                        );
-                                    }}
-                                />
-                            ))}
-                        </div>
-                    </Form.Group>
-
-                    <Form.Group className="mb-3">
-                        <Form.Label>原價總計</Form.Label>
+                        <Form.Label>試算金額</Form.Label>
                         <Form.Control type="number" value={calculatedPrice} readOnly />
                     </Form.Group>
                     <Form.Group className="mb-3">
-                        <Form.Label>設定售價</Form.Label>
+                        <Form.Label>最終售價</Form.Label>
                         <Form.Control type="number" name="selling_price" min={0} value={formData.selling_price} onChange={handlePriceChange} required />
                     </Form.Group>
                 </Modal.Body>

--- a/client/src/pages/inventory/InventoryUpdate.tsx
+++ b/client/src/pages/inventory/InventoryUpdate.tsx
@@ -144,6 +144,19 @@ const InventoryEntryForm = () => {
       p => !p.categories || !p.categories.some(c => categories.some(cat => cat.name === c))
     ), [filteredProducts, categories]);
 
+  const selectedProduct = useMemo(
+    () => products.find(p => String(p.product_id) === formData.product_id),
+    [products, formData.product_id]
+  );
+
+  const purchasePriceDisplay = useMemo(() => {
+    const price = selectedProduct?.purchase_price as number | string | undefined | null;
+    if (price === null || price === undefined) {
+      return "";
+    }
+    return typeof price === "number" ? price.toString() : price;
+  }, [selectedProduct]);
+
   return (
     <>
       <Header />
@@ -152,9 +165,9 @@ const InventoryEntryForm = () => {
         style={{ marginLeft: "200px", paddingRight: "30px", maxWidth: "calc(100% - 220px)" }}
       >
         <Form>
-          {/* 搜尋品項獨立一列 */}
+          {/* 搜尋與品項選擇 */}
           <Row className="mb-3">
-            <Col xs={12} md={6}>
+            <Col xs={12} md={6} className="mb-3 mb-md-0">
               <Form.Group controlId="product_search" className="mb-2">
                 <Form.Label>搜尋品項</Form.Label>
                 <Form.Control
@@ -165,12 +178,7 @@ const InventoryEntryForm = () => {
                 />
               </Form.Group>
             </Col>
-          </Row>
-
-          {/* 第二列顯示品項與數量 */}
-          <Row className="mb-3">
-            <Col xs={12} md={6} className="mb-3 mb-md-0">
-              <p></p>
+            <Col xs={12} md={6}>
               <Form.Group controlId="product_id">
                 <Form.Label>品項</Form.Label>
                 <Form.Select
@@ -202,8 +210,11 @@ const InventoryEntryForm = () => {
                 </Form.Select>
               </Form.Group>
             </Col>
+          </Row>
 
-            <Col xs={12} md={6}>
+          {/* 數量與進貨價 */}
+          <Row className="mb-3">
+            <Col xs={12} md={6} className="mb-3 mb-md-0">
               <Form.Group controlId="quantity">
                 <Form.Label>數量</Form.Label>
                 <Form.Control
@@ -211,6 +222,17 @@ const InventoryEntryForm = () => {
                   name="quantity"
                   value={formData.quantity}
                   onChange={handleChange}
+                />
+              </Form.Group>
+            </Col>
+            <Col xs={12} md={6}>
+              <Form.Group controlId="purchase_price">
+                <Form.Label>進貨價錢</Form.Label>
+                <Form.Control
+                  type="text"
+                  value={purchasePriceDisplay}
+                  readOnly
+                  placeholder="尚未提供"
                 />
               </Form.Group>
             </Col>

--- a/client/src/services/ProductBundleService.ts
+++ b/client/src/services/ProductBundleService.ts
@@ -44,6 +44,7 @@ export interface Product {
     product_name: string;
     product_price: number;
     product_code: string;
+    purchase_price?: number | string | null;
     visible_store_ids?: number[];
     categories?: string[];
 }

--- a/client/src/services/ProductSellService.ts
+++ b/client/src/services/ProductSellService.ts
@@ -22,6 +22,7 @@ export interface Product {
   product_code?: string;
   product_name: string;
   product_price: number;
+  purchase_price?: number | string | null;
   inventory_id: number;
   inventory_quantity: number;
   categories?: string[];

--- a/client/src/services/ProductService.ts
+++ b/client/src/services/ProductService.ts
@@ -10,6 +10,7 @@ export interface Product {
   code?: string;
   content?: string;
   price: number;
+  purchase_price?: number | string | null;
   inventory_count?: number;
   visible_store_ids?: number[];
 }
@@ -50,7 +51,7 @@ export const getProductById = async (productId: number): Promise<Product> => {
   }
 };
 
-export const addProduct = async (data: { code: string; name: string; price: number; visible_store_ids?: number[] | null; category_ids?: number[] }) => {
+export const addProduct = async (data: { code: string; name: string; price: number; purchase_price?: number | null; visible_store_ids?: number[] | null; category_ids?: number[] }) => {
   try {
     const token = localStorage.getItem("token");
     const response = await axios.post(`${API_URL}/`, data, {
@@ -69,7 +70,7 @@ export const addProduct = async (data: { code: string; name: string; price: numb
 
 export const updateProduct = async (
   productId: number,
-  data: { code: string; name: string; price: number; visible_store_ids?: number[] | null; category_ids?: number[] }
+  data: { code: string; name: string; price: number; purchase_price?: number | null; visible_store_ids?: number[] | null; category_ids?: number[] }
 ) => {
   try {
     const token = localStorage.getItem("token");

--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -368,6 +368,7 @@ CREATE TABLE `product` (
   `code` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
   `price` decimal(10,2) NOT NULL,
+  `purchase_price` decimal(10,2) DEFAULT NULL COMMENT '最新進貨成本價',
   `visible_store_ids` json DEFAULT NULL COMMENT '限制顯示的分店 store_id 列表，NULL 表示全店可見',
   `status` enum('PUBLISHED','UNPUBLISHED') NOT NULL DEFAULT 'PUBLISHED',
   `unpublished_reason` text COLLATE utf8mb4_unicode_ci,

--- a/mysql-init-scripts/02_data.sql
+++ b/mysql-init-scripts/02_data.sql
@@ -43,17 +43,17 @@ INSERT INTO `micro_surgery` (`micro_surgery_selection`, `micro_surgery_descripti
 ('複合式療程', '全臉美容'),
 ('醫學美容', '改善暗沉');
 
-INSERT INTO `product` (`code`, `name`, `price`, `status`) VALUES
-('SKN001', '保濕面膜', 580.00, 'PUBLISHED'),
-('SKN002', '精華液', 1200.00, 'PUBLISHED'),
-('SKN003', '潔面乳', 450.00, 'PUBLISHED'),
-('SKN004', '保濕乳液', 780.00, 'PUBLISHED'),
-('SKN005', '防曬霜', 650.00, 'PUBLISHED'),
-('SUP001', '膠原蛋白粉', 1500.00, 'PUBLISHED'),
-('SUP002', '維他命C', 850.00, 'PUBLISHED'),
-('SUP003', '魚油', 720.00, 'PUBLISHED'),
-('HRB001', '舒壓茶包', 380.00, 'PUBLISHED'),
-('HRB002', '薰衣草精油', 550.00, 'PUBLISHED');
+INSERT INTO `product` (`code`, `name`, `price`, `purchase_price`, `status`) VALUES
+('SKN001', '保濕面膜', 580.00, 350.00, 'PUBLISHED'),
+('SKN002', '精華液', 1200.00, 720.00, 'PUBLISHED'),
+('SKN003', '潔面乳', 450.00, 260.00, 'PUBLISHED'),
+('SKN004', '保濕乳液', 780.00, 480.00, 'PUBLISHED'),
+('SKN005', '防曬霜', 650.00, 390.00, 'PUBLISHED'),
+('SUP001', '膠原蛋白粉', 1500.00, 900.00, 'PUBLISHED'),
+('SUP002', '維他命C', 850.00, 510.00, 'PUBLISHED'),
+('SUP003', '魚油', 720.00, 420.00, 'PUBLISHED'),
+('HRB001', '舒壓茶包', 380.00, 210.00, 'PUBLISHED'),
+('HRB002', '薰衣草精油', 550.00, 330.00, 'PUBLISHED');
 
 INSERT INTO `therapy` (`code`, `name`, `price`, `content`, `status`) VALUES
 ('TH001', '全身放鬆按摩', 2800.00, '60分鐘全身按摩，幫助放鬆肌肉，改善血液循環', 'PUBLISHED'),

--- a/server/app/models/inventory_model.py
+++ b/server/app/models/inventory_model.py
@@ -667,7 +667,8 @@ def get_product_list():
                     p.product_id AS Product_ID,
                     p.name AS ProductName,
                     p.code AS ProductCode,
-                    p.price AS ProductPrice
+                    p.price AS ProductPrice,
+                    p.purchase_price AS PurchasePrice
                 FROM product p
                 WHERE p.status = 'PUBLISHED'
                 ORDER BY p.name

--- a/server/app/models/product_model.py
+++ b/server/app/models/product_model.py
@@ -15,13 +15,14 @@ def create_product(data: dict):
     try:
         with conn.cursor() as cursor:
             query = (
-                "INSERT INTO product (code, name, price, visible_store_ids, status) "
-                "VALUES (%s, %s, %s, %s, 'PUBLISHED')"
+                "INSERT INTO product (code, name, price, purchase_price, visible_store_ids, status) "
+                "VALUES (%s, %s, %s, %s, %s, 'PUBLISHED')"
             )
             cursor.execute(query, (
                 data.get("code"),
                 data.get("name"),
                 data.get("price"),
+                data.get("purchase_price"),
                 json.dumps(data.get("visible_store_ids")) if data.get("visible_store_ids") is not None else None,
             ))
             product_id = conn.insert_id()
@@ -48,12 +49,13 @@ def update_product(product_id: int, data: dict):
     try:
         with conn.cursor() as cursor:
             query = (
-                "UPDATE product SET code=%s, name=%s, price=%s, visible_store_ids=%s WHERE product_id=%s"
+                "UPDATE product SET code=%s, name=%s, price=%s, purchase_price=%s, visible_store_ids=%s WHERE product_id=%s"
             )
             cursor.execute(query, (
                 data.get("code"),
                 data.get("name"),
                 data.get("price"),
+                data.get("purchase_price"),
                 json.dumps(data.get("visible_store_ids")) if data.get("visible_store_ids") is not None else None,
                 product_id,
             ))

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -474,6 +474,7 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                 p.code AS product_code,
                 p.name AS product_name,
                 p.price AS product_price,
+                p.purchase_price AS purchase_price,
                 p.visible_store_ids,
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id,
@@ -495,7 +496,7 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
         if status:
             query += " WHERE p.status = %s"
             params.append(status)
-        query += " GROUP BY p.product_id, p.code, p.name, p.price, p.visible_store_ids ORDER BY p.name"
+        query += " GROUP BY p.product_id, p.code, p.name, p.price, p.purchase_price, p.visible_store_ids ORDER BY p.name"
         cursor.execute(query, tuple(params))
     result = cursor.fetchall()
     conn.close()
@@ -532,6 +533,7 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                 p.code AS product_code,
                 p.name AS product_name,
                 p.price AS product_price,
+                p.purchase_price AS purchase_price,
                 p.visible_store_ids,
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id,
@@ -562,7 +564,7 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
 
-        query += " GROUP BY p.product_id, p.code, p.name, p.price, p.visible_store_ids ORDER BY p.name"
+        query += " GROUP BY p.product_id, p.code, p.name, p.price, p.purchase_price, p.visible_store_ids ORDER BY p.name"
 
         cursor.execute(query, tuple(params))
         result = cursor.fetchall()


### PR DESCRIPTION
## Summary
- add a purchase_price column to the product schema and sample data and propagate it through product model/service layers
- update the inventory stock-in page to lay out search/product selectors side-by-side, move quantity, and surface the product purchase price
- rename and reorder product/therapy bundle and item modals to match the requested labels and positioning, including a purchase price input for products

## Testing
- npm run build *(fails: repository currently contains pre-existing TypeScript errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9600ad504832985e30548d20dfe71