### PR TITLE
feat: localize member identity labels

### DIFF
--- a/client/src/components/MemberSummaryCard.tsx
+++ b/client/src/components/MemberSummaryCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Card } from "react-bootstrap";
 import { MemberData } from "../types/medicalTypes";
+import { resolveMemberIdentityLabel } from "../utils/memberIdentity";
 
 interface MemberSummaryCardProps {
   member: MemberData | null;
@@ -26,7 +27,9 @@ const MemberSummaryCard: React.FC<MemberSummaryCardProps> = ({
   hideHeader = false,
 }) => {
   const name = displayOrDash(member?.name ?? fallbackName);
-  const identity = displayOrDash(member?.identity_type ?? undefined);
+  const identity = displayOrDash(
+    resolveMemberIdentityLabel(member?.identity_type ?? undefined),
+  );
   const code = displayOrDash(member?.member_code ?? memberCode);
   const note = displayOrDash(member?.note ?? undefined);
 

--- a/client/src/pages/member/MemberInfo.tsx
+++ b/client/src/pages/member/MemberInfo.tsx
@@ -10,6 +10,7 @@ import { formatGregorianBirthday, formatGender, calculateAge } from "../../utils
 import { useMemberManagement } from "../../hooks/useMemberManagement";
 import "./memberInfo.css";
 import { sortByStoreAndMemberCode } from "../../utils/storeMemberSort";
+import { resolveMemberIdentityLabel } from "../../utils/memberIdentity";
 import usePermissionGuard from "../../hooks/usePermissionGuard";
 
 const MemberInfo: React.FC = () => {
@@ -81,7 +82,7 @@ const MemberInfo: React.FC = () => {
                 <td className="align-middle">{member.Name}</td>
                 {/* 顯示資料庫中的 member_code */}
                 <td className="align-middle" style={{ whiteSpace: 'nowrap' }}>{member.member_code ?? ""}</td>
-                <td className="align-middle">{member.IdentityType || ""}</td>
+                <td className="align-middle">{resolveMemberIdentityLabel(member.IdentityType) || ""}</td>
                 <td className="align-middle">{formatGregorianBirthday(member.Birth, 'YYYY/MM/DD')}</td>
                 <td className="align-middle">{calculateAge(member.Birth)}</td>
                 <td className="align-middle">{member.Address}</td>

--- a/client/src/services/MemberService.ts
+++ b/client/src/services/MemberService.ts
@@ -1,5 +1,6 @@
 //client\src\services\MemberService.ts
 import axios from "axios";
+import { resolveMemberIdentityLabel } from "../utils/memberIdentity";
 import { base_url } from "./BASE_URL";
 
 const API_URL = `${base_url}/member`;
@@ -82,7 +83,7 @@ const transformBackendToFrontend = (member: BackendMember): Member => {
     Member_ID: String(member.member_id),
     member_code: member.member_code || undefined,
     Name: member.name,
-    IdentityType: member.identity_type || '一般會員',
+    IdentityType: resolveMemberIdentityLabel(member.identity_type) || '一般會員',
     Gender: member.gender || '',
     Birth: member.birthday ? (typeof member.birthday === 'string' ? member.birthday : member.birthday.toISOString().split('T')[0]) : '',
     Phone: member.phone || '',

--- a/client/src/utils/memberIdentity.ts
+++ b/client/src/utils/memberIdentity.ts
@@ -1,13 +1,47 @@
-import { MEMBER_IDENTITY_OPTIONS, MemberIdentity } from "../types/memberIdentity";
+import { MEMBER_IDENTITY_LABELS, MEMBER_IDENTITY_OPTIONS, MemberIdentity } from "../types/memberIdentity";
 
-const IDENTITY_ALIASES: Record<string, MemberIdentity> = {
-  "推廣商": "推廣商(分店能量師)",
-  "推廣商(分店)": "推廣商(分店能量師)",
-  "推廣商（分店能量師）": "推廣商(分店能量師)",
-  "一般會員": "會員",
-  "一般價": "一般售價",
-  "一般價格": "一般售價",
-  "一般售價": "一般售價",
+const canonicalizeIdentityValue = (value: string) =>
+  value
+    .replace(/[\s_（）()\-]/g, "")
+    .toUpperCase();
+
+const IDENTITY_NORMALIZATION_MAP: Record<string, MemberIdentity> = {
+  [canonicalizeIdentityValue("直營店")]: "直營店",
+  [canonicalizeIdentityValue("Direct Store")]: "直營店",
+  [canonicalizeIdentityValue("直營")]: "直營店",
+
+  [canonicalizeIdentityValue("加盟店")]: "加盟店",
+  [canonicalizeIdentityValue("Franchise Store")]: "加盟店",
+  [canonicalizeIdentityValue("Franchise")]: "加盟店",
+
+  [canonicalizeIdentityValue("合夥商")]: "合夥商",
+  [canonicalizeIdentityValue("Partner")]: "合夥商",
+
+  [canonicalizeIdentityValue("推廣商(分店能量師)")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("推廣商")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("推廣商(分店)")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("推廣商（分店能量師）")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("Promoter")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("Promoter Branch")]: "推廣商(分店能量師)",
+
+  [canonicalizeIdentityValue("B2B合作專案")]: "B2B合作專案",
+  [canonicalizeIdentityValue("B2B Project")]: "B2B合作專案",
+  [canonicalizeIdentityValue("B2B")]: "B2B合作專案",
+
+  [canonicalizeIdentityValue("心耀商")]: "心耀商",
+  [canonicalizeIdentityValue("Heart Shine")]: "心耀商",
+  [canonicalizeIdentityValue("Heart Shop")]: "心耀商",
+
+  [canonicalizeIdentityValue("會員")]: "會員",
+  [canonicalizeIdentityValue("Member")]: "會員",
+  [canonicalizeIdentityValue("一般會員")]: "會員",
+  [canonicalizeIdentityValue("General Member")]: "會員",
+
+  [canonicalizeIdentityValue("一般售價")]: "一般售價",
+  [canonicalizeIdentityValue("一般價格")]: "一般售價",
+  [canonicalizeIdentityValue("一般價")]: "一般售價",
+  [canonicalizeIdentityValue("General Price")]: "一般售價",
+  [canonicalizeIdentityValue("General")]: "一般售價",
 };
 
 export const normalizeMemberIdentity = (
@@ -21,12 +55,76 @@ export const normalizeMemberIdentity = (
     return null;
   }
 
-  if (IDENTITY_ALIASES[trimmed]) {
-    return IDENTITY_ALIASES[trimmed];
+  const canonical = canonicalizeIdentityValue(trimmed);
+  if (IDENTITY_NORMALIZATION_MAP[canonical]) {
+    return IDENTITY_NORMALIZATION_MAP[canonical];
   }
 
   const directMatch = MEMBER_IDENTITY_OPTIONS.find(
     ({ value, label }) => value === trimmed || label === trimmed,
   );
   return directMatch ? directMatch.value : null;
+};
+
+const IDENTITY_DISPLAY_MAP: Record<string, string> = {
+  [canonicalizeIdentityValue("直營店")]: "直營店",
+  [canonicalizeIdentityValue("Direct Store")]: "直營店",
+
+  [canonicalizeIdentityValue("加盟店")]: "加盟店",
+  [canonicalizeIdentityValue("Franchise Store")]: "加盟店",
+
+  [canonicalizeIdentityValue("合夥商")]: "合夥商",
+  [canonicalizeIdentityValue("Partner")]: "合夥商",
+
+  [canonicalizeIdentityValue("推廣商(分店能量師)")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("推廣商")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("推廣商(分店)")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("推廣商（分店能量師）")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("Promoter")]: "推廣商(分店能量師)",
+  [canonicalizeIdentityValue("Promoter Branch")]: "推廣商(分店能量師)",
+
+  [canonicalizeIdentityValue("B2B合作專案")]: "B2B合作專案",
+  [canonicalizeIdentityValue("B2B Project")]: "B2B合作專案",
+  [canonicalizeIdentityValue("B2B")]: "B2B合作專案",
+
+  [canonicalizeIdentityValue("心耀商")]: "心耀商",
+  [canonicalizeIdentityValue("Heart Shine")]: "心耀商",
+  [canonicalizeIdentityValue("Heart Shop")]: "心耀商",
+
+  [canonicalizeIdentityValue("會員")]: "會員",
+  [canonicalizeIdentityValue("Member")]: "會員",
+
+  [canonicalizeIdentityValue("一般會員")]: "一般會員",
+  [canonicalizeIdentityValue("General Member")]: "一般會員",
+  [canonicalizeIdentityValue("一般售價")]: "一般會員",
+  [canonicalizeIdentityValue("General Price")]: "一般會員",
+  [canonicalizeIdentityValue("General")]: "一般會員",
+};
+
+export const resolveMemberIdentityLabel = (
+  rawIdentity?: string | null,
+): string | null => {
+  if (!rawIdentity) {
+    return null;
+  }
+  const trimmed = rawIdentity.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const canonical = canonicalizeIdentityValue(trimmed);
+  if (IDENTITY_DISPLAY_MAP[canonical]) {
+    return IDENTITY_DISPLAY_MAP[canonical];
+  }
+
+  const normalized = normalizeMemberIdentity(trimmed);
+  if (!normalized) {
+    return trimmed;
+  }
+
+  if (normalized === "一般售價") {
+    return "一般會員";
+  }
+
+  return MEMBER_IDENTITY_LABELS[normalized];
 };


### PR DESCRIPTION
## Summary
- normalize raw member identity values to consistent Chinese labels
- show localized identity names in member lists and member summary cards across purchase flows

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e5548ee9108329be41644cbb762237