### PR TITLE
Handle NULL identity keys in price tier aggregations

### DIFF
--- a/server/app/models/product_bundle_model.py
+++ b/server/app/models/product_bundle_model.py
@@ -54,7 +54,16 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
                         ''
                     ) AS bundle_contents,
                     GROUP_CONCAT(DISTINCT c.name) AS categories,
-                    COALESCE(JSON_OBJECTAGG(pbpt.identity_type, pbpt.price), '{}') AS price_tiers
+                    COALESCE(
+                        JSON_OBJECTAGG(
+                            COALESCE(
+                                NULLIF(pbpt.identity_type, ''),
+                                CONCAT('UNKNOWN_', pbpt.price_tier_id)
+                            ),
+                            pbpt.price
+                        ),
+                        '{}'
+                    ) AS price_tiers
                 FROM
                     product_bundles pb
                 LEFT JOIN

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -497,7 +497,16 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id,
                 GROUP_CONCAT(c.name) AS categories,
-                COALESCE(JSON_OBJECTAGG(ppt.identity_type, ppt.price), '{{}}') AS price_tiers
+                COALESCE(
+                    JSON_OBJECTAGG(
+                        COALESCE(
+                            NULLIF(ppt.identity_type, ''),
+                            CONCAT('UNKNOWN_', ppt.price_tier_id)
+                        ),
+                        ppt.price
+                    ),
+                    '{}'
+                ) AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id
             LEFT JOIN category c ON pc.category_id = c.category_id
@@ -576,7 +585,16 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                 COALESCE(SUM(i.quantity), 0) AS inventory_quantity,
                 0 AS inventory_id,
                 GROUP_CONCAT(c.name) AS categories,
-                COALESCE(JSON_OBJECTAGG(ppt.identity_type, ppt.price), '{{}}') AS price_tiers
+                COALESCE(
+                    JSON_OBJECTAGG(
+                        COALESCE(
+                            NULLIF(ppt.identity_type, ''),
+                            CONCAT('UNKNOWN_', ppt.price_tier_id)
+                        ),
+                        ppt.price
+                    ),
+                    '{}'
+                ) AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id
             LEFT JOIN category c ON pc.category_id = c.category_id

--- a/server/app/models/therapy_bundle_model.py
+++ b/server/app/models/therapy_bundle_model.py
@@ -43,7 +43,16 @@ def get_all_therapy_bundles(status: str | None = None, store_id: int | None = No
                         ''
                     ) AS bundle_contents,
                     GROUP_CONCAT(DISTINCT c.name) AS categories,
-                    COALESCE(JSON_OBJECTAGG(tbpt.identity_type, tbpt.price), '{}') AS price_tiers
+                    COALESCE(
+                        JSON_OBJECTAGG(
+                            COALESCE(
+                                NULLIF(tbpt.identity_type, ''),
+                                CONCAT('UNKNOWN_', tbpt.price_tier_id)
+                            ),
+                            tbpt.price
+                        ),
+                        '{}'
+                    ) AS price_tiers
                 FROM
                     therapy_bundles tb
                 LEFT JOIN

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -541,7 +541,11 @@ def get_all_therapies_for_dropdown(status: str | None = 'PUBLISHED', store_id: i
             sql = (
                 "SELECT t.therapy_id, t.code, t.name, t.price, t.visible_store_ids, t.visible_permissions, "
                 "GROUP_CONCAT(c.name) AS categories, "
-                "COALESCE(JSON_OBJECTAGG(tpt.identity_type, tpt.price), '{}') AS price_tiers FROM therapy t "
+                "COALESCE(" \
+                "JSON_OBJECTAGG(" \
+                "COALESCE(NULLIF(tpt.identity_type, ''), CONCAT('UNKNOWN_', tpt.price_tier_id))," \
+                "tpt.price)," \
+                "'{}') AS price_tiers FROM therapy t "
                 "LEFT JOIN therapy_category tc ON t.therapy_id = tc.therapy_id "
                 "LEFT JOIN category c ON tc.category_id = c.category_id "
                 "LEFT JOIN therapy_price_tier tpt ON tpt.therapy_id = t.therapy_id AND tpt.identity_type IS NOT NULL"

--- a/server/app/models/therapy_sell_model.py
+++ b/server/app/models/therapy_sell_model.py
@@ -18,7 +18,16 @@ def get_all_therapy_packages(status: str | None = 'PUBLISHED', store_id: int | N
                 SELECT t.therapy_id, t.code AS TherapyCode, t.price AS TherapyPrice,
                        t.name AS TherapyName, t.content AS TherapyContent,
                        t.visible_store_ids, GROUP_CONCAT(c.name) AS categories,
-                       COALESCE(JSON_OBJECTAGG(tpt.identity_type, tpt.price), '{}') AS price_tiers
+                       COALESCE(
+                           JSON_OBJECTAGG(
+                               COALESCE(
+                                   NULLIF(tpt.identity_type, ''),
+                                   CONCAT('UNKNOWN_', tpt.price_tier_id)
+                               ),
+                               tpt.price
+                           ),
+                           '{}'
+                       ) AS price_tiers
                 FROM therapy t
                 LEFT JOIN therapy_category tc ON t.therapy_id = tc.therapy_id
                 LEFT JOIN category c ON tc.category_id = c.category_id
@@ -72,7 +81,16 @@ def search_therapy_packages(keyword, status: str | None = 'PUBLISHED', store_id:
                 SELECT t.therapy_id, t.code AS TherapyCode, t.price AS TherapyPrice,
                        t.name AS TherapyName, t.content AS TherapyContent,
                        t.visible_store_ids, GROUP_CONCAT(c.name) AS categories,
-                       COALESCE(JSON_OBJECTAGG(tpt.identity_type, tpt.price), '{}') AS price_tiers
+                       COALESCE(
+                           JSON_OBJECTAGG(
+                               COALESCE(
+                                   NULLIF(tpt.identity_type, ''),
+                                   CONCAT('UNKNOWN_', tpt.price_tier_id)
+                               ),
+                               tpt.price
+                           ),
+                           '{}'
+                       ) AS price_tiers
                 FROM therapy t
                 LEFT JOIN therapy_category tc ON t.therapy_id = tc.therapy_id
                 LEFT JOIN category c ON tc.category_id = c.category_id


### PR DESCRIPTION
## Summary
- ensure price tier JSON aggregation across therapy and product queries substitutes fallback keys for missing identity values to prevent MySQL JSON errors

## Testing
- pytest tests/test_therapy_api.py::test_get_therapy_bundles -q *(fails: pyenv version `3.11.3` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e543128ed883299a1960dd674b383a