### PR TITLE
Enforce role permissions across management routes

### DIFF
--- a/server/app/routes/inventory.py
+++ b/server/app/routes/inventory.py
@@ -63,6 +63,8 @@ def search_inventory_items():
 def get_low_stock_items():
     """獲取低於閾值的庫存記錄"""
     try:
+        if getattr(request, 'permission', None) == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         user_store_level = request.store_level
         user_store_id = request.store_id
         is_admin = user_store_level == '總店' or request.permission == 'admin'
@@ -128,6 +130,8 @@ def update_inventory(inventory_id):
     """更新庫存記錄"""
     data = request.json
     try:
+        if getattr(request, 'permission', None) == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         if inventory_id >= 1000000:
             return jsonify({"error": "銷售資料無法做更動，銷售資料要做更動請至銷售產品/銷售療程做修改"}), 400
 
@@ -183,6 +187,8 @@ def add_inventory():
 def delete_inventory(inventory_id):
     """刪除庫存記錄"""
     try:
+        if getattr(request, 'permission', None) != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
         existing = get_inventory_by_id(inventory_id)
         if not existing:
             return jsonify({"error": "找不到該庫存記錄"}), 404

--- a/server/app/routes/medical_record.py
+++ b/server/app/routes/medical_record.py
@@ -75,6 +75,8 @@ def create():
 def delete(record_id):
     """刪除健康理療記錄，並進行權限檢查"""
     try:
+        if getattr(request, 'permission', None) != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
         # --- 權限檢查 ---
         user_store_level = request.store_level
         user_store_id = request.store_id
@@ -160,6 +162,8 @@ def get_record(record_id):
 def update(record_id):
     """更新健康理療記錄，並進行權限檢查"""
     try:
+        if getattr(request, 'permission', None) == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         # --- 權限檢查 ---
         user_store_level = request.store_level
         user_store_id = request.store_id

--- a/server/app/routes/member.py
+++ b/server/app/routes/member.py
@@ -98,6 +98,8 @@ def create_member_route():
 def delete_member_route(member_id):
     """刪除會員，並進行權限檢查"""
     try:
+        if getattr(request, "permission", None) != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
         # --- 權限檢查 ---
         user_store_level = request.store_level
         user_store_id = request.store_id
@@ -126,6 +128,8 @@ def update_member_route(member_id):
     """更新會員資料，並進行權限檢查"""
     data = request.json
     try:
+        if getattr(request, "permission", None) == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         # --- 權限檢查 ---
         user_store_level = request.store_level
         user_store_id = request.store_id

--- a/server/app/routes/product_sell.py
+++ b/server/app/routes/product_sell.py
@@ -74,10 +74,22 @@ def add_sale():
     data = request.json or {}
     try:
         user = get_user_from_token(request)
+        permission = user.get('permission') if user else getattr(request, 'permission', None)
         if user and user.get("store_id") and not data.get("store_id"):
             data["store_id"] = user.get("store_id")
         if user and user.get("staff_id") and not data.get("staff_id"):
             data["staff_id"] = user.get("staff_id")
+
+        if permission == 'therapist':
+            discount_value = data.get("discount_amount")
+            if discount_value is None:
+                discount_value = data.get("discountAmount")
+            try:
+                discount_numeric = float(discount_value or 0)
+            except (TypeError, ValueError):
+                discount_numeric = 0
+            if discount_numeric:
+                return jsonify({"error": "無操作權限"}), 403
 
         # 驗證必要欄位
         required_fields = [
@@ -107,11 +119,13 @@ def update_sale(sale_id):
         sale = get_product_sell_by_id(sale_id)
         if not sale:
             return jsonify({"error": "找不到產品銷售記錄"}), 404
-            
+
         user = get_user_from_token(request)
+        permission = user.get('permission') if user else getattr(request, 'permission', None)
+        if permission == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         if user and user.get('permission') != 'admin' and sale.get('store_id') != user.get('store_id'):
             return jsonify({"error": "無權限修改其他商店的記錄"}), 403
-            
         update_product_sell(sale_id, data)
         return jsonify({"message": "產品銷售記錄更新成功"}), 200
     except ValueError as e:
@@ -123,14 +137,18 @@ def update_sale(sale_id):
 @auth_required
 def delete_sale(sale_id):
     try:
+        user = get_user_from_token(request)
+        permission = user.get('permission') if user else getattr(request, 'permission', None)
+        if permission != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
+
         sale = get_product_sell_by_id(sale_id)
         if not sale:
             return jsonify({"error": "找不到產品銷售記錄"}), 404
-            
-        user = get_user_from_token(request)
-        if user and user.get('permission') != 'admin' and sale.get('store_id') != user.get('store_id'):
+
+        if permission != 'admin' and sale.get('store_id') != user.get('store_id'):
             return jsonify({"error": "無權限刪除其他商店的記錄"}), 403
-            
+
         delete_product_sell(sale_id)
         return jsonify({"message": "產品銷售記錄刪除成功"}), 200
     except Exception as e:

--- a/server/app/routes/pure_medical_record.py
+++ b/server/app/routes/pure_medical_record.py
@@ -74,6 +74,8 @@ def create_pure_record():
 def update_record(pure_id):
     """更新淨化健康紀錄，並進行權限檢查"""
     try:
+        if getattr(request, 'permission', None) == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         # 權限檢查
         existing_record = get_pure_record_by_id(pure_id)
         if not existing_record:
@@ -96,6 +98,8 @@ def update_record(pure_id):
 def delete_record(pure_id):
     """刪除淨化健康紀錄，並進行權限檢查"""
     try:
+        if getattr(request, 'permission', None) != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
         # 權限檢查
         existing_record = get_pure_record_by_id(pure_id)
         if not existing_record:

--- a/server/app/routes/stress_test.py
+++ b/server/app/routes/stress_test.py
@@ -168,6 +168,8 @@ def add_stress_test_route():
 @auth_required
 def update_stress_test_route(stress_id):
     try:
+        if getattr(request, 'permission', None) == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
         # 權限檢查
         record_to_update = get_stress_test_by_id_with_answers(stress_id)
         if not record_to_update:
@@ -197,6 +199,8 @@ def update_stress_test_route(stress_id):
 def delete_stress_test_route(test_id):
     """刪除壓力測試，並檢查權限"""
     try:
+        if getattr(request, 'permission', None) != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
         # 權限檢查
         record_to_delete = get_stress_test_by_id(test_id)
         if not record_to_delete:

--- a/server/app/routes/therapy.py
+++ b/server/app/routes/therapy.py
@@ -110,14 +110,17 @@ def update_record(record_id):
         record = get_therapy_record_by_id(record_id)
         if not record:
             return jsonify({"error": "找不到該療程紀錄"}), 404
-            
+
         # 獲取用戶資訊
         user = get_user_from_token(request)
-        
+        permission = user.get('permission') if user else getattr(request, 'permission', None)
+        if permission == 'therapist':
+            return jsonify({"error": "無操作權限"}), 403
+
         # 限制只能操作自己商店的記錄
         if user and user.get('store_id') and record.get('store_id') != user.get('store_id'):
             return jsonify({"error": "無權限修改其他商店的記錄"}), 403
-            
+
         # 進行更新
         update_therapy_record(record_id, data)
         return jsonify({"message": "更新成功"}), 200
@@ -134,10 +137,13 @@ def delete_record(record_id):
         record = get_therapy_record_by_id(record_id)
         if not record:
             return jsonify({"error": "找不到該療程紀錄"}), 404
-            
+
         # 獲取用戶資訊
         user = get_user_from_token(request)
-        
+        permission = user.get('permission') if user else getattr(request, 'permission', None)
+        if permission != 'admin':
+            return jsonify({"error": "無操作權限"}), 403
+
         # 限制只能操作自己商店的記錄
         if user and user.get('store_id') and record.get('store_id') != user.get('store_id'):
             return jsonify({"error": "無權限刪除其他商店的記錄"}), 403


### PR DESCRIPTION
## Summary
- align member, health record, therapy, and stress-test APIs with the updated role matrix so therapists cannot modify records and only admins may delete
- block therapists from adjusting discounts or editing product and therapy sales while restricting sales deletions to admins and limiting low-stock analysis access
- gate inventory, finance, and staff management routes to keep therapists out of back-office features and reserve destructive actions for admins

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c80e75c11883299ded2696d79b51c0