### PR TITLE
Fix product and bundle price tier queries

### DIFF
--- a/server/app/models/product_bundle_model.py
+++ b/server/app/models/product_bundle_model.py
@@ -68,7 +68,11 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
                 LEFT JOIN
                     category c ON pbc.category_id = c.category_id
                 LEFT JOIN
-                    product_bundle_price_tier pbpt ON pb.bundle_id = pbpt.bundle_id
+                    product_bundle_price_tier pbpt ON (
+                        pb.bundle_id = pbpt.bundle_id
+                        AND pbpt.identity_type IS NOT NULL
+                        AND pbpt.identity_type != ''
+                    )
             """
             params = []
             if status:
@@ -251,7 +255,11 @@ def get_bundle_details_by_id(bundle_id: int):
             bundle_details['items'] = items
             bundle_details['category_ids'] = [c['category_id'] for c in cats]
             bundle_details['categories'] = [c['name'] for c in cats]
-            bundle_details['price_tiers'] = {row['identity_type']: float(row['price']) for row in tier_rows}
+            bundle_details['price_tiers'] = {
+                row['identity_type']: float(row['price'])
+                for row in tier_rows
+                if row.get('identity_type')
+            }
             return bundle_details
     finally:
         conn.close()

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -497,12 +497,16 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id,
                 GROUP_CONCAT(c.name) AS categories,
-                COALESCE(JSON_OBJECTAGG(ppt.identity_type, ppt.price), '{}') AS price_tiers
+                COALESCE(JSON_OBJECTAGG(ppt.identity_type, ppt.price), '{{}}') AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id
             LEFT JOIN category c ON pc.category_id = c.category_id
             LEFT JOIN inventory i ON p.product_id = i.product_id {store_join}
-            LEFT JOIN product_price_tier ppt ON ppt.product_id = p.product_id
+            LEFT JOIN product_price_tier ppt ON (
+                ppt.product_id = p.product_id
+                AND ppt.identity_type IS NOT NULL
+                AND ppt.identity_type != ''
+            )
         """
 
         params = []
@@ -576,12 +580,16 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id,
                 GROUP_CONCAT(c.name) AS categories,
-                COALESCE(JSON_OBJECTAGG(ppt.identity_type, ppt.price), '{}') AS price_tiers
+                COALESCE(JSON_OBJECTAGG(ppt.identity_type, ppt.price), '{{}}') AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id
             LEFT JOIN category c ON pc.category_id = c.category_id
             LEFT JOIN inventory i ON p.product_id = i.product_id {store_join}
-            LEFT JOIN product_price_tier ppt ON ppt.product_id = p.product_id
+            LEFT JOIN product_price_tier ppt ON (
+                ppt.product_id = p.product_id
+                AND ppt.identity_type IS NOT NULL
+                AND ppt.identity_type != ''
+            )
         """
 
         params = []

--- a/server/app/models/therapy_bundle_model.py
+++ b/server/app/models/therapy_bundle_model.py
@@ -55,7 +55,11 @@ def get_all_therapy_bundles(status: str | None = None, store_id: int | None = No
                 LEFT JOIN
                     category c ON tbc.category_id = c.category_id
                 LEFT JOIN
-                    therapy_bundle_price_tier tbpt ON tb.bundle_id = tbpt.bundle_id
+                    therapy_bundle_price_tier tbpt ON (
+                        tb.bundle_id = tbpt.bundle_id
+                        AND tbpt.identity_type IS NOT NULL
+                        AND tbpt.identity_type != ''
+                    )
             """
             params = []
             if status:
@@ -219,7 +223,11 @@ def get_bundle_details_by_id(bundle_id: int):
             bundle_details['items'] = items
             bundle_details['category_ids'] = [c['category_id'] for c in cats]
             bundle_details['categories'] = [c['name'] for c in cats]
-            bundle_details['price_tiers'] = {row['identity_type']: float(row['price']) for row in tier_rows}
+            bundle_details['price_tiers'] = {
+                row['identity_type']: float(row['price'])
+                for row in tier_rows
+                if row.get('identity_type')
+            }
             return bundle_details
     finally:
         conn.close()

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -544,7 +544,11 @@ def get_all_therapies_for_dropdown(status: str | None = 'PUBLISHED', store_id: i
                 "COALESCE(JSON_OBJECTAGG(tpt.identity_type, tpt.price), '{}') AS price_tiers FROM therapy t "
                 "LEFT JOIN therapy_category tc ON t.therapy_id = tc.therapy_id "
                 "LEFT JOIN category c ON tc.category_id = c.category_id "
-                "LEFT JOIN therapy_price_tier tpt ON tpt.therapy_id = t.therapy_id"
+                "LEFT JOIN therapy_price_tier tpt ON ("
+                "    tpt.therapy_id = t.therapy_id "
+                "    AND tpt.identity_type IS NOT NULL "
+                "    AND tpt.identity_type != ''"
+                ")"
             )
             params = []
             if status:


### PR DESCRIPTION
## Summary
- escape price tier aggregation SQL so product listings no longer break when formatting the base query
- filter price tier joins to ignore rows without an identity key across products, therapies, and bundles
- guard bundle detail responses against null identity price tiers when building dictionaries

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e8f1a48483298922774c5dd04aa2