### PR TITLE
Fix product price tier aggregation defaults

### DIFF
--- a/server/app/models/product_bundle_model.py
+++ b/server/app/models/product_bundle_model.py
@@ -58,7 +58,10 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
                         JSON_OBJECTAGG(
                             COALESCE(
                                 NULLIF(pbpt.identity_type, ''),
-                                CONCAT('UNKNOWN_', pbpt.price_tier_id)
+                                CASE
+                                    WHEN pbpt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', pbpt.price_tier_id)
+                                    ELSE CONCAT('UNKNOWN_BUNDLE_', pbpt.bundle_id)
+                                END
                             ),
                             pbpt.price
                         ),

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -501,11 +501,14 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                     JSON_OBJECTAGG(
                         COALESCE(
                             NULLIF(ppt.identity_type, ''),
-                            CONCAT('UNKNOWN_', ppt.price_tier_id)
+                            CASE
+                                WHEN ppt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', ppt.price_tier_id)
+                                ELSE CONCAT('UNKNOWN_PRODUCT_', ppt.product_id)
+                            END
                         ),
                         ppt.price
                     ),
-                    '{}'
+                    '{{}}'
                 ) AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id
@@ -589,11 +592,14 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                     JSON_OBJECTAGG(
                         COALESCE(
                             NULLIF(ppt.identity_type, ''),
-                            CONCAT('UNKNOWN_', ppt.price_tier_id)
+                            CASE
+                                WHEN ppt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', ppt.price_tier_id)
+                                ELSE CONCAT('UNKNOWN_PRODUCT_', ppt.product_id)
+                            END
                         ),
                         ppt.price
                     ),
-                    '{}'
+                    '{{}}'
                 ) AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id


### PR DESCRIPTION
## Summary
- ensure price tier JSON aggregation for products always generates non-null keys
- fix product bundle price tier aggregation to provide a deterministic fallback key when identity is missing

## Testing
- python -m compileall server

------
https://chatgpt.com/codex/tasks/task_e_68e546bfa8b88329b6b0bc22ee373232