### PR TITLE
Group member list by store and member code

### DIFF
--- a/client/src/services/MemberService.ts
+++ b/client/src/services/MemberService.ts
@@ -48,6 +48,8 @@ export interface Member {
   Referrer: string;  // 介紹人 ID
   Occupation: string;
   Note: string;
+  StoreId?: string;
+  StoreName?: string;
 }
 
 /**
@@ -66,6 +68,8 @@ interface BackendMember {
   phone: string;
   occupation: string;
   note: string;
+  store_id?: number | string | null;
+  store_name?: string | null;
 }
 
 /**
@@ -84,7 +88,11 @@ const transformBackendToFrontend = (member: BackendMember): Member => {
     BloodType: member.blood_type || '',
     Referrer: member.inferrer_id ? String(member.inferrer_id) : '',
     Occupation: member.occupation || '',
-    Note: member.note || ''
+    Note: member.note || '',
+    StoreId: member.store_id !== undefined && member.store_id !== null && member.store_id !== ''
+      ? String(member.store_id)
+      : undefined,
+    StoreName: member.store_name || undefined
   };
 };
 

--- a/server/app/models/member_model.py
+++ b/server/app/models/member_model.py
@@ -64,17 +64,21 @@ def get_all_members(store_level: str, store_id: int):
     try:
         with conn.cursor() as cursor:
             base_sql = """
-                SELECT member_id, member_code, name, birthday, address, phone, gender, blood_type,
-                       line_id, inferrer_id, occupation, note, store_id
-                FROM member
+                SELECT m.member_id, m.member_code, m.name, m.birthday, m.address, m.phone, m.gender, m.blood_type,
+                       m.line_id, m.inferrer_id, m.occupation, m.note, m.store_id, s.store_name
+                FROM member AS m
+                LEFT JOIN store AS s ON m.store_id = s.store_id
             """
             params = []
-            
+
             if store_level == "分店":
-                base_sql += " WHERE store_id = %s"
+                base_sql += " WHERE m.store_id = %s"
                 params.append(store_id)
-            
-            base_sql += " ORDER BY member_id DESC"
+
+            base_sql += (
+                " ORDER BY m.store_id IS NULL, m.store_id, m.member_code IS NULL,"
+                " COALESCE(CHAR_LENGTH(m.member_code), 0), m.member_code, m.member_id"
+            )
             
             cursor.execute(base_sql, tuple(params))
             result = cursor.fetchall()
@@ -92,20 +96,24 @@ def search_members(keyword: str, store_level: str, store_id: int):
     try:
         with conn.cursor() as cursor:
             like_keyword = f"%{keyword}%"
-            
+
             base_sql = """
-                SELECT member_id, member_code, name, birthday, address, phone, gender, blood_type,
-                       line_id, inferrer_id, occupation, note, store_id
-                FROM member
-                WHERE (name LIKE %s OR phone LIKE %s OR member_code LIKE %s)
+                SELECT m.member_id, m.member_code, m.name, m.birthday, m.address, m.phone, m.gender, m.blood_type,
+                       m.line_id, m.inferrer_id, m.occupation, m.note, m.store_id, s.store_name
+                FROM member AS m
+                LEFT JOIN store AS s ON m.store_id = s.store_id
+                WHERE (m.name LIKE %s OR m.phone LIKE %s OR m.member_code LIKE %s)
             """
             params = [like_keyword, like_keyword, like_keyword]
 
             if store_level == "分店":
-                base_sql += " AND store_id = %s"
+                base_sql += " AND m.store_id = %s"
                 params.append(store_id)
 
-            base_sql += " ORDER BY member_id DESC"
+            base_sql += (
+                " ORDER BY m.store_id IS NULL, m.store_id, m.member_code IS NULL,"
+                " COALESCE(CHAR_LENGTH(m.member_code), 0), m.member_code, m.member_id"
+            )
 
             cursor.execute(base_sql, tuple(params))
             result = cursor.fetchall()
@@ -188,10 +196,11 @@ def get_member_by_id(member_id: int):
     try:
         with conn.cursor() as cursor:
             cursor.execute("""
-                SELECT member_id, member_code, name, birthday, address, phone, gender, blood_type,
-                       line_id, inferrer_id, occupation, note, store_id
-                FROM member
-                WHERE member_id = %s
+                SELECT m.member_id, m.member_code, m.name, m.birthday, m.address, m.phone, m.gender, m.blood_type,
+                       m.line_id, m.inferrer_id, m.occupation, m.note, m.store_id, s.store_name
+                FROM member AS m
+                LEFT JOIN store AS s ON m.store_id = s.store_id
+                WHERE m.member_id = %s
             """, (member_id,))
             result = cursor.fetchone()
         return result


### PR DESCRIPTION
## Summary
- join member queries with the store table so each record includes its branch name
- extend the member service model to surface store identifiers and names to the frontend
- render the branch column between the checkbox and name on the member list
- order member queries by store and member_code so branch mates stay grouped and sorted
- sort the client-side table by store and member_code to mirror server ordering

## Testing
- npm run build (client) *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ec7b1d18832988288fbab3420f50