### PR TITLE
Remove member summary card from add product sell page

### DIFF
--- a/client/src/components/MemberSummaryCard.tsx
+++ b/client/src/components/MemberSummaryCard.tsx
@@ -7,6 +7,7 @@ interface MemberSummaryCardProps {
   memberCode?: string;
   fallbackName?: string;
   className?: string;
+  hideHeader?: boolean;
 }
 
 const displayOrDash = (value?: string | null) => {
@@ -22,6 +23,7 @@ const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({
   memberCode,
   fallbackName,
   className,
+  hideHeader = false,
 }) => {
   const name = displayOrDash(member?.name ?? fallbackName);
   const identity = displayOrDash(member?.identity_type ?? undefined);
@@ -30,7 +32,9 @@ const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({
 
   return (
     <Card className={className}>
-      <Card.Header className="bg-light fw-semibold">會員基本資料</Card.Header>
+      {!hideHeader && (
+        <Card.Header className="bg-light fw-semibold">會員基本資料</Card.Header>
+      )}
       <Card.Body>
         <div className="mb-3">
           <div className="text-muted small">姓名</div>

--- a/client/src/pages/product/AddProductSell.tsx
+++ b/client/src/pages/product/AddProductSell.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import Header from "../../components/Header";
 import DynamicContainer from "../../components/DynamicContainer";
 import MemberColumn from "../../components/MemberColumn";
-import MemberSummaryCard from "../../components/MemberSummaryCard";
 import { MemberData } from "../../types/medicalTypes";
 import { addProductSell, ProductSellData, getProductSellById, updateProductSell, ProductSell } from "../../services/ProductSellService";
 import { getStoreId } from "../../services/LoginService";
@@ -488,12 +487,6 @@ const AddProductSell: React.FC = () => {
 
           {/* --- Right Column --- */}
           <Col md={6}>
-            <MemberSummaryCard
-              member={selectedMember}
-              memberCode={memberCode}
-              fallbackName={memberName}
-              className="mb-3 shadow-sm"
-            />
             <Form.Group className="mb-3">
               <Form.Label>購買日期</Form.Label>
               <Form.Control type="date" lang="en-CA" value={purchaseDate} max={new Date().toISOString().split("T")[0]} onChange={(e) => setPurchaseDate(e.target.value)} required />


### PR DESCRIPTION
## Summary
- remove the member summary card from the add product sell page so the entire panel is hidden

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db63e13b7083299ba20bf113c18ec8