### PR TITLE
Make member summary header optional for add product sell page

### DIFF
--- a/client/src/components/MemberSummaryCard.tsx
+++ b/client/src/components/MemberSummaryCard.tsx
@@ -7,6 +7,7 @@ interface MemberSummaryCardProps {
   memberCode?: string;
   fallbackName?: string;
   className?: string;
+  hideHeader?: boolean;
 }
 
 const displayOrDash = (value?: string | null) => {
@@ -22,6 +23,7 @@ const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({
   memberCode,
   fallbackName,
   className,
+  hideHeader = false,
 }) => {
   const name = displayOrDash(member?.name ?? fallbackName);
   const identity = displayOrDash(member?.identity_type ?? undefined);
@@ -30,7 +32,9 @@ const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({
 
   return (
     <Card className={className}>
-      <Card.Header className="bg-light fw-semibold">會員基本資料</Card.Header>
+      {!hideHeader && (
+        <Card.Header className="bg-light fw-semibold">會員基本資料</Card.Header>
+      )}
       <Card.Body>
         <div className="mb-3">
           <div className="text-muted small">姓名</div>

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -493,6 +493,7 @@ const AddProductSell: React.FC = () => {
               memberCode={memberCode}
               fallbackName={memberName}
               className="mb-3 shadow-sm"
+              hideHeader
             />
             <Form.Group className="mb-3">
               <Form.Label>購買日期</Form.Label>


### PR DESCRIPTION
## Summary
- allow hiding the MemberSummaryCard header via a new optional prop
- hide the header on the add product sell page to remove the extra section title

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db63e13b7083299ba20bf113c18ec8