### PR TITLE
fix: guard JSON price tier keys

### DIFF
--- a/server/app/models/product_bundle_model.py
+++ b/server/app/models/product_bundle_model.py
@@ -60,7 +60,10 @@ def get_all_product_bundles(status: str | None = None, store_id: int | None = No
                                 NULLIF(pbpt.identity_type, ''),
                                 CASE
                                     WHEN pbpt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', pbpt.price_tier_id)
-                                    ELSE CONCAT('UNKNOWN_BUNDLE_', pbpt.bundle_id)
+                                    ELSE CONCAT(
+                                        'UNKNOWN_BUNDLE_',
+                                        COALESCE(CAST(pbpt.bundle_id AS CHAR), CAST(pb.bundle_id AS CHAR), '0')
+                                    )
                                 END
                             ),
                             pbpt.price

--- a/server/app/models/product_sell_model.py
+++ b/server/app/models/product_sell_model.py
@@ -503,12 +503,12 @@ def get_all_products_with_inventory(store_id=None, status: str | None = 'PUBLISH
                             NULLIF(ppt.identity_type, ''),
                             CASE
                                 WHEN ppt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', ppt.price_tier_id)
-                                ELSE CONCAT('UNKNOWN_PRODUCT_', ppt.product_id)
+                                ELSE CONCAT('UNKNOWN_PRODUCT_', CAST(p.product_id AS CHAR))
                             END
                         ),
                         ppt.price
                     ),
-                    '{{}}'
+                    '{}'
                 ) AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id
@@ -594,12 +594,12 @@ def search_products_with_inventory(keyword, store_id=None, status: str | None = 
                             NULLIF(ppt.identity_type, ''),
                             CASE
                                 WHEN ppt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', ppt.price_tier_id)
-                                ELSE CONCAT('UNKNOWN_PRODUCT_', ppt.product_id)
+                                ELSE CONCAT('UNKNOWN_PRODUCT_', CAST(p.product_id AS CHAR))
                             END
                         ),
                         ppt.price
                     ),
-                    '{{}}'
+                    '{}'
                 ) AS price_tiers
             FROM product p
             LEFT JOIN product_category pc ON p.product_id = pc.product_id

--- a/server/app/models/therapy_bundle_model.py
+++ b/server/app/models/therapy_bundle_model.py
@@ -47,7 +47,10 @@ def get_all_therapy_bundles(status: str | None = None, store_id: int | None = No
                         JSON_OBJECTAGG(
                             COALESCE(
                                 NULLIF(tbpt.identity_type, ''),
-                                CONCAT('UNKNOWN_', tbpt.price_tier_id)
+                                CASE
+                                    WHEN tbpt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', tbpt.price_tier_id)
+                                    ELSE CONCAT('UNKNOWN_BUNDLE_', CAST(tb.bundle_id AS CHAR))
+                                END
                             ),
                             tbpt.price
                         ),

--- a/server/app/models/therapy_model.py
+++ b/server/app/models/therapy_model.py
@@ -543,7 +543,11 @@ def get_all_therapies_for_dropdown(status: str | None = 'PUBLISHED', store_id: i
                 "GROUP_CONCAT(c.name) AS categories, "
                 "COALESCE(" \
                 "JSON_OBJECTAGG(" \
-                "COALESCE(NULLIF(tpt.identity_type, ''), CONCAT('UNKNOWN_', tpt.price_tier_id))," \
+                "COALESCE(" \
+                "NULLIF(tpt.identity_type, '')," \
+                "CASE WHEN tpt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', tpt.price_tier_id) " \
+                "ELSE CONCAT('UNKNOWN_TIER_', CAST(t.therapy_id AS CHAR)) END" \
+                ")," \
                 "tpt.price)," \
                 "'{}') AS price_tiers FROM therapy t "
                 "LEFT JOIN therapy_category tc ON t.therapy_id = tc.therapy_id "

--- a/server/app/models/therapy_sell_model.py
+++ b/server/app/models/therapy_sell_model.py
@@ -22,7 +22,10 @@ def get_all_therapy_packages(status: str | None = 'PUBLISHED', store_id: int | N
                            JSON_OBJECTAGG(
                                COALESCE(
                                    NULLIF(tpt.identity_type, ''),
-                                   CONCAT('UNKNOWN_', tpt.price_tier_id)
+                                   CASE
+                                       WHEN tpt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', tpt.price_tier_id)
+                                       ELSE CONCAT('UNKNOWN_TIER_', CAST(t.therapy_id AS CHAR))
+                                   END
                                ),
                                tpt.price
                            ),
@@ -85,7 +88,10 @@ def search_therapy_packages(keyword, status: str | None = 'PUBLISHED', store_id:
                            JSON_OBJECTAGG(
                                COALESCE(
                                    NULLIF(tpt.identity_type, ''),
-                                   CONCAT('UNKNOWN_', tpt.price_tier_id)
+                                   CASE
+                                       WHEN tpt.price_tier_id IS NOT NULL THEN CONCAT('UNKNOWN_', tpt.price_tier_id)
+                                       ELSE CONCAT('UNKNOWN_TIER_', CAST(t.therapy_id AS CHAR))
+                                   END
                                ),
                                tpt.price
                            ),


### PR DESCRIPTION
## Summary
- ensure JSON_OBJECTAGG fallbacks use non-null keys for product, therapy, and bundle queries
- normalize placeholder JSON defaults to valid empty objects
- prevent MySQL 3158 errors when price tier joins return NULL rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e549d8ec988329a710f920172f4313