### PR TITLE
Add member summary panels to sales flows

### DIFF
--- a/client/src/components/MemberSummaryCard.tsx
+++ b/client/src/components/MemberSummaryCard.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Card } from "react-bootstrap";
+import { MemberData } from "../types/medicalTypes";
+
+interface MemberSummaryCardProps {
+  member: MemberData | null;
+  memberCode?: string;
+  fallbackName?: string;
+  className?: string;
+}
+
+const displayOrDash = (value?: string | null) => {
+  if (!value) {
+    return "-";
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : "-";
+};
+
+const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({
+  member,
+  memberCode,
+  fallbackName,
+  className,
+}) => {
+  const name = displayOrDash(member?.name ?? fallbackName);
+  const identity = displayOrDash(member?.identity_type ?? undefined);
+  const code = displayOrDash(member?.member_code ?? memberCode);
+  const note = displayOrDash(member?.note ?? undefined);
+
+  return (
+    <Card className={className}>
+      <Card.Header className="bg-light fw-semibold">會員基本資料</Card.Header>
+      <Card.Body>
+        <div className="mb-3">
+          <div className="text-muted small">姓名</div>
+          <div className="fw-semibold">{name}</div>
+        </div>
+        <div className="mb-3">
+          <div className="text-muted small">身分別</div>
+          <div className="fw-semibold">{identity}</div>
+        </div>
+        <div className="mb-3">
+          <div className="text-muted small">會員編號</div>
+          <div className="fw-semibold">{code}</div>
+        </div>
+        <div>
+          <div className="text-muted small">備註</div>
+          <div className="fw-semibold" style={{ whiteSpace: "pre-wrap" }}>{note}</div>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default MemberSummaryCard;

--- a/client/src/pages/member/AddMember.tsx
+++ b/client/src/pages/member/AddMember.tsx
@@ -16,6 +16,7 @@ const AddMember: React.FC = () => {
 
     const initialFormState = {
         member_code: "",
+        identity_type: "一般會員",
         name: "",
         birthday: "",
         age: "",
@@ -113,6 +114,7 @@ const AddMember: React.FC = () => {
         const dataToSubmit = { // <-- 我們先將要提交的資料建立成一個物件
             member_code: form.member_code,
             name: form.name,
+            identity_type: form.identity_type,
             birthday: form.birthday,
             address: form.address,
             phone: form.phone,
@@ -165,7 +167,26 @@ const AddMember: React.FC = () => {
                             )}
                         </Form.Group>
                     </Col>
-                    <Col md={6}></Col>
+                    <Col md={6}>
+                        <Form.Group>
+                            <Form.Label>身份別</Form.Label>
+                            <Form.Select
+                                name="identity_type"
+                                value={form.identity_type}
+                                onChange={handleSelectChange}
+                                required
+                            >
+                                <option value="直營店">直營店</option>
+                                <option value="加盟店">加盟店</option>
+                                <option value="合夥商">合夥商</option>
+                                <option value="推廣商(分店能量師)">推廣商(分店能量師)</option>
+                                <option value="B2B合作專案">B2B合作專案</option>
+                                <option value="心耀商">心耀商</option>
+                                <option value="會員">會員</option>
+                                <option value="一般會員">一般會員</option>
+                            </Form.Select>
+                        </Form.Group>
+                    </Col>
 
                     <Col md={6}>
                         <Form.Group>

--- a/client/src/pages/member/EditMember.tsx
+++ b/client/src/pages/member/EditMember.tsx
@@ -11,6 +11,7 @@ import { calculateAge } from '../../utils/memberUtils';
 // MemberFormData interface (保持不變)
 interface MemberFormData {
     member_code: string;
+    identity_type: string;
     name: string;
     birthday: string;
     age: string;
@@ -49,6 +50,7 @@ const EditMember: React.FC = () => {
                     // 將從服務獲取的資料填充到表單 state
                     setForm({
                         member_code: data.member_code || "",
+                        identity_type: data.IdentityType || "一般會員",
                         name: data.Name || "",
                         birthday: data.Birth ? new Date(data.Birth).toISOString().split('T')[0] : "",
                         gender: data.Gender || "Male",
@@ -108,6 +110,7 @@ const EditMember: React.FC = () => {
             // 將 form state 轉換為 Member service 期望的格式 (大寫鍵)
             const payload: Partial<Member> = {
                 Name: form.name,
+                IdentityType: form.identity_type,
                 Birth: form.birthday,
                 Gender: form.gender,
                 BloodType: form.bloodType,
@@ -139,7 +142,26 @@ const EditMember: React.FC = () => {
                 <Form onSubmit={handleSubmit}>
                     <Row className="g-3">
                         <Col md={6}><Form.Group><Form.Label>編號</Form.Label><Form.Control type="text" value={form.member_code || ''} readOnly disabled /></Form.Group></Col>
-                        <Col md={6}></Col> {/* 空白佔位 */}
+                        <Col md={6}>
+                            <Form.Group>
+                                <Form.Label>身份別</Form.Label>
+                                <Form.Select
+                                    name="identity_type"
+                                    value={form.identity_type || ''}
+                                    onChange={handleChange}
+                                    required
+                                >
+                                    <option value="直營店">直營店</option>
+                                    <option value="加盟店">加盟店</option>
+                                    <option value="合夥商">合夥商</option>
+                                    <option value="推廣商(分店能量師)">推廣商(分店能量師)</option>
+                                    <option value="B2B合作專案">B2B合作專案</option>
+                                    <option value="心耀商">心耀商</option>
+                                    <option value="會員">會員</option>
+                                    <option value="一般會員">一般會員</option>
+                                </Form.Select>
+                            </Form.Group>
+                        </Col>
                         
                         <Col md={6}><Form.Group><Form.Label>姓名</Form.Label><Form.Control name="name" value={form.name || ''} onChange={handleChange} required /></Form.Group></Col>
                         <Col md={3}><Form.Group><Form.Label>生日</Form.Label><Form.Control type="date" name="birthday" value={form.birthday || ''} onChange={handleChange} required /></Form.Group></Col>

--- a/client/src/pages/member/MemberInfo.tsx
+++ b/client/src/pages/member/MemberInfo.tsx
@@ -43,6 +43,7 @@ const MemberInfo: React.FC = () => {
             <th>店別</th>
             <th>姓名</th>
             <th style={{ minWidth: '8ch' }}>會員編號</th>
+            <th>身份別</th>
             <th>生日</th>
             <th>年齡</th>
             <th>住址</th>
@@ -57,9 +58,9 @@ const MemberInfo: React.FC = () => {
     
     // 定義表格內容
     const tableBody = loading ? (
-        <tr><td colSpan={13} className="text-center py-5"><Spinner animation="border" variant="info" /></td></tr>
+        <tr><td colSpan={14} className="text-center py-5"><Spinner animation="border" variant="info" /></td></tr>
     ) : error ? (
-        <tr><td colSpan={13} className="text-center text-danger py-5">{error}</td></tr>
+        <tr><td colSpan={14} className="text-center text-danger py-5">{error}</td></tr>
     ) : sortedMembers.length > 0 ? (
         sortedMembers.map((member) => (
             <tr key={member.Member_ID}>
@@ -75,6 +76,7 @@ const MemberInfo: React.FC = () => {
                 <td className="align-middle">{member.Name}</td>
                 {/* 顯示資料庫中的 member_code */}
                 <td className="align-middle" style={{ whiteSpace: 'nowrap' }}>{member.member_code ?? ""}</td>
+                <td className="align-middle">{member.IdentityType || ""}</td>
                 <td className="align-middle">{formatGregorianBirthday(member.Birth, 'YYYY/MM/DD')}</td>
                 <td className="align-middle">{calculateAge(member.Birth)}</td>
                 <td className="align-middle">{member.Address}</td>
@@ -87,7 +89,7 @@ const MemberInfo: React.FC = () => {
             </tr>
         ))
     ) : (
-        <tr><td colSpan={13} className="text-center text-muted py-5">尚無資料</td></tr>
+        <tr><td colSpan={14} className="text-center text-muted py-5">尚無資料</td></tr>
     );
     
     // 新增：處理修改按鈕的點擊事件

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import MemberColumn from "../../components/MemberColumn";
+import MemberSummaryCard from "../../components/MemberSummaryCard";
 import { MemberData } from "../../types/medicalTypes";
 import { addProductSell, ProductSellData, getProductSellById, updateProductSell, ProductSell } from "../../services/ProductSellService";
 import { getStoreId } from "../../services/LoginService";
@@ -68,6 +69,7 @@ const AddProductSell: React.FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [formSubmitted, setFormSubmitted] = useState<boolean>(false);
+  const [selectedMember, setSelectedMember] = useState<MemberData | null>(null);
 
   useEffect(() => {
     const init = async () => {
@@ -215,8 +217,12 @@ const AddProductSell: React.FC = () => {
     setMemberName(name);
     setMemberId(data?.member_id?.toString() || "");
     setError(null);
+    setSelectedMember(data);
   };
-  const handleError = (errorMsg: string) => setError(errorMsg);
+  const handleError = (errorMsg: string) => {
+    setError(errorMsg);
+    setSelectedMember(null);
+  };
   const openProductSelection = () => {
     const formState = {
       selectedStore,
@@ -479,6 +485,12 @@ const AddProductSell: React.FC = () => {
 
           {/* --- Right Column --- */}
           <Col md={6}>
+            <MemberSummaryCard
+              member={selectedMember}
+              memberCode={memberCode}
+              fallbackName={memberName}
+              className="mb-3 shadow-sm"
+            />
             <Form.Group className="mb-3">
               <Form.Label>購買日期</Form.Label>
               <Form.Control type="date" lang="en-CA" value={purchaseDate} max={new Date().toISOString().split("T")[0]} onChange={(e) => setPurchaseDate(e.target.value)} required />

--- a/client/src/pages/therapy/AddTherapySell.tsx
+++ b/client/src/pages/therapy/AddTherapySell.tsx
@@ -11,6 +11,7 @@ import {
   InputGroup,
 } from "react-bootstrap";
 import MemberColumn from "../../components/MemberColumn";
+import MemberSummaryCard from "../../components/MemberSummaryCard";
 import { useNavigate, useLocation } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
@@ -18,6 +19,8 @@ import { getStaffMembers, addTherapySell, SelectedTherapyPackageUIData, TherapyS
 import { SalesOrderItemData } from "../../services/SalesOrderService";
 import { getStoreName } from "../../utils/authUtils";
 import { fetchTherapyBundlesForSale, TherapyBundle } from "../../services/TherapyBundleService";
+import { getMemberByCode } from "../../services/MedicalService";
+import { MemberData } from "../../types/medicalTypes";
 
 interface DropdownItem {
   id: number;
@@ -54,6 +57,7 @@ const AddTherapySell: React.FC = () => {
   const saleCategoryOptions = ["銷售", "贈品", "折扣", "預購", "暫借"];
 
   const [memberName, setMemberName] = useState<string>("");
+  const [selectedMember, setSelectedMember] = useState<MemberData | null>(null);
   const [staffList, setStaffList] = useState<DropdownItem[]>([]);
   const [therapyPackages, setTherapyPackages] = useState<SelectedTherapyPackageUIData[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -207,6 +211,38 @@ const AddTherapySell: React.FC = () => {
   useEffect(() => {
     setFinalPayableAmount(packagesOriginalTotal - Number(formData.discountAmount || 0));
   }, [packagesOriginalTotal, formData.discountAmount]);
+
+  useEffect(() => {
+    const code = formData.memberCode?.trim();
+    if (!code) {
+      if (selectedMember) {
+        setSelectedMember(null);
+      }
+      return;
+    }
+
+    if (!isEditMode) {
+      return;
+    }
+
+    if (selectedMember?.member_code === code) {
+      return;
+    }
+
+    const loadMember = async () => {
+      try {
+        const member = await getMemberByCode(code);
+        setSelectedMember(member);
+        if (member?.name) {
+          setMemberName(member.name);
+        }
+      } catch (err) {
+        console.error("載入會員資料失敗", err);
+      }
+    };
+
+    loadMember();
+  }, [formData.memberCode, isEditMode, selectedMember]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -386,140 +422,155 @@ const AddTherapySell: React.FC = () => {
             <Card.Body>
               {error && <Alert variant="danger">{error}</Alert>}
               <Form onSubmit={handleSubmit}>
+                <Row className="g-4">
+                  <Col lg={8}>
+                    <Row className="mb-3">
+                      <Col>
+                        <MemberColumn
+                          memberCode={formData.memberCode}
+                          name={memberName}
+                          isEditMode={isEditMode}
+                            onMemberChange={(code, name, data) => {
+                              setFormData(prev => ({ ...prev, memberCode: code, memberId: data?.member_id?.toString() || "" }));
+                              setMemberName(name);
+                              setSelectedMember(data);
+                              if (data) {
+                                setError(null);
+                              }
+                            }}
+                          onError={(msg) => {
+                            setError(msg);
+                            setSelectedMember(null);
+                          }}
+                        />
+                      </Col>
+                    </Row>
+                    <Row className="mb-3">
+                      <Form.Group as={Col} controlId="therapyPackages">
+                        <Form.Label>療程品項</Form.Label>
+                        <div className="d-flex gap-2">
+                          <div className="flex-grow-1 border rounded p-2" style={{ minHeight: '40px', maxHeight: '120px', overflowY: 'auto' }}>
+                            {therapyPackages.length > 0 ? (
+                              therapyPackages.map((pkg, i) => (
+                                <div key={i}>{pkg.TherapyContent || pkg.TherapyName} x {pkg.userSessions} (單價: NT${pkg.TherapyPrice?.toLocaleString()})</div>
+                              ))
+                            ) : (
+                              <span className="text-muted">點擊「選取」按鈕選擇療程</span>
+                            )}
+                          </div>
+                          <Button
+                            variant="info"
+                            type="button"
+                            className="text-white align-self-start px-3"
+                            onClick={openPackageSelection}
+                            disabled={isEditMode}
+                          >選取</Button>
+                        </div>
+                        {isEditMode ? (
+                          <Form.Text className="text-danger">修改模式無法新增療程品項，若需新增請使用新增功能。</Form.Text>
+                        ) : (
+                          <Form.Text muted>可複選，跳出新視窗選取。</Form.Text>
+                        )}
+                      </Form.Group>
+                    </Row>
 
-                <Row className="mb-3">
-                  <Col>
-                    <MemberColumn
+                    <Row className="mb-3">
+                      <Form.Group as={Col} controlId="staffId">
+                        <Form.Label>服務人員</Form.Label>
+                        <Form.Select name="staffId" value={formData.staffId} onChange={handleChange} required>
+                          <option value="">請選擇服務人員</option>
+                          {staffList.map((staff) => (
+                            <option key={staff.id} value={staff.id}>
+                              {staff.name}
+                            </option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                      <Form.Group as={Col} controlId="paymentMethod">
+                        <Form.Label>付款方式</Form.Label>
+                        <Form.Select name="paymentMethod" value={formData.paymentMethod} onChange={handleChange} required>
+                          {paymentMethodOptions.map(opt => (
+                            <option key={opt} value={opt}>{opt}</option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                    </Row>
+
+                    {formData.paymentMethod === '信用卡' && (
+                      <Form.Group className="mb-3" controlId="cardNumber">
+                        <Form.Label>卡號後五碼</Form.Label>
+                        <Form.Control type="text" name="cardNumber" maxLength={5} pattern="\d*" value={formData.cardNumber}
+                          onChange={handleChange} placeholder="請輸入信用卡號後五碼" />
+                      </Form.Group>
+                    )}
+                    {formData.paymentMethod === '轉帳' && (
+                      <Form.Group className="mb-3" controlId="transferCode">
+                        <Form.Label>轉帳帳號末五碼</Form.Label>
+                        <Form.Control type="text" name="transferCode" maxLength={5} pattern="\d*" value={formData.transferCode}
+                          onChange={handleChange} placeholder="請輸入轉帳帳號末五碼" />
+                      </Form.Group>
+                    )}
+
+                    <Row className="mb-3">
+                      <Form.Group as={Col} controlId="saleCategory">
+                        <Form.Label>銷售類別</Form.Label>
+                        <Form.Select name="saleCategory" value={formData.saleCategory} onChange={handleChange} required>
+                          {saleCategoryOptions.map(opt => (
+                            <option key={opt} value={opt}>{opt}</option>
+                          ))}
+                        </Form.Select>
+                      </Form.Group>
+                      <Form.Group as={Col} controlId="discountAmount">
+                        <Form.Label>折價</Form.Label>
+                        <InputGroup>
+                          <InputGroup.Text>NT$</InputGroup.Text>
+                          <Form.Control type="number" name="discountAmount" min="0" step="any" value={formData.discountAmount} onChange={handleChange} placeholder="輸入折價金額" />
+                        </InputGroup>
+                      </Form.Group>
+                    </Row>
+
+                    <Row className="mb-3">
+                      <Form.Group as={Col}>
+                        <Form.Label>總價</Form.Label>
+                        <Form.Control type="text" value={`NT$ ${packagesOriginalTotal.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
+                      </Form.Group>
+                      <Form.Group as={Col}>
+                        <Form.Label>應收</Form.Label>
+                        <Form.Control type="text" value={`NT$ ${finalPayableAmount.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
+                      </Form.Group>
+                    </Row>
+
+                    <Form.Group className="mb-3" controlId="date">
+                      <Form.Label>購買日期</Form.Label>
+                      <Form.Control type="date" lang="en-CA" name="date" value={formData.date} onChange={handleChange} required />
+                    </Form.Group>
+
+                    <Form.Group className="mb-3" controlId="note">
+                      <Form.Label>備註</Form.Label>
+                      <Form.Control as="textarea" rows={3} name="note" value={formData.note} onChange={handleChange} />
+                    </Form.Group>
+
+                    <div className="d-flex justify-content-end gap-2">
+                      <Button variant="info" type="submit" className="text-white" disabled={loading}>
+                        {loading ? "儲存中..." : "確認"}
+                      </Button>
+                      <Button variant="info" type="button" className="text-white" onClick={handleCancel}>
+                        取消
+                      </Button>
+                      <Button variant="info" type="button" className="text-white" onClick={handlePrint}>
+                        列印
+                      </Button>
+                    </div>
+                  </Col>
+                  <Col lg={4}>
+                    <MemberSummaryCard
+                      member={selectedMember}
                       memberCode={formData.memberCode}
-                      name={memberName}
-                      isEditMode={isEditMode}
-                        onMemberChange={(code, name, data) => {
-                          setFormData(prev => ({ ...prev, memberCode: code, memberId: data?.member_id?.toString() || "" }));
-                          setMemberName(name);
-                          if (data) {
-                            setError(null);
-                          }
-                        }}
-                      onError={(msg) => setError(msg)}
+                      fallbackName={memberName}
+                      className="shadow-sm h-100"
                     />
                   </Col>
                 </Row>
-                <Row className="mb-3">
-                  <Form.Group as={Col} controlId="therapyPackages">
-                    <Form.Label>療程品項</Form.Label>
-                    <div className="d-flex gap-2">
-                      <div className="flex-grow-1 border rounded p-2" style={{ minHeight: '40px', maxHeight: '120px', overflowY: 'auto' }}>
-                        {therapyPackages.length > 0 ? (
-                          therapyPackages.map((pkg, i) => (
-                            <div key={i}>{pkg.TherapyContent || pkg.TherapyName} x {pkg.userSessions} (單價: NT${pkg.TherapyPrice?.toLocaleString()})</div>
-                          ))
-                        ) : (
-                          <span className="text-muted">點擊「選取」按鈕選擇療程</span>
-                        )}
-                      </div>
-                      <Button
-                        variant="info"
-                        type="button"
-                        className="text-white align-self-start px-3"
-                        onClick={openPackageSelection}
-                        disabled={isEditMode}
-                      >選取</Button>
-                    </div>
-                    {isEditMode ? (
-                      <Form.Text className="text-danger">修改模式無法新增療程品項，若需新增請使用新增功能。</Form.Text>
-                    ) : (
-                      <Form.Text muted>可複選，跳出新視窗選取。</Form.Text>
-                    )}
-                  </Form.Group>
-                </Row>
-
-                <Row className="mb-3">
-                  <Form.Group as={Col} controlId="staffId">
-                    <Form.Label>服務人員</Form.Label>
-                    <Form.Select name="staffId" value={formData.staffId} onChange={handleChange} required>
-                      <option value="">請選擇服務人員</option>
-                      {staffList.map((staff) => (
-                        <option key={staff.id} value={staff.id}>
-                          {staff.name}
-                        </option>
-                      ))}
-                    </Form.Select>
-                  </Form.Group>
-                  <Form.Group as={Col} controlId="paymentMethod">
-                    <Form.Label>付款方式</Form.Label>
-                    <Form.Select name="paymentMethod" value={formData.paymentMethod} onChange={handleChange} required>
-                      {paymentMethodOptions.map(opt => (
-                        <option key={opt} value={opt}>{opt}</option>
-                      ))}
-                    </Form.Select>
-                  </Form.Group>
-                </Row>
-
-                {formData.paymentMethod === '信用卡' && (
-                  <Form.Group className="mb-3" controlId="cardNumber">
-                    <Form.Label>卡號後五碼</Form.Label>
-                    <Form.Control type="text" name="cardNumber" maxLength={5} pattern="\d*" value={formData.cardNumber}
-                      onChange={handleChange} placeholder="請輸入信用卡號後五碼" />
-                  </Form.Group>
-                )}
-                {formData.paymentMethod === '轉帳' && (
-                  <Form.Group className="mb-3" controlId="transferCode">
-                    <Form.Label>轉帳帳號末五碼</Form.Label>
-                    <Form.Control type="text" name="transferCode" maxLength={5} pattern="\d*" value={formData.transferCode}
-                      onChange={handleChange} placeholder="請輸入轉帳帳號末五碼" />
-                  </Form.Group>
-                )}
-
-                <Row className="mb-3">
-                  <Form.Group as={Col} controlId="saleCategory">
-                    <Form.Label>銷售類別</Form.Label>
-                    <Form.Select name="saleCategory" value={formData.saleCategory} onChange={handleChange} required>
-                      {saleCategoryOptions.map(opt => (
-                        <option key={opt} value={opt}>{opt}</option>
-                      ))}
-                    </Form.Select>
-                  </Form.Group>
-                  <Form.Group as={Col} controlId="discountAmount">
-                    <Form.Label>折價</Form.Label>
-                    <InputGroup>
-                      <InputGroup.Text>NT$</InputGroup.Text>
-                      <Form.Control type="number" name="discountAmount" min="0" step="any" value={formData.discountAmount} onChange={handleChange} placeholder="輸入折價金額" />
-                    </InputGroup>
-                  </Form.Group>
-                </Row>
-
-                <Row className="mb-3">
-                  <Form.Group as={Col}>
-                    <Form.Label>總價</Form.Label>
-                    <Form.Control type="text" value={`NT$ ${packagesOriginalTotal.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
-                  </Form.Group>
-                  <Form.Group as={Col}>
-                    <Form.Label>應收</Form.Label>
-                    <Form.Control type="text" value={`NT$ ${finalPayableAmount.toLocaleString()}`} readOnly disabled className="bg-light text-end" />
-                  </Form.Group>
-                </Row>
-
-                <Form.Group className="mb-3" controlId="date">
-                  <Form.Label>購買日期</Form.Label>
-                  <Form.Control type="date" lang="en-CA" name="date" value={formData.date} onChange={handleChange} required />
-                </Form.Group>
-
-                <Form.Group className="mb-3" controlId="note">
-                  <Form.Label>備註</Form.Label>
-                  <Form.Control as="textarea" rows={3} name="note" value={formData.note} onChange={handleChange} />
-                </Form.Group>
-
-                <div className="d-flex justify-content-end gap-2">
-                  <Button variant="info" type="submit" className="text-white" disabled={loading}>
-                    {loading ? "儲存中..." : "確認"}
-                  </Button>
-                  <Button variant="info" type="button" className="text-white" onClick={handleCancel}>
-                    取消
-                  </Button>
-                  <Button variant="info" type="button" className="text-white" onClick={handlePrint}>
-                    列印
-                  </Button>
-                </div>
               </Form>
             </Card.Body>
           </Card>

--- a/client/src/services/MemberService.ts
+++ b/client/src/services/MemberService.ts
@@ -39,6 +39,7 @@ export interface Member {
   /** 會員代碼 (例如 M001) */
   member_code?: string;
   Name: string;
+  IdentityType?: string;
   Gender: string;
   Birth: string;
   Phone: string;
@@ -59,6 +60,7 @@ interface BackendMember {
   member_id: number | string;
   member_code?: string;
   name: string;
+  identity_type?: string;
   birthday: Date | string;
   gender: 'Male' | 'Female' | 'Other' | string;
   blood_type: 'A' | 'B' | 'AB' | 'O' | string;
@@ -80,6 +82,7 @@ const transformBackendToFrontend = (member: BackendMember): Member => {
     Member_ID: String(member.member_id),
     member_code: member.member_code || undefined,
     Name: member.name,
+    IdentityType: member.identity_type || '一般會員',
     Gender: member.gender || '',
     Birth: member.birthday ? (typeof member.birthday === 'string' ? member.birthday : member.birthday.toISOString().split('T')[0]) : '',
     Phone: member.phone || '',
@@ -105,6 +108,7 @@ const transformFrontendToBackend = (member: Partial<Member>): Partial<BackendMem
   if (member.Member_ID) backendMember.member_id = member.Member_ID;
   if (member.member_code) backendMember.member_code = member.member_code;
   if (member.Name) backendMember.name = member.Name;
+  if (member.IdentityType !== undefined) backendMember.identity_type = member.IdentityType;
   if (member.Gender) backendMember.gender = member.Gender;
   if (member.Birth) backendMember.birthday = member.Birth;
   if (member.Phone) backendMember.phone = member.Phone;
@@ -235,6 +239,7 @@ export const deleteMember = async (memberId: string) => {
 export const createMember = async (memberData: {
   member_code: string; // <-- 1. 新增 member_code 參數定義
   name: string;
+  identity_type: string;
   birthday: string;
   address?: string;
   phone?: string;

--- a/client/src/types/medicalTypes.ts
+++ b/client/src/types/medicalTypes.ts
@@ -3,6 +3,7 @@ export interface MemberData {
     member_id: number;
     member_code?: string;
     name: string;
+    identity_type?: string;
     address: string;
     birthday: string;
     blood_type: string;

--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -323,6 +323,7 @@ CREATE TABLE `member` (
   `member_id` int NOT NULL AUTO_INCREMENT,
   `member_code` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `identity_type` enum('直營店','加盟店','合夥商','推廣商(分店能量師)','B2B合作專案','心耀商','會員','一般會員') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '一般會員' COMMENT '會員身份別',
   `birthday` date DEFAULT NULL,
   `gender` enum('Male','Female','Other') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `blood_type` enum('A','B','AB','O') COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/server/app/models/member_model.py
+++ b/server/app/models/member_model.py
@@ -23,16 +23,19 @@ def create_member(data, store_id: int):
             if blood_type_value == '':
                 blood_type_value = None
 
+            identity_type_value = data.get("identity_type") or "一般會員"
+
             sql = """
                 INSERT INTO member (
-                    member_code, name, birthday, gender, blood_type,
+                    member_code, name, identity_type, birthday, gender, blood_type,
                     line_id, address, inferrer_id, phone, occupation, note,
-                    store_id 
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    store_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """
             params = (
                 data.get("member_code"),
                 data.get("name"),
+                identity_type_value,
                 data.get("birthday"),
                 data.get("gender"),
                 blood_type_value,
@@ -64,7 +67,7 @@ def get_all_members(store_level: str, store_id: int):
     try:
         with conn.cursor() as cursor:
             base_sql = """
-                SELECT m.member_id, m.member_code, m.name, m.birthday, m.address, m.phone, m.gender, m.blood_type,
+                SELECT m.member_id, m.member_code, m.name, m.identity_type, m.birthday, m.address, m.phone, m.gender, m.blood_type,
                        m.line_id, m.inferrer_id, m.occupation, m.note, m.store_id, s.store_name
                 FROM member AS m
                 LEFT JOIN store AS s ON m.store_id = s.store_id
@@ -97,7 +100,7 @@ def search_members(keyword: str, store_level: str, store_id: int):
             like_keyword = f"%{keyword}%"
 
             base_sql = """
-                SELECT m.member_id, m.member_code, m.name, m.birthday, m.address, m.phone, m.gender, m.blood_type,
+                SELECT m.member_id, m.member_code, m.name, m.identity_type, m.birthday, m.address, m.phone, m.gender, m.blood_type,
                        m.line_id, m.inferrer_id, m.occupation, m.note, m.store_id, s.store_name
                 FROM member AS m
                 LEFT JOIN store AS s ON m.store_id = s.store_id
@@ -175,13 +178,15 @@ def update_member(member_id, data):
             if blood_type_value == '':
                 blood_type_value = None
 
+            identity_type_value = data.get("identity_type") or "一般會員"
+
             cursor.execute("""
                 UPDATE member SET
-                    name=%s, birthday=%s, address=%s, phone=%s, gender=%s,
+                    name=%s, identity_type=%s, birthday=%s, address=%s, phone=%s, gender=%s,
                     blood_type=%s, line_id=%s, inferrer_id=%s, occupation=%s, note=%s
                 WHERE member_id = %s
             """, (
-                data.get("name"), data.get("birthday"), data.get("address"),
+                data.get("name"), identity_type_value, data.get("birthday"), data.get("address"),
                 data.get("phone"), data.get("gender"), blood_type_value,
                 data.get("line_id"), data.get("inferrer_id"), data.get("occupation"),
                 data.get("note"), member_id
@@ -195,7 +200,7 @@ def get_member_by_id(member_id: int):
     try:
         with conn.cursor() as cursor:
             cursor.execute("""
-                SELECT m.member_id, m.member_code, m.name, m.birthday, m.address, m.phone, m.gender, m.blood_type,
+                SELECT m.member_id, m.member_code, m.name, m.identity_type, m.birthday, m.address, m.phone, m.gender, m.blood_type,
                        m.line_id, m.inferrer_id, m.occupation, m.note, m.store_id, s.store_name
                 FROM member AS m
                 LEFT JOIN store AS s ON m.store_id = s.store_id
@@ -212,7 +217,7 @@ def get_member_by_code(member_code: str):
         with conn.cursor() as cursor:
             cursor.execute(
                 """
-                SELECT member_id, member_code, name, birthday, address, phone, gender, blood_type,
+                SELECT member_id, member_code, name, identity_type, birthday, address, phone, gender, blood_type,
                        line_id, inferrer_id, occupation, note, store_id
                 FROM member
                 WHERE member_code = %s

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -83,6 +83,9 @@ def create_member_route():
         
         if not data.get('name') or not data.get('birthday'):
             return jsonify({"error": "姓名和生日為必填欄位。"}), 400
+
+        if not data.get('identity_type'):
+            return jsonify({"error": "會員身份別為必填欄位。"}), 400
         
         # 呼叫 model 函式新增會員，並傳入當前使用者的 store_id
         create_member(data, user_store_id)
@@ -139,8 +142,10 @@ def update_member_route(member_id):
         # --- 權限檢查結束 ---
 
         member_data = {
-            "name": data.get("name"), "birthday": data.get("birthday"), "address": data.get("address"),
-            "phone": data.get("phone"), "gender": data.get("gender"), 
+            "name": data.get("name"),
+            "identity_type": data.get("identityType") or data.get("identity_type"),
+            "birthday": data.get("birthday"), "address": data.get("address"),
+            "phone": data.get("phone"), "gender": data.get("gender"),
             "blood_type": data.get("bloodType") or data.get("blood_type"),
             "line_id": data.get("lineId") or data.get("line_id"),
             "inferrer_id": data.get("inferrerId") or data.get("inferrer_id"),
@@ -177,7 +182,7 @@ def export_members():
         df = pd.DataFrame(members)
 
         column_mapping = {
-            'member_id': '會員ID', 'member_code': '會員編號', 'name': '姓名',
+            'member_id': '會員ID', 'member_code': '會員編號', 'name': '姓名', 'identity_type': '身份別',
             'birthday': '生日', 'address': '地址', 'phone': '電話', 'gender': '性別',
             'blood_type': '血型', 'line_id': 'Line ID', 'inferrer_id': '推薦人編號',
             'occupation': '職業', 'note': '備註', 'store_name': '所屬分店'

--- a/server/tests/test_member_api.py
+++ b/server/tests/test_member_api.py
@@ -66,6 +66,7 @@ def generate_test_data():
     # Generate random test data for a member
     return {
         "name": "Test User " + ''.join(random.choices(string.ascii_letters, k=5)),
+        "identity_type": "一般會員",
         "birthday": "1990-01-01",
         "address": "Test Address",
         "phone": "0912345678",


### PR DESCRIPTION
## Summary
- add a reusable member summary card component to display core profile details
- surface the member card alongside product and therapy sales forms with live data from the selected member
- ensure therapy edit mode fetches member info and extend the shared member type with the identity field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da6bb1244c83298957167ee47080e2