### PR TITLE
Add modal guard for therapist edit actions

### DIFF
--- a/client/src/components/NoPermissionModal.tsx
+++ b/client/src/components/NoPermissionModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Modal, Button } from 'react-bootstrap';
+
+interface NoPermissionModalProps {
+  show: boolean;
+  onHide: () => void;
+  message?: string;
+}
+
+const NoPermissionModal: React.FC<NoPermissionModalProps> = ({ show, onHide, message = '無操作權限' }) => {
+  return (
+    <Modal show={show} onHide={onHide} centered backdrop="static">
+      <Modal.Header closeButton>
+        <Modal.Title>提示</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className="text-center fs-5">
+        {message}
+      </Modal.Body>
+      <Modal.Footer className="justify-content-center">
+        <Button variant="info" className="text-white px-4" onClick={onHide}>
+          確認
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default NoPermissionModal;

--- a/client/src/hooks/usePermissionGuard.tsx
+++ b/client/src/hooks/usePermissionGuard.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import NoPermissionModal from '../components/NoPermissionModal';
+import { getUserRole } from '../utils/authUtils';
+
+type Role = 'admin' | 'basic' | 'therapist';
+
+interface UsePermissionGuardOptions {
+  disallowedRoles?: Role[];
+  message?: string;
+}
+
+interface UsePermissionGuardResult {
+  checkPermission: () => boolean;
+  modal: ReactNode;
+  userRole: Role | null;
+}
+
+const resolveRole = (): Role | null => {
+  const roleFromUtils = getUserRole();
+  if (roleFromUtils) {
+    return roleFromUtils;
+  }
+  const permission = localStorage.getItem('permission');
+  if (permission === 'admin' || permission === 'basic' || permission === 'therapist') {
+    return permission;
+  }
+  return null;
+};
+
+export const usePermissionGuard = (
+  { disallowedRoles = ['therapist'], message = '無操作權限' }: UsePermissionGuardOptions = {}
+): UsePermissionGuardResult => {
+  const [showModal, setShowModal] = useState(false);
+  const userRole = resolveRole();
+
+  const handleClose = useCallback(() => setShowModal(false), []);
+  const handleOpen = useCallback(() => setShowModal(true), []);
+
+  const checkPermission = useCallback(() => {
+    if (userRole && disallowedRoles.includes(userRole)) {
+      handleOpen();
+      return false;
+    }
+    return true;
+  }, [userRole, disallowedRoles, handleOpen]);
+
+  const modal = useMemo(
+    () => (
+      <NoPermissionModal show={showModal} onHide={handleClose} message={message} />
+    ),
+    [showModal, handleClose, message]
+  );
+
+  return { checkPermission, modal, userRole };
+};
+
+export default usePermissionGuard;

--- a/client/src/pages/finance/SalesOrderList.tsx
+++ b/client/src/pages/finance/SalesOrderList.tsx
@@ -9,6 +9,7 @@ import { SalesOrderListRow, getSalesOrders, deleteSalesOrders, exportSalesOrders
 import { formatCurrency } from '../../utils/productSellUtils'; // 借用金額格式化工具
 import { downloadBlob } from '../../utils/downloadBlob';
 import { formatDateToYYYYMMDD } from '../../utils/dateUtils';
+import usePermissionGuard from '../../hooks/usePermissionGuard';
 
 const SalesOrderList: React.FC = () => {
     const navigate = useNavigate();
@@ -17,6 +18,7 @@ const SalesOrderList: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const [keyword, setKeyword] = useState("");
     const [selectedIds, setSelectedIds] = useState<number[]>([]);
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
 
     const fetchData = useCallback(async (searchKeyword?: string) => {
         setLoading(true);
@@ -134,17 +136,25 @@ const SalesOrderList: React.FC = () => {
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={handleExport} disabled={loading}>報表匯出</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={handleExportSelected} disabled={loading || selectedIds.length === 0}>勾選匯出</Button></Col>
                     <Col xs="auto"><Button variant="info" className="text-white" onClick={handleDelete} disabled={loading || selectedIds.length === 0}>刪除</Button></Col>
-                    <Col xs="auto"><Button variant="info" className="text-white" onClick={() => navigate(`/finance/sales/add?order_id=${selectedIds[0]}`)} disabled={loading || selectedIds.length !== 1}>修改</Button></Col>
+                    <Col xs="auto"><Button variant="info" className="text-white" onClick={() => {
+                        if (!checkPermission()) {
+                            return;
+                        }
+                        navigate(`/finance/sales/add?order_id=${selectedIds[0]}`);
+                    }} disabled={loading || selectedIds.length !== 1}>修改</Button></Col>
                 </Row>
             </Container>
         </>
     );
 
     return (
-        <div className="d-flex flex-column min-vh-100 bg-light">
-            <Header />
-            <DynamicContainer content={content} />
-        </div>
+        <>
+            <div className="d-flex flex-column min-vh-100 bg-light">
+                <Header />
+                <DynamicContainer content={content} />
+            </div>
+            {permissionModal}
+        </>
     );
 };
 

--- a/client/src/pages/inventory/InventoryDetail.tsx
+++ b/client/src/pages/inventory/InventoryDetail.tsx
@@ -5,6 +5,7 @@ import DynamicContainer from "../../components/DynamicContainer";
 import { getInventoryRecords, exportInventory, deleteInventoryItem } from "../../services/InventoryService";
 import { downloadBlob } from "../../utils/downloadBlob";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 const formatDate = (d: string) => {
   const dt = new Date(d);
@@ -41,6 +42,7 @@ const InventoryDetail: React.FC = () => {
   const [endDate, setEndDate] = useState("");
   const [saleStaff, setSaleStaff] = useState("");
   const [buyer, setBuyer] = useState("");
+  const { checkPermission, modal: permissionModal } = usePermissionGuard();
 
   const handleSearch = () => {
     getInventoryRecords({
@@ -215,6 +217,9 @@ const InventoryDetail: React.FC = () => {
             variant="info"
             className="text-white px-4 me-2"
             onClick={() => {
+              if (!checkPermission()) {
+                return;
+              }
               if (!selectedId) {
                 alert('請先勾選要修改的資料');
                 return;
@@ -237,6 +242,7 @@ const InventoryDetail: React.FC = () => {
     <>
       <Header />
       <DynamicContainer content={content} />
+      {permissionModal}
     </>
   );
 };

--- a/client/src/pages/inventory/InventorySearch.tsx
+++ b/client/src/pages/inventory/InventorySearch.tsx
@@ -6,6 +6,7 @@ import DynamicContainer from "../../components/DynamicContainer";
 import ScrollableTable from "../../components/ScrollableTable";
 import { getAllInventory, searchInventory, deleteInventoryItem, exportInventory } from "../../services/InventoryService";
 import { downloadBlob } from "../../utils/downloadBlob";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 // 庫存項目接口
 interface InventoryItem {
@@ -34,6 +35,7 @@ const InventorySearch: React.FC = () => {
     const [inventoryItems, setInventoryItems] = useState<InventoryItem[]>([]);
     const [selectedItems, setSelectedItems] = useState<number[]>([]);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
 
     // 從 localStorage 中獲取用戶所屬店鋪ID
     const getUserStoreId = (): number | undefined => {
@@ -166,11 +168,15 @@ const InventorySearch: React.FC = () => {
 
     // 跳轉到更新頁面
     const handleEdit = () => {
+        if (!checkPermission()) {
+            setError("無操作權限");
+            return;
+        }
         if (selectedItems.length !== 1) {
             setError("請選擇一個項目進行修改");
             return;
         }
-        
+
         navigate(`/inventory/inventory-update?id=${selectedItems[0]}`);
     };
     
@@ -350,6 +356,7 @@ const InventorySearch: React.FC = () => {
         <>
             <Header />
             <DynamicContainer content={content} />
+            {permissionModal}
         </>
     );
 };

--- a/client/src/pages/medical_record/MedicalRecord.tsx
+++ b/client/src/pages/medical_record/MedicalRecord.tsx
@@ -7,11 +7,12 @@ import ScrollableTable from "../../components/ScrollableTable";
 import { useMedicalRecordManagement, HealthRecordIndex } from "../../hooks/useMedicalRecord";
 import { formatMedicalHistory, formatMicroSurgery } from "../../utils/medicalUtils";
 import "./medicalRecord.css";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 const MedicalRecord: React.FC = () => {
     const navigate = useNavigate();
-    const { 
-        records, 
+    const {
+        records,
         searchValue, 
         setSearchValue, 
         selectedIds, 
@@ -36,11 +37,16 @@ const MedicalRecord: React.FC = () => {
             <th>備註</th>
         </tr>
     );
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
+
     // 新增處理修改按鈕點擊的函數
     const handleEdit = () => {
-        // 必須檢查是否只勾選了「一個」項目
-        if (selectedIds.length === 1) {
-            // 獲取勾選的第一個 ID (也是唯一一個)
+        if (!checkPermission()) {
+            return;
+        }
+      // 必須檢查是否只勾選了「一個」項目
+      if (selectedIds.length === 1) {
+          // 獲取勾選的第一個 ID (也是唯一一個)
             const idToEdit = selectedIds[0];
 
             // **最重要的部分**：
@@ -141,13 +147,16 @@ const MedicalRecord: React.FC = () => {
     );
 
     return (
-        <div className="d-flex flex-column min-vh-100 bg-white">
-            {/* 使用 Header 元件 */}
-            <Header />
-            
-            {/* 使用 DynamicContainer */}
-            <DynamicContainer content={content} className="p-4 align-items-start" />
-        </div>
+        <>
+            <div className="d-flex flex-column min-vh-100 bg-white">
+                {/* 使用 Header 元件 */}
+                <Header />
+
+                {/* 使用 DynamicContainer */}
+                <DynamicContainer content={content} className="p-4 align-items-start" />
+            </div>
+            {permissionModal}
+        </>
     );
 };
 

--- a/client/src/pages/member/MemberInfo.tsx
+++ b/client/src/pages/member/MemberInfo.tsx
@@ -10,11 +10,12 @@ import { formatGregorianBirthday, formatGender, calculateAge } from "../../utils
 import { useMemberManagement } from "../../hooks/useMemberManagement";
 import "./memberInfo.css";
 import { sortByStoreAndMemberCode } from "../../utils/storeMemberSort";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 const MemberInfo: React.FC = () => {
     const navigate = useNavigate();
-    const { 
-        members, 
+    const {
+        members,
         loading, // 假設您的 hook 返回 loading 狀態
         error,   // 假設您的 hook 返回 error 狀態
         keyword, 
@@ -36,6 +37,7 @@ const MemberInfo: React.FC = () => {
             ),
         [members]
     );
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
     // 定義表格標頭
     const tableHeader = (
         <tr>
@@ -94,6 +96,9 @@ const MemberInfo: React.FC = () => {
     
     // 新增：處理修改按鈕的點擊事件
     const handleEdit = () => {
+        if (!checkPermission()) {
+            return;
+        }
         // 再次確認是否剛好只選取了一項
         if (selectedMemberIds.length === 1) {
             const memberToEditId = selectedMemberIds[0];
@@ -185,10 +190,13 @@ const MemberInfo: React.FC = () => {
     );
     
     return (
-        <div className="d-flex flex-column min-vh-100 bg-light">
-            <Header /> 
-            <DynamicContainer content={content} />
-        </div>
+        <>
+            <div className="d-flex flex-column min-vh-100 bg-light">
+                <Header />
+                <DynamicContainer content={content} />
+            </div>
+            {permissionModal}
+        </>
     );
 };
 

--- a/client/src/pages/product/ProductSell.tsx
+++ b/client/src/pages/product/ProductSell.tsx
@@ -11,6 +11,7 @@ import { useProductSell } from "../../hooks/useProductSell";
 import { ProductSell as ProductSellType } from "../../services/ProductSellService"; // 匯入更新後的型別
 import { fetchAllBundles, Bundle } from "../../services/ProductBundleService";
 import { sortByStoreAndMemberCode } from "../../utils/storeMemberSort";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 const paymentMethodValueToDisplayMap: { [key: string]: string } = {
     Cash: "現金",
@@ -24,7 +25,7 @@ const paymentMethodValueToDisplayMap: { [key: string]: string } = {
 const ProductSell: React.FC = () => {
     const navigate = useNavigate();
     const [bundleMap, setBundleMap] = useState<Record<number, { name: string; contents: string }>>({});
-    const isTherapist = useMemo(() => localStorage.getItem('permission') === 'therapist', []);
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
     const {
         sales,
         selectedSales,
@@ -266,8 +267,7 @@ const ProductSell: React.FC = () => {
                             className="text-white px-4" // warning 配 text-dark 可能較好
                             disabled={loading || selectedSales.length !== 1}
                             onClick={() => {
-                                if (isTherapist) {
-                                    alert('無操作權限');
+                                if (!checkPermission()) {
                                     return;
                                 }
                                 if (selectedSales.length === 1) {
@@ -288,6 +288,7 @@ const ProductSell: React.FC = () => {
             {/* 修改頁面標題 */}
             <Header />
             <DynamicContainer content={content} />
+            {permissionModal}
         </>
     );
 };

--- a/client/src/pages/therapy/TherapyRecord.tsx
+++ b/client/src/pages/therapy/TherapyRecord.tsx
@@ -10,6 +10,7 @@ import { formatDate, truncateText, formatNumber } from "../../utils/therapyUtils
 import { getTherapyPackages, getStaffMembers, TherapyPackage, StaffMember } from "../../services/TherapyDropdownService";
 import { downloadBlob } from "../../utils/downloadBlob";
 import { exportTherapyRecords } from "../../services/TherapyService";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 const TherapyRecord: React.FC = () => {
     const navigate = useNavigate();
@@ -35,6 +36,7 @@ const TherapyRecord: React.FC = () => {
         handleCheckboxChange,
         handleSearch,
     } = useTherapyRecord();
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
 
     const handleExport = async () => {
         try {
@@ -288,11 +290,14 @@ const TherapyRecord: React.FC = () => {
                         <Button
                             variant="info"
                             className="text-white px-4"
-                            onClick={() =>
+                            onClick={() => {
+                                if (!checkPermission()) {
+                                    return;
+                                }
                                 navigate('/therapy-record/add-therapy-record', {
                                     state: { recordId: selectedIds[0] },
-                                })
-                            }
+                                });
+                            }}
                             disabled={loading || selectedIds.length !== 1}
                         >
                             修改
@@ -307,6 +312,7 @@ const TherapyRecord: React.FC = () => {
         <>
             <Header />
             <DynamicContainer content={content} />
+            {permissionModal}
         </>
     );
 };

--- a/client/src/pages/therapy/TherapySell.tsx
+++ b/client/src/pages/therapy/TherapySell.tsx
@@ -15,6 +15,7 @@ import { formatDateToYYYYMMDD } from "../../utils/dateUtils";
 import { formatCurrency } from "../../utils/productSellUtils"; // 借用金額格式化
 import { fetchAllTherapyBundles, TherapyBundle } from "../../services/TherapyBundleService";
 import { sortByStoreAndMemberCode } from "../../utils/storeMemberSort";
+import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 // 更新 interface 以符合 Figma 需求
 export interface TherapySellRow { // 更改 interface 名稱以避免與組件名衝突
@@ -70,7 +71,7 @@ const TherapySell: React.FC = () => {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [bundleMap, setBundleMap] = useState<Record<number, { name: string; contents: string }>>({});
-    const isTherapist = localStorage.getItem('permission') === 'therapist';
+    const { checkPermission, modal: permissionModal } = usePermissionGuard();
 
 
 
@@ -218,9 +219,8 @@ const TherapySell: React.FC = () => {
             alert("請先選擇要刪除的項目");
             return;
         }
-        if (isTherapist) {
+        if (!checkPermission()) {
             setError('無操作權限');
-            alert('無操作權限');
             return;
         }
         if (window.confirm(`確定要刪除選定的 ${selectedItems.length} 筆紀錄嗎？`)) {
@@ -240,7 +240,7 @@ const TherapySell: React.FC = () => {
                 const message = error.message || "刪除失敗，請重試";
                 setError(message);
                 if (message === '無操作權限') {
-                    alert('無操作權限');
+                    checkPermission();
                 }
             } finally {
                 setLoading(false);
@@ -379,9 +379,8 @@ const TherapySell: React.FC = () => {
                             variant="info"
                             className="text-white px-4"
                             onClick={() => {
-                                if (isTherapist) {
+                                if (!checkPermission()) {
                                     setError('無操作權限');
-                                    alert('無操作權限');
                                     return;
                                 }
                                 if (selectedItems.length === 1) {
@@ -404,6 +403,7 @@ const TherapySell: React.FC = () => {
         <>
             <Header />
             <DynamicContainer content={content} />
+            {permissionModal}
         </>
     );
 };


### PR DESCRIPTION
## Summary
- add a shared NoPermissionModal component and permission guard hook to centralize "無操作權限" messaging
- block therapists from entering edit flows across member, medical, therapy, inventory, product, and finance pages by triggering the modal

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da87ca588483298d14f2b2c27ac6b3