### PR TITLE
Ensure MySQL connections use utf8mb4_bin collation

### DIFF
--- a/server/app/config.py
+++ b/server/app/config.py
@@ -12,7 +12,8 @@ DB_CONFIG = {
     "user": os.getenv("DB_USER"),
     "password": os.getenv("DB_PASSWORD"),
     "database": os.getenv("DB_DATABASE"),
-    "charset": "utf8mb4"
+    "charset": "utf8mb4",
+    "init_command": "SET NAMES utf8mb4 COLLATE utf8mb4_bin"
 }
 
 


### PR DESCRIPTION
## Summary
- configure every PyMySQL connection to initialize with the utf8mb4_bin collation so literals match table collations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62a92ab308329a149b7b5d3e925dd