### PR TITLE
Remove page margins on printed sales orders

### DIFF
--- a/client/src/pages/finance/AddSalesOrder.tsx
+++ b/client/src/pages/finance/AddSalesOrder.tsx
@@ -53,6 +53,13 @@ const AddSalesOrder: React.FC = () => {
     const [totalDiscount, setTotalDiscount] = useState(0); // 總折價
     const [grandTotal, setGrandTotal] = useState(0);
 
+    const selectedMemberName = memberId
+        ? members.find(member => String(member.Member_ID) === String(memberId))?.Name || ''
+        : '';
+    const selectedStaffName = staffId
+        ? staffMembers.find(staff => String(staff.staff_id) === String(staffId))?.name || ''
+        : '';
+
     // 動態更新項目
     const handleItemChange = (index: number, field: keyof SalesOrderItemData, value: string | number) => {
         const newItems = [...items];
@@ -263,9 +270,121 @@ const AddSalesOrder: React.FC = () => {
     const handlePrint = () => {
         window.print();
     };
-    
-    // --- JSX 部分 ---
-    const content = (
+
+    const formatNumber = (value: number | string | undefined | null) => {
+        if (value === undefined || value === null || value === '') {
+            return '';
+        }
+        const numeric = typeof value === 'number' ? value : Number(value);
+        if (Number.isNaN(numeric)) {
+            return '';
+        }
+        return numeric.toLocaleString();
+    };
+
+    const printableItems = items.filter(item =>
+        item.item_description ||
+        item.item_code ||
+        item.unit ||
+        item.unit_price ||
+        item.quantity ||
+        item.subtotal ||
+        item.category ||
+        item.note
+    );
+
+    const renderPrintableCard = (copyLabel: string) => (
+        <Card className="print-card">
+            <Card.Header className="text-center">
+                <h4>全崴國際無限充能館</h4>
+                <h3>銷售單</h3>
+                <div className="text-end copy-label">{copyLabel}</div>
+            </Card.Header>
+            <Card.Body>
+                <Row className="mb-3">
+                    <Col md={3} sm={6} className="mb-2">
+                        <div><strong>銷售單號：</strong>{orderNumber}</div>
+                    </Col>
+                    <Col md={3} sm={6} className="mb-2">
+                        <div><strong>銷售單位：</strong>{saleUnit}</div>
+                    </Col>
+                    <Col md={3} sm={6} className="mb-2">
+                        <div><strong>銷售類別：</strong>{saleCategory}</div>
+                    </Col>
+                    <Col md={3} sm={6} className="mb-2">
+                        <div><strong>銷售日期：</strong>{orderDate}</div>
+                    </Col>
+                </Row>
+
+                <div className="table-responsive">
+                    <table className="table table-bordered print-table">
+                        <thead>
+                            <tr>
+                                <th>序號</th>
+                                <th>編號</th>
+                                <th style={{ minWidth: '400px' }}>產品名稱/規格型號</th>
+                                <th>單位</th>
+                                <th>單價</th>
+                                <th>數量</th>
+                                <th>小計</th>
+                                <th>分類</th>
+                                <th>備註</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {printableItems.length > 0 ? (
+                                printableItems.map((item, index) => (
+                                    <tr key={`print-${index}`}>
+                                        <td>{index + 1}</td>
+                                        <td>{item.item_code || ''}</td>
+                                        <td style={{ minWidth: '300px' }}>{item.item_description || ''}</td>
+                                        <td>{item.unit || ''}</td>
+                                        <td>{formatNumber(item.unit_price)}</td>
+                                        <td>{formatNumber(item.quantity)}</td>
+                                        <td>{formatNumber(item.subtotal)}</td>
+                                        <td>{item.category || ''}</td>
+                                        <td>{item.note || ''}</td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan={9} className="text-center">無品項資料</td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="print-summary-row mt-3">
+                    <div className="summary-field">
+                        <strong>金額(大寫)：</strong>
+                    </div>
+                    <div className="summary-field">
+                        <strong>購買人：</strong>{selectedMemberName}
+                    </div>
+                    <div className="summary-field">
+                        <strong>金額(小寫)：</strong>{formatNumber(grandTotal)}
+                    </div>
+                    <div className="summary-field">
+                        <strong>銷售人：</strong>{selectedStaffName}
+                    </div>
+                </div>
+                {note && (
+                    <Row className="mt-2">
+                        <Col>
+                            <div><strong>備註：</strong>{note}</div>
+                        </Col>
+                    </Row>
+                )}
+            </Card.Body>
+            <Card.Footer className="d-flex justify-content-between print-footer">
+                <div>使用者簽名：____________________</div>
+                <div>門市簽收：____________________</div>
+            </Card.Footer>
+        </Card>
+    );
+
+    const interactiveContent = (
         <Container className="p-4">
             <Card>
                 <Card.Header className="text-center">
@@ -280,7 +399,7 @@ const AddSalesOrder: React.FC = () => {
                         <Col md={3}><Form.Group><Form.Label>銷售類別</Form.Label><Form.Control value={saleCategory} onChange={e => setSaleCategory(e.target.value)}/></Form.Group></Col>
                         <Col md={3}><Form.Group><Form.Label>銷售日期</Form.Label><Form.Control type="date" value={orderDate} onChange={e => setOrderDate(e.target.value)}/></Form.Group></Col>
                     </Row>
-                    
+
                     {/* 表格化項目輸入 */}
                     <div className="table-responsive">
                         <table className="table table-bordered print-table">
@@ -314,8 +433,8 @@ const AddSalesOrder: React.FC = () => {
                                         <td><Form.Control type="number" size="sm" value={item.unit_price || ""} onChange={e => handleItemChange(index, 'unit_price', Number(e.target.value))} /></td>
                                         <td><Form.Control type="number" size="sm" value={item.quantity || ""} onChange={e => handleItemChange(index, 'quantity', Number(e.target.value))} /></td>
                                         <td><Form.Control size="sm" value={item.subtotal || ""} readOnly disabled /></td>
-                                        <td><Form.Control size="sm" /></td>
-                                        <td><Form.Control size="sm" /></td>
+                                        <td><Form.Control size="sm" value={item.category || ""} onChange={e => handleItemChange(index, 'category', e.target.value)} /></td>
+                                        <td><Form.Control size="sm" value={item.note || ""} onChange={e => handleItemChange(index, 'note', e.target.value)} /></td>
                                         <td className="no-print"><Button variant="outline-danger" size="sm" onClick={() => removeItem(index)}>X</Button></td>
                                     </tr>
                                 ))}
@@ -347,6 +466,23 @@ const AddSalesOrder: React.FC = () => {
                 </Card.Footer>
             </Card>
         </Container>
+    );
+
+    const printableContent = (
+        <Container fluid className="print-landscape">
+            <div className="print-duplicate">
+                {renderPrintableCard('顧客聯')}
+                {renderPrintableCard('門市聯')}
+            </div>
+        </Container>
+    );
+
+    // --- JSX 部分 ---
+    const content = (
+        <>
+            <div className="screen-only">{interactiveContent}</div>
+            <div className="print-only">{printableContent}</div>
+        </>
     );
 
     return (

--- a/client/src/pages/finance/printStyles.css
+++ b/client/src/pages/finance/printStyles.css
@@ -1,4 +1,49 @@
+.screen-only {
+  display: block;
+}
+
+.print-only {
+  display: none;
+  width: 100%;
+}
+
+.copy-label {
+  font-weight: 600;
+}
+
+.print-footer {
+  font-size: 0.9rem;
+}
+
+.print-summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.print-summary-row .summary-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.print-duplicate {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+}
+
+.print-landscape {
+  width: 100%;
+}
+
 @media print {
+  body {
+    margin: 0 !important;
+  }
+
   /* Ensure table uses full width and wraps text */
   .print-table {
     width: 100%;
@@ -14,5 +59,111 @@
   .print-table th:nth-child(3),
   .print-table td:nth-child(3) {
     width: 25%;
+  }
+
+  .screen-only {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+
+  @page {
+    size: A4 landscape;
+    margin: 0;
+  }
+
+  .print-only .container,
+  .print-container .container {
+    max-width: none !important;
+    width: 100% !important;
+    padding: 0 !important;
+  }
+
+  .print-landscape {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 100%;
+    width: 100vw;
+    padding: 0 6mm;
+    gap: 6mm;
+  }
+
+  .print-duplicate {
+    flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 6mm;
+  }
+
+  .print-card {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    max-width: none;
+    width: 100%;
+    page-break-inside: avoid;
+    break-inside: avoid;
+    margin: 0 !important;
+    border: 1px solid #000 !important;
+    box-shadow: none !important;
+    font-size: 10px;
+  }
+
+  .print-card h3,
+  .print-card h4 {
+    margin-bottom: 2px;
+    font-size: 14px;
+  }
+
+  .print-card .card-header,
+  .print-card .card-body,
+  .print-card .card-footer {
+    padding: 6px 10px !important;
+  }
+
+  .print-card .card-body {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .print-card .table-responsive {
+    flex: 1 1 auto;
+  }
+
+  .print-card .table {
+    font-size: 9px;
+    margin-bottom: 6px;
+  }
+
+  .print-card .table th,
+  .print-card .table td {
+    padding: 2px !important;
+  }
+
+  .print-card + .print-card {
+    margin-top: 0 !important;
+  }
+
+  .print-footer {
+    border-top: 1px solid #000;
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .print-card .print-summary-row {
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .print-card .print-summary-row .summary-field {
+    flex: 0 1 auto;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Summary
- set the printable sales order page margin to zero so both copies can use the full sheet width

## Testing
- npm run build *(fails: Rollup cannot resolve entry module "index.html" in the existing project setup)*

------
https://chatgpt.com/codex/tasks/task_e_68da6bc7d4d88329bdab761840369833