### PR TITLE
Add identity-specific pricing schema and seed data

### DIFF
--- a/docs/membership_pricing_design.md
+++ b/docs/membership_pricing_design.md
@@ -1,0 +1,85 @@
+# 會員身分別售價功能設計說明
+
+## 1. 背景與目標
+客戶希望針對不同身份別（直營店、加盟店、合夥商、推廣商 / 分店能量師、B2B合作專案、心耀商、會員、一般售價等）提供對應的產品、療程、產品組合與療程組合售價，同時保留目前 `product`、`therapy` 等主資料表的架構。新功能需支援：
+
+- 為不同身份別定義獨立的售價、品號與顯示名稱。
+- 對應多種可銷售項目：單一產品、療程、產品組合、療程組合。
+- 可限制價目表僅在特定門市生效，或設定生效區間與優先順序。
+- 系統在銷售時依據會員身份別、門市與目前日期自動挑選正確售價，若找不到對應價目則使用原始基礎定價作為保底。
+
+## 2. 資料模型調整
+
+### 2.1 新增與調整的表格
+| 表格 | 說明 |
+| --- | --- |
+| `member_identity_type` | 身分類別主檔。使用英數 `identity_type_code` 作為主鍵，提供中文顯示名稱、優先順序、是否為預設值等欄位。`member.identity_type` 由原本 ENUM 改為外鍵參照此表。 |
+| `member_price_book` | 以身份別為主的價目表。定義價目表名稱、適用身份別、作用範圍（商品 / 療程 / 組合 / 全部）、狀態、優先順序、生效起訖日等。 |
+| `member_price_book_store` | 價目表與門市的關聯表，用來限制價目表僅在指定門市啟用。若無資料代表全門市適用。 |
+| `member_price_book_item` | 單一價目條目。記錄對應項目（產品、療程、產品組合、療程組合）、售價、自訂品號/名稱、可選的數量區間與 JSON 格式的額外屬性（例如包裝數量）。 |
+| `vw_member_product_prices`、`vw_member_therapy_prices` | 方便查詢的檢視表，將價目表資訊與原始產品 / 療程主檔整合。 |
+
+### 2.2 主要欄位說明
+- `member.identity_type`：改為 `varchar(32)`，預設值 `GENERAL_MEMBER`，並加上外鍵 `fk_member_identity_type`。
+- `member_price_book.scope_type`：用來標示價目表適用的類型。若為 `ALL` 也可以混合放入不同 `item_type` 的條目。
+- `member_price_book.priority`：同一身份別允許建立多個價目表時，系統會從數值最小者開始判斷是否符合（支援未來區域性活動或限時促銷）。
+- `member_price_book_item.custom_code` / `custom_name`：儲存 Excel 中客戶提供的身份別專用品號與名稱。若為 `NULL` 則沿用原始項目名稱。
+- `member_price_book_item.metadata`：保留包裝規格（例如「24盒裝 / 單盒價」）、促銷備註等彈性資訊，方便 API 直接回傳。
+- `CHECK` 約束確保價格為非負、數量區間正確；外鍵確保資料一致性。
+
+## 3. 資料載入與遷移建議
+1. **建置身份別主檔**：於 `mysql-init-scripts/02_data.sql` 中加入所有身份別初始資料，可再視需求調整 `priority` 與 `is_default`。
+2. **建置價目表**：先為每一身份別及品項類型建立至少一個 `member_price_book`。若 Excel 提供多個時段或區域價目，可拆分為多個價目表並設定 `valid_from` / `valid_to` 及 `member_price_book_store`。
+3. **匯入價目條目**：撰寫匯入腳本（建議使用 Python + Pandas）將 `會員別售價.xlsx` 逐一轉換為 `member_price_book_item`。重點對映如下：
+   - Excel 身份別 → `member_price_book.identity_type`
+   - 產品 / 療程 / 組合代碼 → 先以既有 `product`、`therapy`、`product_bundles`、`therapy_bundles` 主檔查找 `id`
+   - 身份別專屬品號 / 名稱 → 對應至 `custom_code`、`custom_name`
+   - 售價 → 填入 `price`
+   - 若 Excel 內區分「單盒價 / 三盒 / 六盒」，可利用 `metadata` JSON 或設定多筆條目與不同 `custom_code`
+4. **維運流程**：
+   - 新增或調整價目時，先建立新的 `member_price_book`（可先維持 `DRAFT` 狀態），填入條目後再切換為 `ACTIVE`。
+   - 若需要暫停使用，可將 `status` 改為 `INACTIVE` 或設定 `valid_to`。
+   - 若需多層 fallback，可利用 `priority` 與 `valid_from/valid_to` 控制。
+
+## 4. 價格決策流程
+以下為銷售流程查價時的建議邏輯：
+
+```sql
+SELECT mpi.*
+FROM member_price_book mpb
+JOIN member_price_book_item mpi ON mpb.price_book_id = mpi.price_book_id
+LEFT JOIN member_price_book_store mpbs ON mpb.price_book_id = mpbs.price_book_id
+WHERE mpb.identity_type = :member_identity
+  AND mpi.item_type = :item_type
+  AND mpi.item_id = :item_id
+  AND mpb.status = 'ACTIVE'
+  AND mpi.status = 'ACTIVE'
+  AND (mpb.valid_from IS NULL OR mpb.valid_from <= CURRENT_DATE)
+  AND (mpb.valid_to IS NULL OR mpb.valid_to >= CURRENT_DATE)
+  AND (mpbs.store_id IS NULL OR mpbs.store_id = :store_id)
+ORDER BY mpb.priority ASC, mpi.min_quantity DESC
+LIMIT 1;
+```
+
+若查無資料則回退至原始 `product.price` / `therapy.price` / `product_bundles.selling_price` 等欄位。
+
+## 5. API / 後台介面調整建議
+- **後台管理頁面**：
+  - 新增「身份別管理」頁簽，用於維護 `member_identity_type`（名稱、說明、優先序、是否啟用）。
+  - 新增「價目表管理」頁面，支援建立 / 編輯價目表、分配門市、匯入 Excel（CSV）檔案產生條目、查詢價目歷史。
+  - 在產品 / 療程 / 組合編輯頁面顯示已綁定的身份別售價清單，方便快速定位。
+- **銷售流程**：於 `product_sell`、`therapy_sell` API 取品項時，根據會員身份別與門市套用上述查價邏輯，並回傳 `custom_code`、`custom_name` 供前端顯示或列印收據。
+- **批量匯入工具**：提供指令列或後台上傳 Excel 功能，將客戶更新的價目表匯入至 `member_price_book_item`，並自動調整生效日期。
+
+## 6. 未來擴充方向
+- **版本控管 / 稽核**：可新增 `member_price_book_audit` 或利用事件表紀錄異動人員與時間。
+- **通路折扣規則**：若未來需要依購買數量或促銷活動套用折扣，可擴充 `metadata` 或新增 `member_price_rule` 表格儲存公式。
+- **與庫存 / 採購整合**：`custom_code` 可作為門市對外發票或採購單上的品號，確保報表與帳務一致。
+
+## 7. 範例資料
+`mysql-init-scripts/02_data.sql` 已新增示範：
+- 身份別主檔資料。
+- 「直營店 / 會員」產品與療程的價目表、門市限制及部分品項售價。
+- 可透過 `vw_member_product_prices`、`vw_member_therapy_prices` 立即檢視結果，作為串接 API 或撰寫查詢的範例。
+
+此設計可在不破壞既有產品 / 療程資料結構的情況下，支援客戶提出的身份別售價需求，並保留擴充空間以因應後續的促銷與版本管理需求。

--- a/mysql-init-scripts/01_schema.sql
+++ b/mysql-init-scripts/01_schema.sql
@@ -15,6 +15,9 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
+DROP VIEW IF EXISTS `vw_member_product_prices`;
+DROP VIEW IF EXISTS `vw_member_therapy_prices`;
+
 --
 -- Table structure for table `emergency_contact`
 --
@@ -317,13 +320,30 @@ CREATE TABLE `medical_record` (
 --
 
 DROP TABLE IF EXISTS `member`;
+DROP TABLE IF EXISTS `member_identity_type`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `member_identity_type` (
+  `identity_type_code` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `display_name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` text COLLATE utf8mb4_unicode_ci,
+  `priority` int NOT NULL DEFAULT '100' COMMENT '數字越小代表優先權越高',
+  `is_default` tinyint(1) NOT NULL DEFAULT '0' COMMENT '是否為預設身分類別',
+  `is_system` tinyint(1) NOT NULL DEFAULT '0' COMMENT '是否為系統保留類型，避免被刪除',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`identity_type_code`),
+  UNIQUE KEY `uniq_member_identity_display_name` (`display_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `member` (
   `member_id` int NOT NULL AUTO_INCREMENT,
   `member_code` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `identity_type` enum('直營店','加盟店','合夥商','推廣商(分店能量師)','B2B合作專案','心耀商','會員','一般會員') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '一般會員' COMMENT '會員身份別',
+  `identity_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'GENERAL_MEMBER' COMMENT '對應到 member_identity_type.identity_type_code',
   `birthday` date DEFAULT NULL,
   `gender` enum('Male','Female','Other') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `blood_type` enum('A','B','AB','O') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -337,6 +357,8 @@ CREATE TABLE `member` (
   PRIMARY KEY (`member_id`),
   KEY `inferrer_id` (`inferrer_id`),
   KEY `fk_member_store` (`store_id`),
+  KEY `identity_type` (`identity_type`),
+  CONSTRAINT `fk_member_identity_type` FOREIGN KEY (`identity_type`) REFERENCES `member_identity_type` (`identity_type_code`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `fk_member_store` FOREIGN KEY (`store_id`) REFERENCES `store` (`store_id`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `member_ibfk_1` FOREIGN KEY (`inferrer_id`) REFERENCES `member` (`member_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=556 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -420,6 +442,146 @@ CREATE TABLE `product_bundles` (
   UNIQUE KEY `bundle_code` (`bundle_code`)
 ) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `member_price_book`
+--
+
+DROP TABLE IF EXISTS `member_price_book`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `member_price_book` (
+  `price_book_id` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '價目表名稱',
+  `identity_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '對應 member_identity_type.identity_type_code',
+  `scope_type` enum('ALL','PRODUCT','THERAPY','PRODUCT_BUNDLE','THERAPY_BUNDLE') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ALL' COMMENT '價目表的適用項目範圍',
+  `status` enum('DRAFT','ACTIVE','INACTIVE') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'DRAFT',
+  `priority` int NOT NULL DEFAULT '100' COMMENT '處理價目表時的優先順序，數字越小優先度越高',
+  `valid_from` date DEFAULT NULL,
+  `valid_to` date DEFAULT NULL,
+  `note` text COLLATE utf8mb4_unicode_ci,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`price_book_id`),
+  KEY `idx_member_price_book_identity` (`identity_type`),
+  KEY `idx_member_price_book_status` (`status`),
+  CONSTRAINT `fk_member_price_book_identity` FOREIGN KEY (`identity_type`) REFERENCES `member_identity_type` (`identity_type_code`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `chk_member_price_book_validity` CHECK (`valid_to` IS NULL OR `valid_from` IS NULL OR `valid_to` >= `valid_from`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `member_price_book_store`
+--
+
+DROP TABLE IF EXISTS `member_price_book_store`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `member_price_book_store` (
+  `price_book_id` int NOT NULL,
+  `store_id` int NOT NULL,
+  PRIMARY KEY (`price_book_id`,`store_id`),
+  KEY `idx_member_price_book_store_store` (`store_id`),
+  CONSTRAINT `fk_member_price_book_store_price_book` FOREIGN KEY (`price_book_id`) REFERENCES `member_price_book` (`price_book_id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_member_price_book_store_store` FOREIGN KEY (`store_id`) REFERENCES `store` (`store_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `member_price_book_item`
+--
+
+DROP TABLE IF EXISTS `member_price_book_item`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `member_price_book_item` (
+  `price_book_item_id` int NOT NULL AUTO_INCREMENT,
+  `price_book_id` int NOT NULL,
+  `item_type` enum('PRODUCT','THERAPY','PRODUCT_BUNDLE','THERAPY_BUNDLE') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `item_id` int NOT NULL,
+  `price` decimal(12,2) NOT NULL,
+  `currency` char(3) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'TWD',
+  `min_quantity` int NOT NULL DEFAULT '1' COMMENT '價格適用的最低購買數量',
+  `max_quantity` int DEFAULT NULL COMMENT '價格適用的最高購買數量，NULL 代表無上限',
+  `custom_code` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '針對特定身分顯示的自訂品號',
+  `custom_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT '針對特定身分顯示的自訂名稱',
+  `metadata` json DEFAULT NULL COMMENT '額外資訊，例如包裝數量、促銷備註等',
+  `status` enum('ACTIVE','INACTIVE') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ACTIVE',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`price_book_item_id`),
+  UNIQUE KEY `uniq_member_price_book_item` (`price_book_id`,`item_type`,`item_id`,`min_quantity`),
+  UNIQUE KEY `uniq_member_price_book_custom_code` (`price_book_id`,`custom_code`),
+  KEY `idx_member_price_book_item_status` (`status`),
+  CONSTRAINT `chk_member_price_book_item_price_non_negative` CHECK (`price` >= 0),
+  CONSTRAINT `chk_member_price_book_item_quantity_range` CHECK (`max_quantity` IS NULL OR `max_quantity` >= `min_quantity`),
+  CONSTRAINT `fk_member_price_book_item_price_book` FOREIGN KEY (`price_book_id`) REFERENCES `member_price_book` (`price_book_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- View structure for view `vw_member_product_prices`
+--
+
+DROP VIEW IF EXISTS `vw_member_product_prices`;
+CREATE VIEW `vw_member_product_prices` AS
+SELECT
+    p.product_id AS product_id,
+    p.code AS base_product_code,
+    p.name AS base_product_name,
+    mpb.price_book_id,
+    mpb.name AS price_book_name,
+    mpb.identity_type,
+    mit.display_name AS identity_display_name,
+    mpb.priority,
+    mpb.status,
+    mpb.valid_from,
+    mpb.valid_to,
+    mpi.price_book_item_id,
+    mpi.price,
+    mpi.currency,
+    mpi.min_quantity,
+    mpi.max_quantity,
+    mpi.custom_code,
+    COALESCE(mpi.custom_name, p.name) AS custom_name,
+    mpi.metadata,
+    mpi.status AS item_status
+FROM member_price_book mpb
+JOIN member_identity_type mit ON mpb.identity_type = mit.identity_type_code
+JOIN member_price_book_item mpi ON mpb.price_book_id = mpi.price_book_id AND mpi.item_type = 'PRODUCT'
+JOIN product p ON mpi.item_id = p.product_id;
+
+--
+-- View structure for view `vw_member_therapy_prices`
+--
+
+DROP VIEW IF EXISTS `vw_member_therapy_prices`;
+CREATE VIEW `vw_member_therapy_prices` AS
+SELECT
+    t.therapy_id AS therapy_id,
+    t.code AS base_therapy_code,
+    t.name AS base_therapy_name,
+    mpb.price_book_id,
+    mpb.name AS price_book_name,
+    mpb.identity_type,
+    mit.display_name AS identity_display_name,
+    mpb.priority,
+    mpb.status,
+    mpb.valid_from,
+    mpb.valid_to,
+    mpi.price_book_item_id,
+    mpi.price,
+    mpi.currency,
+    mpi.min_quantity,
+    mpi.max_quantity,
+    mpi.custom_code,
+    COALESCE(mpi.custom_name, t.name) AS custom_name,
+    mpi.metadata,
+    mpi.status AS item_status
+FROM member_price_book mpb
+JOIN member_identity_type mit ON mpb.identity_type = mit.identity_type_code
+JOIN member_price_book_item mpi ON mpb.price_book_id = mpi.price_book_id AND mpi.item_type = 'THERAPY'
+JOIN therapy t ON mpi.item_id = t.therapy_id;
 
 --
 -- Table structure for table `therapy_bundle_items`

--- a/mysql-init-scripts/02_data.sql
+++ b/mysql-init-scripts/02_data.sql
@@ -2,6 +2,17 @@ SET NAMES 'utf8mb4';
 SET CHARACTER SET utf8mb4;
 
 
+INSERT INTO `member_identity_type` (`identity_type_code`, `display_name`, `description`, `priority`, `is_default`, `is_system`) VALUES
+('DIRECT_STORE', '直營店', '直營店自有通路的專用價目', 10, 0, 1),
+('FRANCHISE', '加盟店', '加盟門市的採購與銷售價', 20, 0, 1),
+('PARTNER', '合夥商', '合夥商的專屬價目與促銷', 30, 0, 1),
+('PROMOTER', '推廣商(分店能量師)', '推廣商或分店能量師使用', 40, 0, 1),
+('B2B_PROJECT', 'B2B合作專案', '企業與大型合作專案的價格', 50, 0, 1),
+('XIN_YAO_MERCHANT', '心耀商', '心耀商渠道的報價', 60, 0, 1),
+('MEMBER', '會員', '正式註冊會員的優惠價', 70, 0, 1),
+('GENERAL_MEMBER', '一般會員', '預設的一般會員身份', 80, 1, 1),
+('GENERAL_RETAIL', '一般售價', '對外一般零售價', 90, 0, 0);
+
 INSERT INTO `store` (`account`, `store_name`, `store_location`, `password`, `permission`) VALUES
 ('taipei', '總店', '台北市信義區松高路11號', 'taipei2025', 'admin'),
 ('taichung', '台中門市', '台中市西區公益路68號', 'taichung2025', 'basic'),
@@ -55,6 +66,22 @@ INSERT INTO `product` (`code`, `name`, `price`, `purchase_price`, `status`) VALU
 ('HRB001', '舒壓茶包', 380.00, 210.00, 'PUBLISHED'),
 ('HRB002', '薰衣草精油', 550.00, 330.00, 'PUBLISHED');
 
+INSERT INTO `member_price_book` (`name`, `identity_type`, `scope_type`, `status`, `priority`, `valid_from`, `note`) VALUES
+('直營店商品價目表', 'DIRECT_STORE', 'PRODUCT', 'ACTIVE', 10, '2024-01-01', '依客戶提供的直營店價目建立'),
+('會員商品價目表', 'MEMBER', 'PRODUCT', 'ACTIVE', 70, '2024-01-01', '註冊會員購買時使用'),
+('直營店療程價目表', 'DIRECT_STORE', 'THERAPY', 'ACTIVE', 10, '2024-01-01', '直營店適用療程售價'),
+('會員療程價目表', 'MEMBER', 'THERAPY', 'ACTIVE', 70, '2024-01-01', '會員適用療程售價');
+
+INSERT INTO `member_price_book_store` (`price_book_id`, `store_id`)
+SELECT price_book_id, 1 FROM `member_price_book` WHERE `name` IN ('直營店商品價目表', '直營店療程價目表');
+
+INSERT INTO `member_price_book_item` (`price_book_id`, `item_type`, `item_id`, `price`, `custom_code`, `custom_name`, `metadata`)
+VALUES
+((SELECT price_book_id FROM member_price_book WHERE name='直營店商品價目表'), 'PRODUCT', (SELECT product_id FROM product WHERE code='SKN001'), 520.00, 'PSA1000', '保濕面膜-直營通路', '{"package":"單入"}'),
+((SELECT price_book_id FROM member_price_book WHERE name='直營店商品價目表'), 'PRODUCT', (SELECT product_id FROM product WHERE code='SUP001'), 1350.00, 'PSA2000', '膠原蛋白粉-直營通路', '{"package":"大罐"}'),
+((SELECT price_book_id FROM member_price_book WHERE name='會員商品價目表'), 'PRODUCT', (SELECT product_id FROM product WHERE code='SKN001'), 560.00, 'PSA1008', '保濕面膜-會員價', '{"package":"單入"}'),
+((SELECT price_book_id FROM member_price_book WHERE name='會員商品價目表'), 'PRODUCT', (SELECT product_id FROM product WHERE code='SUP001'), 1450.00, 'PSA2008', '膠原蛋白粉-會員價', '{"package":"大罐"}');
+
 INSERT INTO `therapy` (`code`, `name`, `price`, `content`, `status`) VALUES
 ('TH001', '全身放鬆按摩', 2800.00, '60分鐘全身按摩，幫助放鬆肌肉，改善血液循環', 'PUBLISHED'),
 ('TH002', '足部反射按摩', 1800.00, '40分鐘足部按摩，刺激穴位，促進身體機能', 'PUBLISHED'),
@@ -66,6 +93,13 @@ INSERT INTO `therapy` (`code`, `name`, `price`, `content`, `status`) VALUES
 ('TH008', '腿部舒緩療程', 1600.00, '35分鐘腿部按摩，改善水腫及疲勞', 'PUBLISHED'),
 ('TH009', '背部深層療程', 2200.00, '45分鐘背部深層按摩，緩解背部緊繃及疼痛', 'PUBLISHED'),
 ('TH010', '身體去角質護理', 2000.00, '40分鐘身體去角質，滋潤肌膚', 'PUBLISHED');
+
+INSERT INTO `member_price_book_item` (`price_book_id`, `item_type`, `item_id`, `price`, `custom_code`, `custom_name`, `metadata`)
+VALUES
+((SELECT price_book_id FROM member_price_book WHERE name='直營店療程價目表'), 'THERAPY', (SELECT therapy_id FROM therapy WHERE code='TH001'), 2600.00, 'TH001-D', '全身放鬆按摩-直營店', '{"duration":"60分鐘"}'),
+((SELECT price_book_id FROM member_price_book WHERE name='直營店療程價目表'), 'THERAPY', (SELECT therapy_id FROM therapy WHERE code='TH004'), 2400.00, 'TH004-D', '臉部護理療程-直營店', '{"duration":"50分鐘"}'),
+((SELECT price_book_id FROM member_price_book WHERE name='會員療程價目表'), 'THERAPY', (SELECT therapy_id FROM therapy WHERE code='TH001'), 2700.00, 'TH001-M', '全身放鬆按摩-會員價', '{"duration":"60分鐘"}'),
+((SELECT price_book_id FROM member_price_book WHERE name='會員療程價目表'), 'THERAPY', (SELECT therapy_id FROM therapy WHERE code='TH004'), 2550.00, 'TH004-M', '臉部護理療程-會員價', '{"duration":"50分鐘"}');
 
 INSERT INTO `family_information` (`name`, `relationship`, `age`, `company`, `occupation`, `phone`) VALUES
 ('王大明', '父親', 58, '台北科技公司', '工程師', '0933123456'),


### PR DESCRIPTION
## Summary
- add a member_identity_type lookup table and pricing book tables/views so items can have identity-specific prices, codes, and names
- seed initial identity types plus sample product and therapy price books tied to direct stores and members
- document the proposed membership pricing design and rollout steps for the new data model

## Testing
- not run (SQL/schema changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e4a92c31308329ad4dee93480ca272